### PR TITLE
Adding cluster discovery via Multicast

### DIFF
--- a/cluster/discovery/discovery.go
+++ b/cluster/discovery/discovery.go
@@ -7,6 +7,15 @@ type NodeEntry struct {
 	GossipVersion string
 }
 
+// Equals method compares two NodeEntries, and returns TRUE if the NodeEntry's data is equal.
+func (ne NodeEntry) Equals(other *NodeEntry) bool {
+	if other == nil {
+		return false
+	} else {
+		return ne.Id == other.Id && ne.Ip == other.Ip && ne.GossipVersion == other.GossipVersion
+	}
+}
+
 // ClusterInfo is the cluster info used while discoveryping nodes
 // and discovering peer nodes using gossip
 type ClusterInfo struct {
@@ -30,4 +39,9 @@ type Cluster interface {
 	// WatchCluster starts a watch on the cluster and calls the provided
 	// callback function when a node is added or removed.
 	WatchCluster(wcb WatchClusterCB, index uint64) error
+
+	// Shutdown allows cluster to stop and clean up internal resources.
+	// This method is idempotent (may be called multiple times), but after calling this method, one should
+	// no longer use this Cluster instance for cluster discovery.
+	Shutdown() error
 }

--- a/cluster/discovery/discovery_kvdb.go
+++ b/cluster/discovery/discovery_kvdb.go
@@ -111,3 +111,8 @@ func (b *discoveryKvdb) WatchCluster(wcb WatchClusterCB, lastIndex uint64) error
 	go b.kv.WatchKey(ClusterDiscoveryKey, lastIndex, wcb, b.watchCluster)
 	return nil
 }
+
+// Shutdown is a dummy implementation
+func (b *discoveryKvdb) Shutdown() error {
+	return nil
+}

