### PR TITLE
Cluster.Start() and MaxClusterNodes parameter fix (#177)

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -41,7 +41,7 @@ type NodeEntry struct {
 
 // ClusterInfo is the basic info about the cluster and its nodes
 type ClusterInfo struct {
-	Size        int
+	MaxSize     int
 	Status      api.Status
 	Id          string
 	NodeEntries map[string]NodeEntry


### PR DESCRIPTION
Introduced special "maxNodes" value 0, which will cause Cluster.Start() to use
persisted "maxNodes" instead of overriding.