### PR TITLE
Reduce the duration for which cluster lock is held

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -56,10 +56,10 @@ type ClusterListener interface {
 	String() string
 
 	// ClusterInit is called when a brand new cluster is initialized.
-	ClusterInit(self *api.Node, state *ClusterInitState) error
+	ClusterInit(self *api.Node) error
 
 	// Init is called when this node is joining an existing cluster for the first time.
-	Init(self *api.Node, state *ClusterInitState) error
+	Init(self *api.Node, state *ClusterInfo) error
 
 	// CleanupInit is called when Init failed.
 	CleanupInit(self *api.Node, clusterInfo *ClusterInfo) error

--- a/cluster/database.go
+++ b/cluster/database.go
@@ -85,19 +85,20 @@ func readClusterInfo() (ClusterInfo, error) {
 	return db, nil
 }
 
-func writeClusterInfo(db *ClusterInfo) error {
+func writeClusterInfo(db *ClusterInfo) (*kvdb.KVPair, error) {
 	kvdb := kvdb.Instance()
 	b, err := json.Marshal(db)
 	if err != nil {
 		dlog.Warnf("Fatal, Could not marshal cluster database to JSON: %v", err)
-		return err
+		return nil, err
 	}
 
-	if _, err := kvdb.Put(ClusterDBKey, b, 0); err != nil {
+	kvp, err := kvdb.Put(ClusterDBKey, b, 0)
+	if err != nil {
 		dlog.Warnf("Fatal, Could not marshal cluster database to JSON: %v", err)
-		return err
+		return nil, err
 	}
 
 	dlog.Infoln("Cluster database updated.")
-	return nil
+	return kvp, nil
 }

--- a/volume/drivers/buse/buse.go
+++ b/volume/drivers/buse/buse.go
@@ -334,11 +334,11 @@ func (d *driver) Shutdown() {
 	syscall.Unmount(BuseMountPath, 0)
 }
 
-func (d *driver) ClusterInit(self *api.Node, initState *cluster.ClusterInitState) error {
+func (d *driver) ClusterInit(self *api.Node) error {
 	return nil
 }
 
-func (d *driver) Init(self *api.Node, initState *cluster.ClusterInitState) error {
+func (d *driver) Init(self *api.Node, clusterInfo *cluster.ClusterInfo) error {
 	return nil
 }
 


### PR DESCRIPTION
Do not hold the lock when Listener's Init functions
are being called.

Cluster And Node Init workflow

1. Take cluster lock
2. Read cluster data from kvdb. If cluster not initialized initialize
   the cluster and update cluster data in kvdb as initialized.
3. Release cluster lock
4. Call Listener's Init functions.
5. Take cluster lock
6. Update cluster data with new node info obtained from listener.
7. Release cluster lock
8 Start cluster watch based on last index obtained step 6.