### PR TITLE
add etc/btrfs/init.sh and make launch-local-btrfs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,10 @@ launch: docker-build-osd
 		-v /var/lib/osd/:/var/lib/osd/\
 		openstorage/osd -d -f /etc/config.yaml
 
+launch-local-btrfs: install
+	sudo bash -x etc/btrfs/init.sh
+	sudo $(shell which osd) -d -f config_btrfs.yaml
+
 clean:
 	go clean -i $(PKGS)
 
@@ -116,4 +120,5 @@ clean:
 	docker-build-osd-internal \
 	docker-build-osd \
 	launch \
+	launch-local-btrfs \
 	clean

--- a/etc/btrfs/init.sh
+++ b/etc/btrfs/init.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -e
+
+if [ -z "${MOUNT_DIR}" ]; then
+  MOUNT_DIR="/var/lib/openstorage/btrfs"
+fi
+if [ -z "${MOUNT_IMAGE}" ]; then
+  MOUNT_IMAGE="/var/lib/openstorage/btrfs.img"
+fi
+if [ -z "${IMAGE_SIZE}" ]; then
+  IMAGE_SIZE="1G"
+fi
+if [ -z "${NO_RM}" ]; then
+  echo "***WARNING***: this will remove ${MOUNT_DIR} and ${MOUNT_IMAGE}, sleeping for 5 seconds so you can ctrl+c..." >&2
+  sleep 5
+fi
+
+apt-get install -yq btrfs-tools
+
+if [ -z "${NO_RM}" ]; then
+  umount ${MOUNT_DIR} || true
+  rm -f ${MOUNT_IMAGE}
+  rm -rf ${MOUNT_DIR}
+  truncate ${MOUNT_IMAGE} -s ${IMAGE_SIZE}
+  mkfs.btrfs ${MOUNT_IMAGE}
+  mkdir -p ${MOUNT_DIR}
+fi
+
+mount ${MOUNT_IMAGE} ${MOUNT_DIR} || true


### PR DESCRIPTION
I have a feeling that the mount in the script should not be there, when I killed osd after running make launch-local-btrfs, I have no way to unmount /var/lib/openstorage/btrfs, it is always busy.

We need to visit this and do documentation.