### PR TITLE
travis: Coveralls.io support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,14 @@ go:
 before_install:  
   - sudo apt-get update -yq
   - sudo apt-get -o Dpkg::Options::="--force-confnew" install -yq docker-ce
+install:
+  - go get github.com/mattn/goveralls
 script:
   - go fmt $(go list ./... | grep -v vendor) | wc -l | grep 0
   - make vet
   - make docker-test
+  - make docker-coverage
+  - goveralls -coverprofile=/mnt/coverage.out -service=travis-ci -repotoken "${COVERALLS_TOKEN}"
   - if [ "${TRAVIS_BRANCH}" == "master" ] && [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
       make docker-build-osd;
       docker login -u "${DOCKER_USER}" -p "${DOCKER_PASS}";

--- a/Makefile
+++ b/Makefile
@@ -193,26 +193,16 @@ clean:
 $(GOPATH)/bin/cover:
 	go get golang.org/x/tools/cmd/cover
 
-$(GOPATH)/bin/gocovmerge:
-	go get github.com/wadey/gocovmerge
+$(GOPATH)/bin/gotestcover:
+	go get github.com/pierrre/gotestcover
 
 # Generate test-coverage HTML report
 # - note: the 'go test -coverprofile...' does append results, so we're merging individual pkgs in for-loop
-coverage: $(GOPATH)/bin/cover $(GOPATH)/bin/gocovmerge
-	rm -f coverage.* c.tmp co.tmp
-	for p in $(PKGS) ; do   \
-	    go test -coverprofile=c.tmp -tags "$(TAGS)" $(TESTFLAGS) $$p ; \
-	    if [ -f c.tmp ]; then \
-	        if [ -s coverage.out ]; then \
-	            mv coverage.out co.tmp ; \
-	            $(GOPATH)/bin/gocovmerge co.tmp c.tmp >> coverage.out ; \
-	            rm -f co.tmp c.tmp ; \
-	        else \
-	            mv c.tmp coverage.out ; \
-	        fi ; \
-	    fi ; \
-	done
+coverage: $(GOPATH)/bin/cover $(GOPATH)/bin/gotestcover
+	gotestcover -coverprofile=coverage.out $(shell go list ./... | grep -v vendor)
 	go tool cover -html=coverage.out -o coverage.html
+	@echo "INFO: Summary of coverage"
+	go tool cover -func=coverage.out
 	@cp coverage.out coverage.html /mnt/ && \
 	echo "INFO: libopenstorage coverage saved at /mnt/coverage.{html,out}"
 


### PR DESCRIPTION
Change the to a tool which provides test coverage results
for all packages and outputs a single file. Now we can display
this file in the logs of Travis. In a future enhancement we will
add support for coveralls.io.

Signed-off-by: Luis Pabón <luis@portworx.com>