### PR TITLE
PWX-2975: Augment API to set logging url

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -95,6 +95,9 @@ type Cluster struct {
 
 	// Nodes is an array of all the nodes in the cluster.
 	Nodes []Node
+
+	// Logging url for the cluster.
+	LoggingURL string
 }
 
 // StatPoint represents the basic structure of a single Stat reported

--- a/api/client/cluster/client.go
+++ b/api/client/cluster/client.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	clusterPath = "/cluster"
+	loggingurl = "/loggingurl"
 )
 
 type clusterClient struct {
@@ -136,6 +137,24 @@ func (c *clusterClient) DisableUpdates() error {
 func (c *clusterClient) EnableUpdates() error {
 	c.c.Put().Resource(clusterPath + "/enablegossip").Do()
 	return nil
+}
+
+func (c *clusterClient) SetLoggingURL(loggingURL string) error {
+
+	resp := api.ClusterResponse{}
+
+	request := c.c.Put().Resource(clusterPath + loggingurl)
+	request.QueryOption("url", loggingURL)
+	if err := request.Do().Unmarshal(&resp); err != nil {
+		return err
+	}
+
+	if resp.Error != "" {
+		return errors.New(resp.Error)
+	}
+
+	return nil
+
 }
 
 func (c *clusterClient) GetGossipState() *cluster.ClusterState {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -47,6 +47,7 @@ type ClusterInfo struct {
 	Id          string
 	UID         string
 	NodeEntries map[string]NodeEntry
+	LoggingURL string
 }
 
 // ClusterInitState is the snapshot state which should be used to initialize
@@ -117,6 +118,10 @@ type ClusterListener interface {
 	// QuorumMember returns true if the listener wants this node to
 	// participate in quorum decisions.
 	QuorumMember(node *api.Node) bool
+
+	// UpdateClusterInfo is called when there is an update to the cluster.
+	UpdateCluster(self *api.Node, clusterInfo *ClusterInfo) error
+
 }
 
 // ClusterState is the gossip state of all nodes in the cluster
@@ -143,6 +148,8 @@ type ClusterData interface {
 
 	// GetGossipState returns the state of nodes according to gossip
 	GetGossipState() *ClusterState
+
+	SetLoggingURL(loggingURL string) error
 }
 
 // ClusterStatus interface provides apis for cluster and node status

--- a/cluster/database.go
+++ b/cluster/database.go
@@ -69,8 +69,8 @@ func readClusterInfo() (ClusterInfo, uint64, error) {
 		Status:      api.Status_STATUS_INIT,
 		NodeEntries: make(map[string]NodeEntry),
 	}
-
 	kv, err := kvdb.Get(ClusterDBKey)
+
 	if err != nil && !strings.Contains(err.Error(), "Key not found") {
 		dlog.Warnln("Warning, could not read cluster database")
 		return db, 0, err

--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,7 @@ type ClusterConfig struct {
 	DefaultDriver string
 	MgmtIp        string
 	DataIp        string
+	LoggingURL    string
 }
 
 type Config struct {

--- a/volume/drivers/buse/buse.go
+++ b/volume/drivers/buse/buse.go
@@ -400,3 +400,7 @@ func (d *driver) Leave(self *api.Node) error {
 func (d *driver) Halt(self *api.Node, db *cluster.ClusterInfo) error {
 	return nil
 }
+
+func (d *driver) UpdateCluster(self *api.Node, db *cluster.ClusterInfo) error {
+	return nil
+}


### PR DESCRIPTION
1.Added support for api server to accept a put request to update the logging url and enumerate to get the values.
 curl -s  -X PUT "http://localhost:9001/v1/cluster/loggingurl?url=harbor.lighthouse.test.com"
curl -s  -X GET -H "Content-type: application/json"  "http://127.0.0.1:9001/v1/cluster/enumerate" | python -m json.tool

Changes are orchestrated via kvdb updates to all nodes. Changes are persisted in the clusterinfo of kvdb.