### PR TITLE
NFS driver doesn't work correctly with empty Consul KV store

### DIFF
--- a/volume/drivers/common/default_store_enumerator.go
+++ b/volume/drivers/common/default_store_enumerator.go
@@ -89,12 +89,20 @@ func (e *defaultStoreEnumerator) Enumerate(
 ) ([]*api.Volume, error) {
 
 	kvp, err := e.kvdb.Enumerate(e.volKeyPrefix())
-	if err != nil {
+
+	if err == kvdb.ErrNotFound {
+		volumes := make([]*api.Volume, 0, 0)
+		return volumes, nil
+	} else if err != nil {
 		return nil, err
 	}
+
 	volumes := make([]*api.Volume, 0, len(kvp))
 	for _, v := range kvp {
 		elem := &api.Volume{}
+		if v.Value == nil {
+			continue
+		}
 		if err := json.Unmarshal(v.Value, elem); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When launching OpenStorage with the following configuration, OpenStorage starts and stops with the following error message:

```
$ cat config.yaml
osd:
  drivers:
    nfs:
      path: /docker-volumes
      server: 192.168.101.106

$ sudo ./osd --daemon --kvdb consul-kv://localhost:8500 --file $PWD/config.yaml 
2016/09/09 11:47:24 proto: duplicate proto type registered: google.protobuf.Empty
INFO[0000] Starting volume driver: nfs                  
INFO[0000] NFS driver initializing with 192.168.101.106:/docker-volumes  
WARN[0000] Unable to start volume driver: nfs, Key not found
$
```

I managed to find that the requested key, which OpenStorage is unable to enumerate, is `openstorage/openstorage/nfs/volumes/` (there's probably a `openstorage/` level too much here). Once this "folder" created **manually** in Consul, relaunching OpenStorage gives the following error:

```
WARN[0000] Unable to start volume driver: nfs, unexpected end of JSON input 
```
1. For the first problem, I added a special case for when the KV backend doesn't have the required key, instead of returning the error.
2. For the second problem, apparently [portworx/kvdb](https://github.com/portworx/kvdb/)'s `Enumerate` function returns at least one element if the prefix exists but is empty (it returns the prefix as the key, without any values). Since the value is empty in this case, unmarshalling its content from JSON raises the error aforementioned.

I'm not sure if the fixes are proper, please don't hesitate to comment. I'm also currently looking at writing some tests.
