### PR TITLE
Do not modify environment variables for AWS if AWS keys passed in params, skip AWS test if no AWS environment variable keys

### DIFF
--- a/drivers/aws/aws.go
+++ b/drivers/aws/aws.go
@@ -61,20 +61,19 @@ func Init(params volume.DriverParams) (volume.VolumeDriver, error) {
 		return nil, err
 	}
 	log.Infof("AWS instance %v zone %v", instance, zone)
-	if accessKey, ok := params["AWS_ACCESS_KEY_ID"]; ok {
-		os.Setenv("AWS_ACCESS_KEY_ID", accessKey)
+	accessKey, ok := params["AWS_ACCESS_KEY_ID"]
+	if !ok {
+		if accessKey = os.Getenv("AWS_ACCESS_KEY_ID"); accessKey == "" {
+			return nil, fmt.Errorf("AWS_ACCESS_KEY_ID environment variable must be set")
+		}
 	}
-	if secretKey, ok := params["AWS_SECRET_ACCESS_KEY"]; ok {
-		os.Setenv("AWS_SECRET_ACCESS_KEY", secretKey)
+	secretKey, ok := params["AWS_SECRET_ACCESS_KEY"]
+	if !ok {
+		if secretKey = os.Getenv("AWS_SECRET_ACCESS_KEY"); secretKey == "" {
+			return nil, fmt.Errorf("AWS_SECRET_ACCESS_KEY environment variable must be set")
+		}
 	}
-	if accessKey := os.Getenv("AWS_ACCESS_KEY_ID"); accessKey == "" {
-		return nil, fmt.Errorf("AWS_ACCESS_KEY_ID environment variable must be set")
-	}
-	if secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY"); secretKey == "" {
-		return nil, fmt.Errorf("AWS_SECRET_ACCESS_KEY environment variable must be set")
-	}
-
-	creds := credentials.NewEnvCredentials()
+	creds := credentials.NewStaticCredentials(accessKey, secretKey, "")
 	region := zone[:len(zone)-1]
 	d := &Driver{
 		ec2: ec2.New(&aws.Config{

--- a/drivers/aws/aws_test.go
+++ b/drivers/aws/aws_test.go
@@ -3,11 +3,15 @@ package aws
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/libopenstorage/openstorage/drivers/test"
 	"github.com/libopenstorage/openstorage/volume"
 )
 
 func TestAll(t *testing.T) {
+	if _, err := credentials.NewEnvCredentials().Get(); err != nil {
+		t.Skip("No AWS credentials, skipping AWS driver test: ", err)
+	}
 	_, err := volume.New(Name, volume.DriverParams{})
 	if err != nil {
 		t.Logf("Failed to initialize Driver: %v", err)


### PR DESCRIPTION
AWS tests won't work for OSS contributors, unless they want to provide their own AWS account/money for testing :) Also better to not modify environment if there is no absolute need to.