### PR TITLE
PWX-2772.r4: Fixing client API for REST REST cluster/inspect/node

### DIFF
--- a/api/client/cluster/client.go
+++ b/api/client/cluster/client.go
@@ -53,7 +53,12 @@ func (c *clusterClient) SetSize(size int) error {
 }
 
 func (c *clusterClient) Inspect(nodeID string) (api.Node, error) {
-	return api.Node{}, nil
+	var resp api.Node
+	request := c.c.Get().Resource(clusterPath + "/inspect/" + nodeID)
+	if err := request.Do().Unmarshal(&resp); err != nil {
+		return api.Node{}, err
+	}
+	return resp, nil
 }
 
 func (c *clusterClient) AddEventListener(cluster.ClusterListener) error {


### PR DESCRIPTION
The client API code was not using the actual server REST-call, but was returning a dummy response. 