--- a/cluster/discovery/discovery_mcast.go
+++ b/cluster/discovery/discovery_mcast.go
@@ -1,0 +1,374 @@
+package discovery
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"go.pedge.io/dlog"
+)
+
+const (
+	// DefaultDiscoSrvAddr is a default MultiCast address for multicast discovery type
+	DefaultDiscoSrvAddr = "224.0.0.1:9010"
+	maxDatagramSize     = 256
+)
+
+type discoveryMcast struct {
+	sync.Mutex    // embedded
+	ClusterInfo   // embedded
+	wcb           WatchClusterCB
+	clusterName   string
+	mcAddr        string
+	restAddr      string
+	port          string
+	restLsnr      net.Listener
+	mcLsnr        *net.UDPConn
+	MaxUDPPackets int
+}
+
+// NewDiscoveryMcast creates a new instance of Multicast kvdb discovery
+func NewDiscoveryMcast(clusterName, mcAddr, restAddr string) (mcClust Cluster, err error) {
+	if "" == mcAddr {
+		mcAddr = DefaultDiscoSrvAddr
+	}
+
+	var port string
+	if _, port, err = net.SplitHostPort(mcAddr); err != nil {
+		// We have to have at least the port
+		dlog.WithField("err", err).Errorf("Invalid multicast address provided")
+		return
+	}
+
+	if "" == restAddr {
+		// Rest bind address not provided, let's compute it from Multicast addr
+		restAddr = ":" + port
+	} else {
+		var port0 string
+		_, port0, err = net.SplitHostPort(restAddr)
+		if err != nil {
+			// We have to have at least the port
+			dlog.WithField("err", err).Errorf("REST service port not provided")
+			return
+		} else if port != port0 {
+			err = fmt.Errorf("REST service must match multicast port (%s =/= %s)", port0, port)
+			return
+		}
+	}
+
+	mcClust = &discoveryMcast{
+		ClusterInfo: ClusterInfo{
+			Size:    0,
+			Nodes:   make(map[string]NodeEntry),
+			Version: 1,
+		},
+		clusterName:   clusterName,
+		mcAddr:        mcAddr,
+		restAddr:      restAddr,
+		port:          port,
+		MaxUDPPackets: 3,
+	}
+	return
+}
+
+func (b *discoveryMcast) AddNode(ne NodeEntry) (*ClusterInfo, error) {
+	b.Lock()
+	defer b.Unlock()
+
+	if _, exists := b.Nodes[ne.Id]; !exists {
+		// We do not exist in the map.
+		b.Size++
+		b.Version++
+		b.Nodes[ne.Id] = ne
+	} else if !b.Nodes[ne.Id].Equals(&ne) {
+		// bizLogic rule - update only if values were different
+		b.Version++
+		b.Nodes[ne.Id] = ne
+	}
+
+	// create a copy
+	ci := *(&b.ClusterInfo)
+	if b.wcb != nil {
+		b.wcb(&ci, nil)
+	}
+
+	return &ci, nil
+}
+
+func (b *discoveryMcast) RemoveNode(ne NodeEntry) (*ClusterInfo, error) {
+	b.Lock()
+	defer b.Unlock()
+
+	_, exists := b.Nodes[ne.Id]
+	if !exists {
+		return nil, fmt.Errorf("Unable to find node %v in discovery db", ne.Id)
+	}
+	delete(b.Nodes, ne.Id)
+	b.Version++
+
+	// create a copy
+	ci := *(&b.ClusterInfo)
+
+	return &ci, nil
+}
+
+func (b *discoveryMcast) Enumerate() (*ClusterInfo, error) {
+	b.Lock()
+	ci := *(&b.ClusterInfo) // Make a copy
+	b.Unlock()
+
+	return &ci, nil
+}
+
+func (b *discoveryMcast) addAllAndNotifyWatch(stream io.ReadCloser) error {
+	var ci ClusterInfo
+	if body, err := ioutil.ReadAll(stream); err != nil {
+		dlog.WithField("err", err).Warnf("Could not read config-request")
+		return err
+	} else if err := json.Unmarshal(body, &ci); err != nil {
+		dlog.WithField("err", err).Warnf("Could not parse config-request")
+		return err
+	}
+
+	//// ideally TRACE message
+	//logrus.Debugf("addAllAndNotifyWatch() got %+v, have %+v", ci, b.ClusterInfo)
+
+	b.Lock()
+	defer b.Unlock()
+
+	stGotNew, stGotUpdates := false, false
+	for k, v := range ci.Nodes {
+		if _, exists := b.Nodes[k]; !exists {
+			dlog.Infof("Discovered node %v", v)
+			b.Nodes[k] = v
+			stGotNew = true
+		} else if ci.Version > b.Version {
+			dlog.Infof("Updated node %v", v)
+			b.Nodes[k] = v
+			stGotUpdates = true
+		} else {
+			dlog.Debugf("Ignoring update to %s (version too low)", k)
+		}
+	}
+
+	if ci.Version > b.Version {
+		b.Version = ci.Version
+	}
+
+	if stGotNew {
+		b.Size = len(b.Nodes)
+		b.Version++
+	}
+
+	// ideally TRACE message
+	dlog.Debugf("addAllAndNotifyWatch() -- post additions, my updated state is %v", b.ClusterInfo)
+
+	if b.wcb != nil && (stGotNew || stGotUpdates) {
+		ci := *(&b.ClusterInfo)
+		b.wcb(&ci, nil)
+	}
+	return nil
+}
+
+// restConfigExchange is a REST-processing function, which will process the passed config
+func (b *discoveryMcast) restConfigExchange(w http.ResponseWriter, r *http.Request) {
+	dlog.Debugf("Processing REST config update via %s %v", r.Method, r.RequestURI)
+
+	w.Header().Add("Server", "OpenLib-Discovery")
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		r.Body.Close()
+		return
+	}
+
+	// Process input config
+	if err := b.addAllAndNotifyWatch(r.Body); err != nil {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(err.Error()))
+		r.Body.Close()
+		return
+	}
+
+	// Send back my updated config
+	ci, _ := b.Enumerate()
+	reply, err := json.Marshal(ci)
+	if err != nil {
+		dlog.WithField("err", err).Warnf("Could not encode my nodes")
+		return
+	}
+	_, err = w.Write(reply)
+	if err != nil {
+		dlog.WithField("err", err).Warnf("Error sending back my nodes")
+	} else {
+		dlog.Debugf("Sent back my nodes") // string(reply)?
+	}
+}
+
+func (b *discoveryMcast) mcastConfigExchange(udpAddr *net.UDPAddr) error {
+	ci, _ := b.Enumerate()
+	payload, err := json.Marshal(ci)
+	if err != nil {
+		dlog.WithField("err", err).Warnf("Failed serializing config %+v", ci)
+		return err
+	}
+
+	url := fmt.Sprintf("http://%s:%s", udpAddr.IP.String(), b.port)
+	dlog.Debugf("Sending config %v to %s", ci, url)
+	resp, err := http.Post(url, "application/json", bytes.NewReader(payload))
+	if err != nil {
+		dlog.WithField("err", err).Warnf("Error sendig POST-config request")
+	} else if resp.StatusCode != http.StatusOK {
+		dlog.Warnf("Got HTTP error [%s] sending config", resp.Status)
+	} else {
+		dlog.Infof("Configuration sent to %v", url)
+
+		if resp.ContentLength > 0 {
+			return b.addAllAndNotifyWatch(resp.Body)
+		}
+		dlog.Debugf("mcastConfigExchange() my config after update: %v", b.ClusterInfo)
+	}
+	return nil
+}
+
+// pingMulticast transmits a MCAST package, looking for the rest of the cluster.
+func (b *discoveryMcast) pingMulticast() error {
+	addr, err := net.ResolveUDPAddr("udp", b.mcAddr)
+	if err != nil {
+		dlog.WithField("err", err).Warnf("Could not resolve UDP for %v", b.mcAddr)
+		return err
+	}
+	c, err := net.DialUDP("udp", nil, addr)
+	if err != nil {
+		dlog.WithField("err", err).Warnf("Could not dial multicast on %+v", *addr)
+		return err
+	}
+
+	dlog.Debugf("Sending multicast ping on %+v", *addr)
+	ploadStr := "pwx:" + b.clusterName
+	pload := []byte(ploadStr)
+	for i := 0; i < b.MaxUDPPackets; i++ {
+		if _, err := c.Write(pload); err != nil {
+			dlog.WithField("err", err).Warnf("Could not send message")
+		} else {
+			dlog.Debugf("Multicast message transmitted for cluster %s", ploadStr)
+		}
+	}
+	return nil
+}
+
+// serveMcast method starts serving the Multicast Listener running in a loop, listening on multicast requests.
+// If request has been received, for the same cluster name, this method will send the latest member-list to the
+// caller's REST service.
+func (b *discoveryMcast) serveMcast() {
+	addr, err := net.ResolveUDPAddr("udp", b.mcAddr)
+	if err != nil {
+		dlog.WithField("err", err).Errorf("Could not resolve UDP for %v", b.mcAddr)
+	}
+	dlog.Debugf("Listening Multicast on %+v", *addr)
+	conn, err := net.ListenMulticastUDP("udp", nil, addr)
+	if err != nil {
+		dlog.WithField("err", err).Errorf("Could not set up multicast listener")
+	}
+	b.mcLsnr = conn
+	conn.SetReadBuffer(maxDatagramSize)
+	needBytes := []byte("pwx:" + b.clusterName)
+	for b.mcLsnr != nil {
+		buf := make([]byte, maxDatagramSize)
+		n, udpAddr, err := conn.ReadFromUDP(buf)
+		if b.mcLsnr == nil {
+			// clumsy solution, but looks like there's no better (see https://github.com/golang/go/issues/4373)
+			break
+		} else if err != nil {
+			dlog.WithField("err", err).Warnf("Error reading multicast UDP (sleep & cont..)", err)
+			time.Sleep(5 * time.Second)
+		} else if n == len(needBytes) && bytes.Equal(buf[:n], needBytes) {
+			dlog.Infof("Got config request from client at %v", udpAddr)
+			// Send the config back
+			b.mcastConfigExchange(udpAddr)
+		} else {
+			// CAUTION- costly string functions below -- should run only if logger is set to DEBUG, but
+			// sadly dlog does not have logrus.GetLevel() equivalent
+			dlog.Debugf("Ignoring config request from client at %s :: need '%s', got %v/'%s'",
+				udpAddr, string(needBytes), buf[:n], string(buf[:n]))
+		}
+	}
+}
+
+// init will initialize and spawn the IP-service with REST config-service
+func (b *discoveryMcast) serveRest() {
+	restServer := &http.Server{
+		Handler:        http.HandlerFunc(b.restConfigExchange),
+		ReadTimeout:    10 * time.Second,
+		WriteTimeout:   10 * time.Second,
+		MaxHeaderBytes: 512,
+	}
+
+	lsnr, err := net.Listen("tcp", b.restAddr)
+	if err != nil {
+		dlog.WithField("err", err).Errorf("Could not set up REST-listener")
+	}
+	b.restLsnr = lsnr
+
+	//http.HandleFunc("/", b.restConfigExchange)
+	dlog.Debugf("REST serving on http://%s/%s", lsnr.Addr(), b.clusterName)
+	restServer.Serve(lsnr)
+}
+
+// Shutdown stops the IP/UDP listeners for multicast discovery.
+func (b *discoveryMcast) Shutdown() (err error) {
+	// remove watch
+	if b.wcb != nil {
+		b.wcb = nil
+	}
+	closing := false
+	// stop IP listener
+	if b.restLsnr != nil {
+		dlog.Debugf("Shutting down REST-Listener")
+		if err = b.restLsnr.Close(); err != nil {
+			dlog.WithField("err", err).Warnf("Could not shut down the kvdb discovery's REST-listener")
+		} else {
+			closing = true
+			b.restLsnr = nil
+		}
+	}
+	// stop UDP listener
+	if b.mcLsnr != nil {
+		dlog.Debugf("Shutting down UDP-Listener")
+		if err = b.mcLsnr.Close(); err != nil {
+			dlog.WithField("err", err).Warnf("Could not shut down the kvdb discovery's UDP-listener")
+		} else {
+			closing = true
+			b.mcLsnr = nil
+		}
+	}
+	if closing {
+		// Allow some grace-time if we closed connections
+		time.Sleep(2 * time.Second)
+	}
+	return
+}
+
+func (b *discoveryMcast) WatchCluster(wcb WatchClusterCB, lastIndex uint64) error {
+	if b.wcb != nil {
+		return fmt.Errorf("watch cluster already started")
+	}
+
+	b.wcb = wcb
+	dlog.Infof("Cluster discovery starting watch at version %d", lastIndex)
+
+	b.Lock()
+	b.Version = lastIndex
+	b.Unlock()
+
+	// Start the internal services...
+	go b.serveRest()
+	b.pingMulticast()
+	go b.serveMcast()
+	return nil
+}

