### PR TITLE
Fixing duplicated REST calls (#175)

### DIFF
--- a/api/client/cluster/client.go
+++ b/api/client/cluster/client.go
@@ -40,7 +40,6 @@ func (c *clusterClient) SetSize(size int) error {
 
 	request := c.c.Get().Resource(clusterPath + "/setsize")
 	request.QueryOption("size", strconv.FormatInt(int64(size), 16))
-	request.Do()
 	if err := request.Do().Unmarshal(&resp); err != nil {
 		return err
 	}
@@ -81,7 +80,6 @@ func (c *clusterClient) NodeStatus(listenerName string) (api.Status, error) {
 	var resp api.Status
 	request := c.c.Get().Resource(clusterPath + "/status")
 	request.QueryOption("name", listenerName)
-	request.Do()
 	if err := request.Do().Unmarshal(&resp); err != nil {
 		return api.Status_STATUS_NONE, err
 	}
@@ -92,7 +90,6 @@ func (c *clusterClient) PeerStatus(listenerName string) (map[string]api.Status, 
 	var resp map[string]api.Status
 	request := c.c.Get().Resource(clusterPath + "/peerstatus")
 	request.QueryOption("name", listenerName)
-	request.Do()
 	if err := request.Do().Unmarshal(&resp); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Removed duplicated client invocation to request.Do(), which initiates the REST call.