### PR TITLE
PWX-4196: Adding /nodehealth REST call

### DIFF
--- a/api/server/cluster.go
+++ b/api/server/cluster.go
@@ -14,6 +14,11 @@ import (
 	"github.com/libopenstorage/openstorage/cluster"
 )
 
+const (
+	nodeOkMsg    = "Node status OK"
+	nodeNotOkMsg = "Node status not OK"
+)
+
 type clusterApi struct {
 	restBase
 }
@@ -333,12 +338,12 @@ func (c *clusterApi) nodeHealth(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if st != api.Status_STATUS_OK {
-		err = fmt.Errorf("Node status not OK (%s)", api.Status_name[int32(st)])
+		err = fmt.Errorf("%s (%s)", nodeNotOkMsg, api.Status_name[int32(st)])
 		c.sendError(c.name, method, w, err.Error(), http.StatusServiceUnavailable)
 		return
 	}
 
-	w.Write([]byte("Node status OK\n"))
+	w.Write([]byte(nodeOkMsg + "\n"))
 }
 
 func (c *clusterApi) peerStatus(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Adding new REST call /nodehealth to report node health status.  Returned status
is similar to /nodestatus, except that it returns '200 OK' only when the node
is OK and ready to serve storage externally.

Ie [HTTP code // body]:
> 503 Service Unavailable // Node status not OK (STATUS_NOT_IN_QUORUM)
> 503 Service Unavailable // Node status not OK (STATUS_INIT)
> 503 Service Unavailable // Node status not OK (STATUS_MAINTENANCE)
> 200 OK // Node status OK