### PR TITLE
fix ca certificates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN \
     asciidoc \
     autoconf \
     automake \
+    ca-certificates \
     e2fslibs-dev \
     libacl1-dev \
     libattr1-dev \


### PR DESCRIPTION
https://github.com/libopenstorage/openstorage/issues/25

Have not tested but almost guarantee this fixes it.

Another alternative is https://github.com/peter-edge/go-cacerts but I actually do not use that as much anymore.