### PR TITLE
Clean up Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,36 @@
-FROM golang:latest
-RUN apt-get update
+FROM golang:1.5.1
+MAINTAINER gou@portworx.com
 
-# Install supporting packages required for btrfs-progs
-RUN apt-get install -y asciidoc xmlto --no-install-recommends
-RUN apt-get install -y uuid-dev libattr1-dev zlib1g-dev libacl1-dev e2fslibs-dev libblkid-dev liblzo2-dev
-RUN apt-get install -y autoconf pkg-config
+RUN \
+  apt-get update -yq && \
+  apt-get install -yq --no-install-recommends \
+    asciidoc \
+    autoconf \
+    automake \
+    e2fslibs-dev \
+    libacl1-dev \
+    libattr1-dev \
+    libblkid-dev \
+    liblzo2-dev \
+    pkg-config \
+    uuid-dev \
+    xmlto \
+    zlib1g-dev
 
-# Clone btrfs-progs and build it
-RUN git clone git://git.kernel.org/pub/scm/linux/kernel/git/kdave/btrfs-progs.git ~/btrfs-progs
-RUN /root/btrfs-progs/autogen.sh
-RUN cd /root/btrfs-progs && \
-  ./configure && make && \
-  make install
+RUN \
+  git clone git://git.kernel.org/pub/scm/linux/kernel/git/kdave/btrfs-progs.git /tmp/btrfs-progs && \
+  /tmp/btrfs-progs/autogen.sh && \
+  cd /tmp/btrfs-progs && \
+  ./configure && \
+  make && \
+  make install && \
+  rm -rf /tmp/btrfs-progs
 
-# Fetch openstorage and dependencies.
-RUN go get -d github.com/libopenstorage/openstorage
 RUN go get github.com/tools/godep
-
-# Upload current openstorage source
-COPY . /go/src/github.com/libopenstorage/openstorage
-
-# Build openstorage and install it.
-RUN cd $GOPATH/src/github.com/libopenstorage/openstorage && godep restore
-RUN cd $GOPATH/src/github.com/libopenstorage/openstorage && make openstorage \
-    && cp osd /bin/osd
+RUN mkdir -p /go/src/github.com/libopenstorage/openstorage/Godeps
+WORKDIR /go/src/github.com/libopenstorage/openstorage
+ADD Godeps/ /go/src/github.com/libopenstorage/openstorage/Godeps/
+RUN godep restore
+ADD . /go/src/github.com/libopenstorage/openstorage/
+RUN go build -tags daemon -o /bin/osd
 CMD ["/bin/osd"]


### PR DESCRIPTION
Signed-off-by: Peter Edge <peter.edge@gmail.com>

This does a few things:

- Adds a maintainer (I think I guessed correctly)
- Does all the apt-get updates and installs in one RUN command, per the docker recommendations
- Cleans up the apt-get installs to all use --no-install-recommends and be in alphabetic order
- Cleans up indentation for other places
- Takes maximum advantage of caching: adds Godeps first, then godep restore, then add the rest of the code
- Sets WORKDIR for development
- Removes /tmp/btrfs-progs when done installing btrfs-progs to save on image space
- Directly compiles the osd binary into /bin/osd