--- a/cluster/discovery/discovery_test.go
+++ b/cluster/discovery/discovery_test.go
@@ -1,0 +1,269 @@
+package discovery
+
+import (
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.pedge.io/dlog"
+)
+
+var LocalIPs = GetLocalIPList()
+
+// GetLocalIPList returns the list of local IP addresses
+func GetLocalIPList() (ipList []string) {
+	//dlog.SetLevel(dlog.LevelDebug)
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		dlog.WithField("err", err).Warnf("Could not enumerate network interfaces (some tests will be disabled)")
+		return
+	}
+	for _, i := range ifaces {
+		addrs, err := i.Addrs()
+		if err != nil {
+			// Let's make it non-fatal warning
+			dlog.WithField("err", err).Warnf("Error inspecting addr %v\n", addrs, err)
+			continue
+		}
+		// TODO: Exclude IPv6?
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP.To4()
+			case *net.IPAddr:
+				ip = v.IP.To4()
+			}
+			// process IP address
+			if ip != nil && !ip.IsLoopback() && !ip.IsUnspecified() {
+				ipList = append(ipList, ip.String())
+			}
+		}
+	}
+	return
+}
+
+// TestMulticastSingleNode tests the mechanics of a single node in KVDB cluster.
+// WARNING: the test assumes 19010 TCP/UDP port is free (will not check if it is)
+func TestMulticastSingleNode(t *testing.T) {
+	serviceA, err := NewDiscoveryMcast("myCluster", "224.0.0.1:19010", "127.0.0.1:19010")
+	defer serviceA.Shutdown()
+	assert.Nil(t, err)
+
+	// Basic sanity check -- add one node, expect to find one node
+
+	node1 := NodeEntry{
+		Id:            "node1",
+		Ip:            "127.0.0.1",
+		GossipVersion: "99",
+	}
+	ci, err := serviceA.AddNode(node1)
+
+	assert.Nil(t, err)
+	assert.NotEmpty(t, ci)
+	assert.Equal(t, 1, ci.Size)
+	assert.Equal(t, 1, len(ci.Nodes))
+	assert.Equal(t, uint64(2), ci.Version)
+	assert.NotNil(t, ci.Nodes[node1.Id])
+	assert.Equal(t, node1, ci.Nodes[node1.Id])
+
+	// Activate watch
+	var watchdCi *ClusterInfo
+	numWatchCalled := 0
+	anonWcb := func(ci *ClusterInfo, err error) error {
+		numWatchCalled++
+		assert.NotNil(t, ci)
+		watchdCi = ci
+		return nil
+	}
+	serviceA.WatchCluster(anonWcb, uint64(123))
+	time.Sleep(1 * time.Second)
+	assert.Equal(t, 0, numWatchCalled)
+	assert.Nil(t, watchdCi)
+
+	// Add another node ...
+	node2 := NodeEntry{
+		Id:            "node2",
+		Ip:            "127.0.0.2",
+		GossipVersion: "88",
+	}
+	ci, err = serviceA.AddNode(node2)
+
+	assert.Nil(t, err)
+	assert.NotEmpty(t, ci)
+	assert.Equal(t, 2, ci.Size)
+	assert.Equal(t, 2, len(ci.Nodes))
+	assert.Equal(t, uint64(124), ci.Version)
+	assert.NotNil(t, ci.Nodes[node1.Id])
+	assert.NotNil(t, ci.Nodes[node2.Id])
+	assert.Equal(t, node2, ci.Nodes[node2.Id])
+
+	// Repeat the same checks w/ watched CI
+	assert.NotEmpty(t, watchdCi)
+	assert.Equal(t, 2, watchdCi.Size)
+	assert.Equal(t, 2, len(watchdCi.Nodes))
+	assert.Equal(t, uint64(124), watchdCi.Version)
+	assert.NotNil(t, watchdCi.Nodes[node1.Id])
+	assert.Equal(t, node1, watchdCi.Nodes[node1.Id])
+	assert.NotNil(t, watchdCi.Nodes[node2.Id])
+	assert.Equal(t, node2, watchdCi.Nodes[node2.Id])
+
+	// Add first node again
+	//
+	ci, err = serviceA.AddNode(node1)
+
+	// make sure version and number of elems didn't change
+	assert.Nil(t, err)
+	assert.Equal(t, 2, ci.Size)
+	assert.Equal(t, 2, len(ci.Nodes))
+	assert.Equal(t, uint64(124), ci.Version)
+
+	// Change then re-add second
+	node2.Ip = "198.162.1.2"
+	ci, err = serviceA.AddNode(node2)
+
+	// expect same number of nodes, new version ID
+	assert.Nil(t, err)
+	assert.Equal(t, 2, ci.Size)
+	assert.Equal(t, 2, len(ci.Nodes))
+	assert.Equal(t, uint64(125), ci.Version)
+	assert.Equal(t, "198.162.1.2", watchdCi.Nodes[node2.Id].Ip)
+
+}
+
+func TestMulticastInvalidConstructors(t *testing.T) {
+	var err error
+	_, err = NewDiscoveryMcast("test-cluster", "224.0.0.1", "127.0.0.1:19011")
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "missing port in address"))
+
+	_, err = NewDiscoveryMcast("test-cluster", "", "127.0.0.1")
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "missing port in address"))
+
+	_, err = NewDiscoveryMcast("test-cluster", "224.0.0.1:19010", "127.0.0.1:19011")
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "must match "))
+}
+
+func TestMulticastConfigPayloads(t *testing.T) {
+	restAddr := "127.0.0.1:19013"
+	svc, err := NewDiscoveryMcast("test-cluster", "224.0.0.1:19013", restAddr)
+	defer svc.Shutdown()
+	assert.Nil(t, err)
+	assert.NotNil(t, svc)
+
+	// GET should fail because REST is not up, until we set up a watch
+	restUrl := "http://" + restAddr
+	resp, err := http.Get(restUrl)
+	assert.Nil(t, resp)
+	assert.NotNil(t, err)
+	assert.True(t, strings.Contains(err.Error(), "connection refused"))
+
+	// set up a watch
+	svc.WatchCluster(func(ci *ClusterInfo, err error) error {
+		assert.NotNil(t, ci)
+		return nil
+	}, uint64(223))
+	time.Sleep(1 * time.Second)
+
+	// GET rest call fails now because it is not supported
+	resp, err = http.Get(restUrl)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
+
+	// POST is supported, but let's pass empty request
+	resp, err = http.Post(restUrl, "application/json", strings.NewReader(""))
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	// .. also non-json object
+	resp, err = http.Post(restUrl, "application/json", strings.NewReader("^test/this_"))
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+// TestMulticastMultiNodes emulates the multi-node environment, by binding to different NICs and ports
+// WARNING: the test assumes 19010 TCP/UDP ports are free (will not check if it is)
+func TestMulticastMultiNodes(t *testing.T) {
+	// For this test, we'll need at least 1 more NIC/IP apart from localhost/127.0.0.1
+	if len(LocalIPs) == 0 {
+		dlog.Warnf("No extra IPs found on this system (how did you log in?!) -- skipping this test")
+		assert.False(t, false)
+		return
+	}
+
+	clusterName := "testCluster2"
+	serviceA, err := NewDiscoveryMcast(clusterName, "224.0.0.1:19010", "127.0.0.1:19010")
+	assert.Nil(t, err)
+	assert.NotNil(t, serviceA)
+	defer serviceA.Shutdown()
+
+	serviceB, err := NewDiscoveryMcast(clusterName, "224.0.0.1:19010", LocalIPs[0]+":19010")
+	assert.Nil(t, err)
+	assert.NotNil(t, serviceA)
+	defer serviceB.Shutdown()
+
+	neA1 := NodeEntry{
+		Id:            "nodeA1",
+		Ip:            "127.0.0.1",
+		GossipVersion: "2",
+	}
+
+	serviceA.AddNode(neA1)
+
+	// Activate watch A
+	var watchdCiA *ClusterInfo
+	serviceA.WatchCluster(func(ci *ClusterInfo, err error) error {
+		assert.NotNil(t, ci)
+		watchdCiA = ci
+		return nil
+	}, uint64(123))
+	time.Sleep(1 * time.Second)
+
+	neBs := make([]NodeEntry, 5)
+	for i := 0; i < len(neBs); i++ {
+		strI := strconv.Itoa(i + 1)
+		neBs[i] = NodeEntry{
+			Id:            "nodeB" + strI,
+			Ip:            "192.168.1.10" + strI,
+			GossipVersion: "2",
+		}
+		serviceB.AddNode(neBs[i])
+	}
+
+	// Activate watch B
+	var watchdCiB *ClusterInfo
+	serviceB.WatchCluster(func(ci *ClusterInfo, err error) error {
+		assert.NotNil(t, ci)
+		watchdCiB = ci
+		return nil
+	}, uint64(223))
+	time.Sleep(1 * time.Second)
+
+	// Validate the configs are in sync between 2 services
+	ciA, _ := serviceA.Enumerate()
+	ciB, _ := serviceB.Enumerate()
+
+	assert.Equal(t, 6, ciA.Size)
+	assert.Equal(t, 6, len(ciA.Nodes))
+	assert.Equal(t, 6, ciB.Size)
+	assert.Equal(t, 6, len(ciB.Nodes))
+
+	assert.NotNil(t, ciB.Nodes[neA1.Id])
+	assert.Equal(t, neA1, ciB.Nodes[neA1.Id])
+	assert.NotNil(t, ciA.Nodes[neA1.Id])
+	assert.Equal(t, neA1, ciA.Nodes[neA1.Id])
+
+	for i := 0; i < len(neBs); i++ {
+		assert.NotNil(t, ciB.Nodes[neBs[i].Id])
+		assert.Equal(t, neBs[i], ciB.Nodes[neBs[i].Id])
+		assert.NotNil(t, ciA.Nodes[neBs[i].Id])
+		assert.Equal(t, neBs[i], ciA.Nodes[neBs[i].Id])
+	}
+}


### PR DESCRIPTION
Summary of changes:
* adding NodeEntry.Equals() to compare w/ another NodeEntry
* adding Cluster.Shutdown() to stop the helper-services
* NewDiscoveryMcast() that creates a new multicast-discovery imlpementation of Cluster
    - note that Cluster.WatchCluster() sets up the helper-services that update configs via multicast
    - these helper-services _must_ be shut down by calling Cluster.Shutdown()
* adding tests for multicast-discovery

TODO:
* reduce service "chattiness" and the amount of updates between the nodes
* AddNode/RemoveNode currently not propagated between the cluster members
* add security (ie. HMAC) to prevent non-authorized cluster nodes entering the cluster