### PR TITLE
aws: deleting a EBS volume also delete the reference in the volume store

### DIFF
--- a/volume/drivers/aws/aws.go
+++ b/volume/drivers/aws/aws.go
@@ -471,7 +471,8 @@ func (d *Driver) Delete(volumeID string) error {
 	if err != nil {
 		return err
 	}
-	return nil
+	err = d.DeleteVol(volumeID)
+	return err
 }
 
 func (d *Driver) Snapshot(volumeID string, readonly bool, locator *api.VolumeLocator) (string, error) {


### PR DESCRIPTION
Deleting a EBS volume from Openstorage properly deletes the volume from AWS but leaves a reference inside the store configured:

```
$ openstorage --file config.yaml aws create test --fs ext4 --size 5000
Waiting for state transition to "attached"...
Waiting for state transition to "detached"....
vol-xxxx
$ openstorage --file config.yaml aws enumerate
[{
 "id": "vol-xxxxx",
 "source": {
  "parent": "",
  "seed": ""
 },
 "readonly": false,
 "locator": {
  "name": "test"
 },
 "ctime": "2016-09-27T13:18:39Z",
 "spec": {
  "ephemeral": false,
  "size": "5242880000",
  "format": "ext4",
  "block_size": "32768",
  "ha_level": "1",
  "cos": 1,
  "dedupe": false,
  "snapshot_interval": 0,
  "shared": false,
  "aggregation_level": 0
 },
 "usage": "0",
 "last_scan": "2016-09-27T13:18:39Z",
 "format": "ext4",
 "status": "up",
 "state": "available",
 "attached_on": "",
 "device_path": "/dev/xvdf",
 "error": ""
}]
$ openstorage --file config.yaml aws delete vol-xxx
vol-xxx
$ openstorage --file config.yaml aws enumerate
[{
 "id": "vol-xxxxx",
 "source": {
  "parent": "",
  "seed": ""
 },
 "readonly": false,
 "locator": {
  "name": "test"
 },
 "ctime": "2016-09-27T13:18:39Z",
 "spec": {
  "ephemeral": false,
  "size": "5242880000",
  "format": "ext4",
  "block_size": "32768",
  "ha_level": "1",
  "cos": 1,
  "dedupe": false,
  "snapshot_interval": 0,
  "shared": false,
  "aggregation_level": 0
 },
 "usage": "0",
 "last_scan": "2016-09-27T13:18:39Z",
 "format": "ext4",
 "status": "up",
 "state": "available",
 "attached_on": "",
 "device_path": "/dev/xvdf",
 "error": ""
}]
```

Extract from the logs:
```
[...]
INFO[0205] aws preparing volume vol-xxx... 
INFO[0214]                                               Driver=aws ID=vol-xxx Request=create
INFO[2020]                                               Driver=aws ID=vol-xxx Request=delete
WARN[2022] 404   Failed to locate volume: Cannot locate volume test  Driver=aws ID=test Request=path
[...]
```

This fix implements the same behavior as in the other volume drivers.