### PR TITLE
Change all log.Warn/Warnf calls to log.Error/Errorf

### DIFF
--- a/api/server/docker.go
+++ b/api/server/docker.go
@@ -59,7 +59,7 @@ func volDriverPath(method string) string {
 
 func (d *driver) volNotFound(request string, id string, e error, w http.ResponseWriter) error {
 	err := fmt.Errorf("Failed to locate volume: " + e.Error())
-	d.logReq(request, id).Warn(http.StatusNotFound, " ", err.Error())
+	d.logReq(request, id).Error(http.StatusNotFound, " ", err.Error())
 	return err
 }
 
@@ -212,7 +212,7 @@ func (d *driver) mount(w http.ResponseWriter, r *http.Request) {
 
 	v, err := volume.Get(d.name)
 	if err != nil {
-		d.logReq(method, "").Warn("Cannot locate volume driver")
+		d.logReq(method, "").Error("Cannot locate volume driver")
 		json.NewEncoder(w).Encode(&volumePathResponse{Err: err})
 		return
 	}
@@ -235,7 +235,7 @@ func (d *driver) mount(w http.ResponseWriter, r *http.Request) {
 	if v.Type()&types.Block != 0 {
 		attachPath, err := v.Attach(volInfo.vol.ID)
 		if err != nil {
-			d.logReq(method, request.Name).Warnf("Cannot attach volume: %v", err.Error())
+			d.logReq(method, request.Name).Errorf("Cannot attach volume: %v", err.Error())
 			json.NewEncoder(w).Encode(&volumePathResponse{Err: err})
 			return
 		}
@@ -248,7 +248,7 @@ func (d *driver) mount(w http.ResponseWriter, r *http.Request) {
 
 	err = v.Mount(volInfo.vol.ID, response.Mountpoint)
 	if err != nil {
-		d.logReq(method, request.Name).Warnf("Cannot mount volume %v, %v",
+		d.logReq(method, request.Name).Errorf("Cannot mount volume %v, %v",
 			response.Mountpoint, err)
 		json.NewEncoder(w).Encode(&volumePathResponse{Err: err})
 		return
@@ -293,7 +293,7 @@ func (d *driver) unmount(w http.ResponseWriter, r *http.Request) {
 
 	v, err := volume.Get(d.name)
 	if err != nil {
-		d.logReq(method, "").Warnf("Cannot locate volume driver: %v", err.Error())
+		d.logReq(method, "").Errorf("Cannot locate volume driver: %v", err.Error())
 		json.NewEncoder(w).Encode(&volumeResponse{Err: err})
 		return
 	}
@@ -315,7 +315,7 @@ func (d *driver) unmount(w http.ResponseWriter, r *http.Request) {
 	mountpoint := path.Join(config.MountBase, request.Name)
 	err = v.Unmount(volInfo.vol.ID, mountpoint)
 	if err != nil {
-		d.logReq(method, request.Name).Warnf("Cannot unmount volume %v, %v",
+		d.logReq(method, request.Name).Errorf("Cannot unmount volume %v, %v",
 			mountpoint, err)
 		json.NewEncoder(w).Encode(&volumeResponse{Err: err})
 		return

--- a/api/server/graphdriver.go
+++ b/api/server/graphdriver.go
@@ -75,7 +75,7 @@ func (d *graphDriver) emptyResponse(w http.ResponseWriter) {
 }
 
 func (d *graphDriver) errResponse(method string, w http.ResponseWriter, err error) {
-	d.logReq(method, "").Warnf("%v", err)
+	d.logReq(method, "").Errorf("%v", err)
 	fmt.Fprintln(w, fmt.Sprintf(`{"Err": %q}`, err.Error()))
 }
 

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -39,12 +39,12 @@ func (rest *restBase) logReq(request string, id string) *log.Entry {
 	})
 }
 func (rest *restBase) sendError(request string, id string, w http.ResponseWriter, msg string, code int) {
-	rest.logReq(request, id).Warn(code, " ", msg)
+	rest.logReq(request, id).Error(code, " ", msg)
 	http.Error(w, msg, code)
 }
 
 func notFound(w http.ResponseWriter, r *http.Request) {
-	log.Warnf("Not found: %+v ", r.URL)
+	log.Errorf("Not found: %+v ", r.URL)
 	http.NotFound(w, r)
 }
 
@@ -66,7 +66,7 @@ func startServer(name string, sockBase string, port int, routes []*Route) error 
 	log.Printf("Starting REST service on %+v", socket)
 	listener, err = net.Listen("unix", socket)
 	if err != nil {
-		log.Warn("Cannot listen on UNIX socket: ", err)
+		log.Error("Cannot listen on UNIX socket: ", err)
 		return err
 	}
 	go http.Serve(listener, router)

--- a/cluster/database.go
+++ b/cluster/database.go
@@ -20,7 +20,7 @@ func readDatabase() (Database, error) {
 
 	kv, err := kvdb.Get("cluster/database")
 	if err != nil && !strings.Contains(err.Error(), "Key not found") {
-		log.Warn("Warning, could not read cluster database")
+		log.Error("Erroring, could not read cluster database")
 		goto done
 	}
 
@@ -31,7 +31,7 @@ func readDatabase() (Database, error) {
 	} else {
 		err = json.Unmarshal(kv.Value, &db)
 		if err != nil {
-			log.Warn("Fatal, Could not parse cluster database ", kv)
+			log.Error("Fatal, Could not parse cluster database ", kv)
 			goto done
 		}
 	}
@@ -44,13 +44,13 @@ func writeDatabase(db *Database) error {
 	kvdb := kv.Instance()
 	b, err := json.Marshal(db)
 	if err != nil {
-		log.Warn("Fatal, Could not marshal cluster database to JSON")
+		log.Error("Fatal, Could not marshal cluster database to JSON")
 		goto done
 	}
 
 	_, err = kvdb.Put("cluster/database", b, 0)
 	if err != nil {
-		log.Warn("Fatal, Could not marshal cluster database to JSON")
+		log.Error("Fatal, Could not marshal cluster database to JSON")
 		goto done
 	}
 

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -147,7 +147,7 @@ func (c *ClusterManager) joinCluster(db *Database, self *api.Node, exist bool) e
 	for e := c.listeners.Front(); e != nil; e = e.Next() {
 		err = e.Value.(ClusterListener).Init(self, db)
 		if err != nil {
-			log.Warnf("Failed to initialize %s: %v",
+			log.Errorf("Failed to initialize %s: %v",
 				e.Value.(ClusterListener).String(), err)
 			goto done
 		}
@@ -158,7 +158,7 @@ found:
 	for e := c.listeners.Front(); e != nil; e = e.Next() {
 		err = e.Value.(ClusterListener).Join(self, db)
 		if err != nil {
-			log.Warnf("Failed to initialize %s: %v",
+			log.Errorf("Failed to initialize %s: %v",
 				e.Value.(ClusterListener).String(), err)
 			goto done
 		}
@@ -168,7 +168,7 @@ found:
 		if id != c.config.NodeId {
 			// Check to see if the IP is the same.  If it is, then we have a stale entry.
 			if n.Ip == self.Ip {
-				log.Warnf("Warning, Detected node %s with the same IP %s in the database.  Will not connect to this node.",
+				log.Errorf("Erroring, Detected node %s with the same IP %s in the database.  Will not connect to this node.",
 					id, n.Ip)
 			} else {
 				// Gossip with this node.
@@ -219,7 +219,7 @@ func (c *ClusterManager) heartBeat() {
 			n, ok := nodeInfo.Value.(api.Node)
 
 			if !ok {
-				log.Warn("Received a bad broadcast packet: %v", nodeInfo.Value)
+				log.Error("Received a bad broadcast packet: %v", nodeInfo.Value)
 				continue
 			}
 
@@ -230,24 +230,24 @@ func (c *ClusterManager) heartBeat() {
 			_, ok = c.nodeCache[n.Id]
 			if ok {
 				if n.Status != api.StatusOk {
-					log.Warn("Detected node ", n.Id, " to be unhealthy.")
+					log.Error("Detected node ", n.Id, " to be unhealthy.")
 
 					for e := c.listeners.Front(); e != nil && c.gEnabled; e = e.Next() {
 						err := e.Value.(ClusterListener).Update(&n)
 						if err != nil {
-							log.Warn("Failed to notify ", e.Value.(ClusterListener).String())
+							log.Error("Failed to notify ", e.Value.(ClusterListener).String())
 						}
 					}
 
 					delete(c.nodeCache, n.Id)
 				} else if nodeInfo.Status == gossiptypes.NODE_STATUS_DOWN {
-					log.Warn("Detected node ", n.Id, " to be offline due to inactivity.")
+					log.Error("Detected node ", n.Id, " to be offline due to inactivity.")
 
 					n.Status = api.StatusOffline
 					for e := c.listeners.Front(); e != nil && c.gEnabled; e = e.Next() {
 						err := e.Value.(ClusterListener).Update(&n)
 						if err != nil {
-							log.Warn("Failed to notify ", e.Value.(ClusterListener).String())
+							log.Error("Failed to notify ", e.Value.(ClusterListener).String())
 						}
 					}
 
@@ -257,13 +257,13 @@ func (c *ClusterManager) heartBeat() {
 				}
 			} else if nodeInfo.Status == gossiptypes.NODE_STATUS_UP {
 				// A node discovered in the cluster.
-				log.Warn("Detected node ", n.Id, " to be in the cluster.")
+				log.Error("Detected node ", n.Id, " to be in the cluster.")
 
 				c.nodeCache[n.Id] = n
 				for e := c.listeners.Front(); e != nil && c.gEnabled; e = e.Next() {
 					err := e.Value.(ClusterListener).Add(&n)
 					if err != nil {
-						log.Warn("Failed to notify ", e.Value.(ClusterListener).String())
+						log.Error("Failed to notify ", e.Value.(ClusterListener).String())
 					}
 				}
 			}
@@ -274,12 +274,12 @@ func (c *ClusterManager) heartBeat() {
 }
 
 func (c *ClusterManager) DisableGossipUpdates() {
-	log.Warn("Disabling gossip updates")
+	log.Error("Disabling gossip updates")
 	c.gEnabled = false
 }
 
 func (c *ClusterManager) EnableGossipUpdates() {
-	log.Warn("Enabling gossip updates")
+	log.Error("Enabling gossip updates")
 	c.gEnabled = true
 }
 

--- a/cmd/osd/main.go
+++ b/cmd/osd/main.go
@@ -44,7 +44,7 @@ func start(c *cli.Context) {
 	// We are in daemon mode.
 	file := c.String("file")
 	if file == "" {
-		log.Warn("OSD configuration file not specified.  Visit openstorage.org for an example.")
+		log.Error("OSD configuration file not specified.  Visit openstorage.org for an example.")
 		return
 	}
 	cfg, err := config.Parse(file)
@@ -59,13 +59,13 @@ func start(c *cli.Context) {
 
 	kv, err := kvdb.New(scheme, "openstorage", []string{u.String()}, nil)
 	if err != nil {
-		log.Warnf("Failed to initialize KVDB: %v (%v)", scheme, err)
-		log.Warnf("Supported datastores: %v", datastores)
+		log.Errorf("Failed to initialize KVDB: %v (%v)", scheme, err)
+		log.Errorf("Supported datastores: %v", datastores)
 		return
 	}
 	err = kvdb.SetInstance(kv)
 	if err != nil {
-		log.Warnf("Failed to initialize KVDB: %v", err)
+		log.Errorf("Failed to initialize KVDB: %v", err)
 		return
 	}
 
@@ -73,7 +73,7 @@ func start(c *cli.Context) {
 	if cfg.Osd.ClusterConfig.NodeId != "" && cfg.Osd.ClusterConfig.ClusterId != "" {
 		dockerClient, err := docker.NewClientFromEnv()
 		if err != nil {
-			log.Warnf("Failed to initialize docker client: %v", err)
+			log.Errorf("Failed to initialize docker client: %v", err)
 			return
 		}
 		cm = cluster.New(cfg.Osd.ClusterConfig, kv, dockerClient)
@@ -84,17 +84,17 @@ func start(c *cli.Context) {
 		log.Infof("Starting volume driver: %v", d)
 		_, err := volume.New(d, v)
 		if err != nil {
-			log.Warnf("Unable to start volume driver: %v, %v", d, err)
+			log.Errorf("Unable to start volume driver: %v, %v", d, err)
 			return
 		}
 		err = apiserver.StartServerAPI(d, 0, config.DriverAPIBase)
 		if err != nil {
-			log.Warnf("Unable to start volume driver: %v", err)
+			log.Errorf("Unable to start volume driver: %v", err)
 			return
 		}
 		err = apiserver.StartPluginAPI(d, config.PluginAPIBase)
 		if err != nil {
-			log.Warnf("Unable to start volume plugin: %v", err)
+			log.Errorf("Unable to start volume plugin: %v", err)
 			return
 		}
 	}
@@ -104,7 +104,7 @@ func start(c *cli.Context) {
 		log.Infof("Starting graph driver: %v", d)
 		err = apiserver.StartGraphAPI(d, 0, config.PluginAPIBase)
 		if err != nil {
-			log.Warnf("Unable to start graph plugin: %v", err)
+			log.Errorf("Unable to start graph plugin: %v", err)
 			return
 		}
 	}
@@ -112,7 +112,7 @@ func start(c *cli.Context) {
 	if cm != nil {
 		err = cm.Start()
 		if err != nil {
-			log.Warnf("Unable to start cluster manager: %v", err)
+			log.Errorf("Unable to start cluster manager: %v", err)
 			return
 		}
 	}

--- a/graph/drivers/layer0/layer0.go
+++ b/graph/drivers/layer0/layer0.go
@@ -147,7 +147,7 @@ func (l *Layer0) create(id, parent string) (string, *Layer0Vol, error) {
 
 	vol, ok := l.volumes[id]
 	if !ok {
-		log.Warnf("Failed to find layer0 volume for id %v", id)
+		log.Errorf("Failed to find layer0 volume for id %v", id)
 		return id, nil, nil
 	}
 
@@ -239,7 +239,7 @@ func (l *Layer0) Remove(id string) error {
 			upperDir := path.Join(path.Join(l.home, l.realID(id)), "upper")
 			err := os.Rename(upperDir, path.Join(v.path, "upper"))
 			if err != nil {
-				log.Warnf("Failed in rename(%v): %v", id, err)
+				log.Errorf("Failed in rename(%v): %v", id, err)
 			}
 			l.Driver.Remove(l.realID(id))
 			err = l.volDriver.Unmount(v.volumeID, v.path)
@@ -250,7 +250,7 @@ func (l *Layer0) Remove(id string) error {
 			delete(l.volumes, v.id)
 		}
 	} else {
-		log.Warnf("Failed to find layer0 vol for id %v", id)
+		log.Errorf("Failed to find layer0 vol for id %v", id)
 	}
 	return err
 }

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -133,7 +133,7 @@ func (m *Mounter) Mount(minor int, device, path, fs string, flags uintptr, data 
 
 	dev, ok := m.paths[path]
 	if ok && dev != device {
-		log.Warnf("cannot mount %q,  device %q is mounted at %q", device, dev, path)
+		log.Errorf("cannot mount %q,  device %q is mounted at %q", device, dev, path)
 		return ErrExist
 	}
 	info, ok := m.mounts[device]
@@ -148,7 +148,7 @@ func (m *Mounter) Mount(minor int, device, path, fs string, flags uintptr, data 
 
 	// Validate input params
 	if fs != info.Fs {
-		log.Warnf("%s Existing mountpoint has fs %q cannot change to %q",
+		log.Errorf("%s Existing mountpoint has fs %q cannot change to %q",
 			device, info.Fs, fs)
 		return ErrEinval
 	}
@@ -194,7 +194,7 @@ func (m *Mounter) Unmount(device, path string) error {
 				if _, pathExists := m.paths[path]; pathExists {
 					delete(m.paths, path)
 				} else {
-					log.Warnf("Path %q for device %q does not exist in pathMap", path, device)
+					log.Errorf("Path %q for device %q does not exist in pathMap", path, device)
 				}
 				// Blow away this mountpoint.
 				info.Mountpoint[i] = info.Mountpoint[len(info.Mountpoint)-1]

--- a/volume/drivers/aws/aws.go
+++ b/volume/drivers/aws/aws.go
@@ -250,7 +250,7 @@ func (d *Driver) Create(
 
 	vol, err := d.ec2.CreateVolume(req)
 	if err != nil {
-		log.Warnf("Failed in CreateVolumeRequest :%v", err)
+		log.Errorf("Failed in CreateVolumeRequest :%v", err)
 		return api.BadVolumeID, err
 	}
 	v := &api.Volume{
@@ -530,7 +530,7 @@ func (d *Driver) volumeState(ec2VolState *string) api.VolumeState {
 	case ec2.VolumeAttachmentStateAttaching, ec2.VolumeAttachmentStateDetaching:
 		return api.VolumePending
 	default:
-		log.Warnf("Failed to translate EC2 volume status %v", ec2VolState)
+		log.Errorf("Failed to translate EC2 volume status %v", ec2VolState)
 	}
 	return api.VolumeError
 }
@@ -549,7 +549,7 @@ func (d *Driver) Format(volumeID api.VolumeID) error {
 	cmd := "/sbin/mkfs." + string(v.Spec.Format)
 	o, err := exec.Command(cmd, devicePath).Output()
 	if err != nil {
-		log.Warnf("Failed to run command %v %v: %v", cmd, devicePath, o)
+		log.Errorf("Failed to run command %v %v: %v", cmd, devicePath, o)
 		return err
 	}
 	v.Format = v.Spec.Format

--- a/volume/drivers/buse/buse.go
+++ b/volume/drivers/buse/buse.go
@@ -176,7 +176,7 @@ func (d *driver) Create(locator api.VolumeLocator, source *api.Source, spec *api
 	cmd := "/sbin/mkfs." + string(spec.Format)
 	o, err := exec.Command(cmd, dev).Output()
 	if err != nil {
-		log.Warnf("Failed to run command %v %v: %v", cmd, dev, o)
+		log.Errorf("Failed to run command %v %v: %v", cmd, dev, o)
 		return api.BadVolumeID, err
 	}
 

--- a/volume/drivers/nfs/nfs.go
+++ b/volume/drivers/nfs/nfs.go
@@ -124,7 +124,7 @@ func Init(params volume.DriverParams) (volume.VolumeDriver, error) {
 	// Create a mount manager for this NFS server. Blank sever is OK.
 	mounter, err := mount.New(mount.NFSMount, server)
 	if err != nil {
-		log.Warnf("Failed to create mount manager for server: %v (%v)", server, err)
+		log.Errorf("Failed to create mount manager for server: %v (%v)", server, err)
 		return nil, err
 	}
 
@@ -210,13 +210,13 @@ func (d *driver) Create(locator api.VolumeLocator, source *api.Source, spec *api
 		if len(source.Seed) != 0 {
 			seed, err := seed.New(source.Seed, spec.ConfigLabels)
 			if err != nil {
-				log.Warnf("Failed to initailize seed from %q : %v",
+				log.Errorf("Failed to initailize seed from %q : %v",
 					source.Seed, err)
 				return api.BadVolumeID, err
 			}
 			err = seed.Load(path.Join(volPath, config.DataDir))
 			if err != nil {
-				log.Warnf("Failed to  seed from %q to %q: %v",
+				log.Errorf("Failed to  seed from %q to %q: %v",
 					source.Seed, nfsMountPath, err)
 				return api.BadVolumeID, err
 			}


### PR DESCRIPTION
When I tried to boot up osd, I got this:

```
$ osd -d -f config_btrfs.yaml
INFO[0000] Starting volume driver: btrfs
WARN[0000] Unable to start volume driver: btrfs, no such file or directory
```

When I saw it was just a warning, my first thought went to "did the osd daemon still boot up? this seems fatal", so I did `ps -ef | grep osd`, which of course returned nothing.

Warn in Go World means "this is a warning, but I'm going to keep going". Error/Fatal are things where you expect the execution path to stop, although personally I dislike using Fatal as it does an `os.Exit(...)` call usually, which I think is bad for the middle of execution.