### PR TITLE
Add btrfs unsupported.go for not linux and cgo

### DIFF
--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package btrfs
 
 import (

--- a/drivers/btrfs/unsupported.go
+++ b/drivers/btrfs/unsupported.go
@@ -1,0 +1,17 @@
+// +build !linux
+
+package btrfs
+
+import (
+	"errors"
+
+	"github.com/libopenstorage/openstorage/volume"
+)
+
+var (
+	errUnsupported = errors.New("btrfs not supported on this platform")
+)
+
+func Init(params volume.DriverParams) (volume.VolumeDriver, error) {
+	return nil, errUnsupported
+}


### PR DESCRIPTION
There are other places we should have similar logic, but we'll get there.