### PR TITLE
fix: nil pointer dereference when using "docker volume ls"

### DIFF
--- a/volume/drivers/common/default_store_enumerator.go
+++ b/volume/drivers/common/default_store_enumerator.go
@@ -181,6 +181,9 @@ func match(
 	locator *api.VolumeLocator,
 	volumeLabels map[string]string,
 ) bool {
+	if locator == nil {
+		return hasSubset(v.Spec.VolumeLabels, volumeLabels)
+	}
 	if locator.Name != "" && v.Locator.Name != locator.Name {
 		return false
 	}


### PR DESCRIPTION
Signed-off-by: Terry Chen <seterrychen@gmail.com>

When using "docker volume ls", the value of locator and volumeLables of `match` method will be nil. It's the root cause of the `nil pointer dereference` problem. (issue #136)

To fix the problem, elem is just added into volumes and `match` function doesn't need to check when locator and labels are nil.

