### PR TITLE
Move to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: required
+services:
+  - docker
+language: go
+go:
+  - 1.6
+script:
+  - make docker-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ language: go
 go:
   - 1.6
 script:
-  - make docker-build
+  - make docker-test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Current Build Status
-[![Build Status](http://emma.openstorage.org/buildStatus/icon?job=Openstorage&style=plastic)](http://emma.openstorage.org/job/Openstorage/)
+[![Build Status](https://travis-ci.org/libopenstorage/openstorage.svg?branch=master)](https://travis-ci.org/libopenstorage/openstorage)
 
 # About Open Storage
 


### PR DESCRIPTION
This moves openstorage from jenkins to travis. The main reasoning here is:

1. Transparency - it's way easier for people to see/understand what is happening when they see a .travis.yml file, as opposed to jenkins where I couldn't actually figure out what build steps were being run until I logged in (and most people don't have openstorage jenkins credentials)
2. Consistent build environment - if we use travis, we know exactly what we are getting, with a blank virtual machine every time, no more customizations that you also have to go to jenkins to see, travis does allow both sudo and docker --privileged though, so we have plenty of ability to add what we need
3. Deployment - travis is way nicer for deployment, which we will get to next