### PR TITLE
Flexvolume for k8s integration

### DIFF
--- a/api/server/flexvolume.go
+++ b/api/server/flexvolume.go
@@ -1,27 +1,145 @@
 package server
 
-type flexVolumeClient struct{}
+import (
+	"fmt"
+
+	"github.com/libopenstorage/openstorage/pkg/mount"
+	"github.com/libopenstorage/openstorage/volume"
+
+	"go.pedge.io/dlog"
+)
+
+const (
+	osdDriverKey = "osdDriver"
+	volumeIdKey  = "volumeID"
+	pxDriverKey  = "pxd"
+)
+
+var (
+	deviceDriverMap map[string]string
+)
+
+type flexVolumeClient struct {
+}
 
 func newFlexVolumeClient() *flexVolumeClient {
+	deviceDriverMap = make(map[string]string)
+
 	return &flexVolumeClient{}
 }
 
+func (c *flexVolumeClient) getVolumeDriver(driverName string) (volume.VolumeDriver, error) {
+	driver, err := volume.Get(driverName)
+	if err != nil {
+		return nil, fmt.Errorf("%v driver not initialized in OSD", driverName)
+	}
+	return driver, nil
+}
 func (c *flexVolumeClient) Init() error {
 	return nil
 }
 
 func (c *flexVolumeClient) Attach(jsonOptions map[string]string) error {
+	driverName, ok := jsonOptions[osdDriverKey]
+	if !ok {
+		return fmt.Errorf("Invalid kubernetes spec file : No OSD driver specified in flexvolume")
+	}
+
+	driver, err := c.getVolumeDriver(driverName)
+	if err != nil {
+		return err
+	}
+
+	mountDevice, ok := jsonOptions[volumeIdKey]
+	if !ok {
+		return fmt.Errorf("Invalid kubernetes spec file : No volumeID specified in flexvolume")
+	}
+
+	_, err = driver.Attach(mountDevice)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
 func (c *flexVolumeClient) Detach(mountDevice string) error {
+	var driverName string
+	driverName, ok := deviceDriverMap[mountDevice]
+	if !ok {
+		dlog.Infof("Could not find driver for (%v). Defaulting to pxd", mountDevice)
+		driverName = pxDriverKey
+	}
+
+	driver, err := c.getVolumeDriver(driverName)
+	if err != nil {
+		return err
+	}
+
+	err = driver.Detach(mountDevice)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
-func (c *flexVolumeClient) Mount(targetMountDir string, mountDevice string, jsonOptions map[string]string) error {
+func (c *flexVolumeClient) Mount(targetMountDir string, mountDevice string,
+	jsonOptions map[string]string) error {
+	driverName, ok := jsonOptions[osdDriverKey]
+	if !ok {
+		return fmt.Errorf("Invalid kubernetes spec file : No OSD driver specified in flexvolume")
+	}
+
+	driver, err := c.getVolumeDriver(driverName)
+	if err != nil {
+		return err
+	}
+
+	if targetMountDir == "" {
+		return fmt.Errorf("Missing target mount path")
+	}
+
+	err = driver.Mount(mountDevice, targetMountDir)
+	if err != nil {
+		return fmt.Errorf("Failed in mount. Driver returned error : (%v)", err)
+	}
+
+	// Update the deviceDriverMap
+	mountManager, _ := mount.New(mount.DeviceMount, "")
+	devPath, err := mountManager.GetDevPath(targetMountDir)
+	if err != nil {
+		return fmt.Errorf("Mount Failed. Could not find mountpoint in /proc/self/mountinfo")
+	}
+	deviceDriverMap[devPath] = driverName
+
 	return nil
 }
 
 func (c *flexVolumeClient) Unmount(mountDir string) error {
+	var driverName string
+
+	// Get the mountDevice from mount manager
+	mountManager, _ := mount.New(mount.DeviceMount, "")
+	mountDevice, err := mountManager.GetDevPath(mountDir)
+	if err != nil {
+		return fmt.Errorf("Invalid mountDir (%v). No device mounted on this path", mountDir)
+	}
+
+	driverName, ok := deviceDriverMap[mountDevice]
+	if !ok {
+		dlog.Infof("Could not find driver for (%v). Defaulting to pxd", mountDevice)
+		driverName = pxDriverKey
+	}
+
+	driver, err := c.getVolumeDriver(driverName)
+	if err != nil {
+		return err
+	}
+
+	err = driver.Unmount(mountDevice, mountDir)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/api/server/flexvolume.go
+++ b/api/server/flexvolume.go
@@ -13,11 +13,9 @@ import (
 const (
 	osdDriverKey = "osdDriver"
 	volumeIDKey  = "volumeID"
-	pxDriverKey  = "pxd"
 )
 
 var (
-	deviceDriverMap map[string]string
 	// ErrInvalidSpecDriver is returned when incorrect or no OSD driver is specified in spec file
 	ErrInvalidSpecDriver = errors.New("Invalid kubernetes spec file : No OSD driver specified in flexvolume")
 	// ErrInvalidSpecVolumeID is returned when incorrect or no volumeID is specified in spec file
@@ -26,9 +24,12 @@ var (
 	ErrNoMountInfo = errors.New("Could not read mountpoints from /proc/self/mountinfo. ")
 	// ErrMissingMountPath is returned when no mountPath specified in mount call
 	ErrMissingMountPath = errors.New("Missing target mount path")
+	deviceDriverMap     = make(map[string]string)
 )
 
-type flexVolumeClient struct{}
+type flexVolumeClient struct {
+	defaultDriver string
+}
 
 func (c *flexVolumeClient) Init() error {
 	return nil
@@ -39,18 +40,15 @@ func (c *flexVolumeClient) Attach(jsonOptions map[string]string) error {
 	if !ok {
 		return ErrInvalidSpecDriver
 	}
-
 	driver, err := c.getVolumeDriver(driverName)
 	if err != nil {
 		return err
 	}
-
 	mountDevice, ok := jsonOptions[volumeIDKey]
 	if !ok {
 		return ErrInvalidSpecVolumeID
 	}
-
-	if _, err = driver.Attach(mountDevice); err != nil {
+	if _, err := driver.Attach(mountDevice); err != nil {
 		return err
 	}
 	return nil
@@ -59,16 +57,14 @@ func (c *flexVolumeClient) Attach(jsonOptions map[string]string) error {
 func (c *flexVolumeClient) Detach(mountDevice string) error {
 	driverName, ok := deviceDriverMap[mountDevice]
 	if !ok {
-		dlog.Infof("Could not find driver for (%v). Defaulting to pxd", mountDevice)
-		driverName = pxDriverKey
+		dlog.Infof("Could not find driver for (%v). Resorting to default driver ", mountDevice)
+		driverName = c.defaultDriver
 	}
-
 	driver, err := c.getVolumeDriver(driverName)
 	if err != nil {
 		return err
 	}
-
-	if err = driver.Detach(mountDevice); err != nil {
+	if err := driver.Detach(mountDevice); err != nil {
 		return err
 	}
 	return nil
@@ -81,27 +77,22 @@ func (c *flexVolumeClient) Mount(targetMountDir string, mountDevice string,
 	if !ok {
 		return ErrInvalidSpecDriver
 	}
-
 	driver, err := c.getVolumeDriver(driverName)
 	if err != nil {
 		return err
 	}
-
 	if targetMountDir == "" {
 		return ErrMissingMountPath
 	}
-
-	if err = driver.Mount(mountDevice, targetMountDir); err != nil {
+	if err := driver.Mount(mountDevice, targetMountDir); err != nil {
 		return err
 	}
-
 	// Update the deviceDriverMap
 	mountManager, err := mount.New(mount.DeviceMount, "")
 	if err != nil {
 		dlog.Infof("Could not read mountpoints from /proc/self/mountinfo. Device - Driver mapping not saved!")
 		return nil
 	}
-
 	devPath, err := mountManager.GetDevPath(targetMountDir)
 	if err != nil {
 		return fmt.Errorf("Mount Failed. Could not find mountpoint in /proc/self/mountinfo")
@@ -111,45 +102,36 @@ func (c *flexVolumeClient) Mount(targetMountDir string, mountDevice string,
 }
 
 func (c *flexVolumeClient) Unmount(mountDir string) error {
-	var driverName string
-
 	// Get the mountDevice from mount manager
 	mountManager, err := mount.New(mount.DeviceMount, "")
 	if err != nil {
 		return ErrNoMountInfo
 	}
-
 	mountDevice, err := mountManager.GetDevPath(mountDir)
 	if err != nil {
 		return fmt.Errorf("Invalid mountDir (%v). No device mounted on this path", mountDir)
 	}
-
 	driverName, ok := deviceDriverMap[mountDevice]
 	if !ok {
-		dlog.Infof("Could not find driver for (%v). Defaulting to pxd", mountDevice)
-		driverName = pxDriverKey
+		dlog.Infof("Could not find driver for (%v). Resorting to default driver. ", mountDevice)
+		driverName = c.defaultDriver
 	}
-
 	driver, err := c.getVolumeDriver(driverName)
 	if err != nil {
 		return err
 	}
-
-	if err = driver.Unmount(mountDevice, mountDir); err != nil {
+	if err := driver.Unmount(mountDevice, mountDir); err != nil {
 		return err
 	}
 	return nil
 }
 
-func newFlexVolumeClient() *flexVolumeClient {
-	deviceDriverMap = make(map[string]string)
-	return &flexVolumeClient{}
+func newFlexVolumeClient(defaultDriver string) *flexVolumeClient {
+	return &flexVolumeClient{
+		defaultDriver: defaultDriver,
+	}
 }
 
 func (c *flexVolumeClient) getVolumeDriver(driverName string) (volume.VolumeDriver, error) {
-	driver, err := volume.Get(driverName)
-	if err != nil {
-		return nil, fmt.Errorf("%v driver not initialized in OSD", driverName)
-	}
-	return driver, nil
+	return volume.Get(driverName)
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -62,9 +62,9 @@ func StartClusterAPI(clusterApiBase string) error {
 }
 
 // StartFlexVolumeAPI starts the flexvolume API on the given port.
-func StartFlexVolumeAPI(port uint16) error {
+func StartFlexVolumeAPI(port uint16, defaultDriver string) error {
 	grpcServer := grpc.NewServer(grpc.MaxConcurrentStreams(math.MaxUint32))
-	flexvolume.RegisterAPIServer(grpcServer, flexvolume.NewAPIServer(newFlexVolumeClient()))
+	flexvolume.RegisterAPIServer(grpcServer, flexvolume.NewAPIServer(newFlexVolumeClient(defaultDriver)))
 	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		return err

--- a/cmd/osd/main.go
+++ b/cmd/osd/main.go
@@ -79,6 +79,7 @@ func start(c *cli.Context) {
 		}
 	}
 
+	isDefaultSet := false
 	// Start the volume drivers.
 	for d, v := range cfg.Osd.Drivers {
 		dlog.Infof("Starting volume driver: %v", d)
@@ -91,9 +92,17 @@ func start(c *cli.Context) {
 			dlog.Warnf("Unable to start volume plugin: %v", err)
 			return
 		}
+		if d != "" && cfg.Osd.ClusterConfig.DefaultDriver == d {
+			isDefaultSet = true
+		}
 	}
 
-	if err := server.StartFlexVolumeAPI(config.FlexVolumePort); err != nil {
+	if cfg.Osd.ClusterConfig.DefaultDriver != "" && !isDefaultSet {
+		dlog.Warnf("Invalid OSD config file: Default Driver specified but driver not initialized")
+		return
+	}
+
+	if err := server.StartFlexVolumeAPI(config.FlexVolumePort, cfg.Osd.ClusterConfig.DefaultDriver); err != nil {
 		dlog.Warnf("Unable to start flexvolume API: %v", err)
 		return
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,7 @@ type ClusterConfig struct {
 	NodeId    string
 	MgtIface  string
 	DataIface string
+	DefaultDriver string
 }
 
 type Config struct {

--- a/pkg/flexvolume/client.go
+++ b/pkg/flexvolume/client.go
@@ -21,6 +21,10 @@ var (
 	successBytes = []byte(`{"Status":"Success"}`)
 )
 
+func newClient(apiClient APIClient) *client {
+	return &client{apiClient}
+}
+
 func (c *client) Init() error {
 	_, err := c.apiClient.Init(
 		context.Background(),
@@ -81,10 +85,6 @@ func (c *client) Unmount(mountDir string) error {
 	)
 	writeOutput(newOutput(err))
 	return err
-}
-
-func newClient(apiClient APIClient) *client {
-	return &client{apiClient}
 }
 
 func newFailureBytes(err error) []byte {

--- a/pkg/flexvolume/client.go
+++ b/pkg/flexvolume/client.go
@@ -1,12 +1,29 @@
 package flexvolume
 
 import (
+	"encoding/json"
+	"os"
+
 	"go.pedge.io/pb/go/google/protobuf"
 	"golang.org/x/net/context"
 )
 
 type client struct {
 	apiClient APIClient
+}
+
+type AttachSuccessOutput struct {
+	Status string
+	Device string
+}
+
+type SuccessOutput struct {
+	Status string
+}
+
+type FailureOutput struct {
+	Status  string
+	Message string
 }
 
 func newClient(apiClient APIClient) *client {
@@ -22,43 +39,119 @@ func (c *client) Init() error {
 }
 
 func (c *client) Attach(jsonOptions map[string]string) error {
+	var output []byte
 	_, err := c.apiClient.Attach(
 		context.Background(),
 		&AttachRequest{
 			JsonOptions: jsonOptions,
 		},
 	)
+	if err == nil {
+		a := AttachSuccessOutput{
+			Status: "Success",
+			Device: jsonOptions["volumeID"],
+		}
+		output, _ = json.Marshal(a)
+	} else {
+		a := FailureOutput{
+			Status:  "Failure",
+			Message: err.Error(),
+		}
+		output, _ = json.Marshal(a)
+	}
+
+	os.Stdout.Write(output)
 	return err
 }
 
 func (c *client) Detach(mountDevice string) error {
+	var output []byte
+
 	_, err := c.apiClient.Detach(
 		context.Background(),
 		&DetachRequest{
 			MountDevice: mountDevice,
 		},
 	)
+
+	if err == nil {
+		a := SuccessOutput{
+			Status: "Success",
+		}
+		output, _ = json.Marshal(a)
+	} else {
+		a := FailureOutput{
+			Status:  "Failure",
+			Message: err.Error(),
+		}
+		output, _ = json.Marshal(a)
+	}
+
+	os.Stdout.Write(output)
 	return err
 }
 
 func (c *client) Mount(targetMountDir string, mountDevice string, jsonOptions map[string]string) error {
-	_, err := c.apiClient.Mount(
-		context.Background(),
-		&MountRequest{
-			TargetMountDir: targetMountDir,
-			MountDevice:    mountDevice,
-			JsonOptions:    jsonOptions,
-		},
-	)
+	err := os.MkdirAll(targetMountDir, os.ModeDir)
+	var output []byte
+
+	if err == nil {
+		_, err = c.apiClient.Mount(
+			context.Background(),
+			&MountRequest{
+				TargetMountDir: targetMountDir,
+				MountDevice:    mountDevice,
+				JsonOptions:    jsonOptions,
+			},
+		)
+		if err == nil {
+			a := SuccessOutput{
+				Status: "Success",
+			}
+			output, _ = json.Marshal(a)
+		} else {
+			a := FailureOutput{
+				Status:  "Failure",
+				Message: err.Error(),
+			}
+			output, _ = json.Marshal(a)
+		}
+	} else {
+		a := FailureOutput{
+			Status:  "Failure",
+			Message: err.Error(),
+		}
+		output, _ = json.Marshal(a)
+	}
+
+	os.Stdout.Write(output)
 	return err
 }
 
 func (c *client) Unmount(mountDir string) error {
+	var output []byte
+
 	_, err := c.apiClient.Unmount(
 		context.Background(),
 		&UnmountRequest{
 			MountDir: mountDir,
 		},
 	)
+
+	if err == nil {
+		a := SuccessOutput{
+			Status: "Success",
+		}
+		output, _ = json.Marshal(a)
+	} else {
+		a := FailureOutput{
+			Status:  "Failure",
+			Message: err.Error(),
+		}
+		output, _ = json.Marshal(a)
+	}
+
+	os.Stdout.Write(output)
+
 	return err
 }


### PR DESCRIPTION
- Implemented the attach/detach/mount/unmount functions in flexvolume server plugin.
- The flexvolume client now writes to stdout the way kubernetes flexvolume plugin expects for each command.
- Modified the mounts package to provide devicePath given a mount point.

Note: Currently we are storing a mapping of devices and their volume drivers in a in-memory map. If the osd daemon dies and upon restart it does not find a volume driver for a device then it defaults to pwx driver.