### PR TITLE
AWS Driver: Do not error out when the block device name is in the "/dev/xvd[b-c][a-z]" format.

### DIFF
--- a/volume/drivers/aws/aws_storage.go
+++ b/volume/drivers/aws/aws_storage.go
@@ -271,8 +271,8 @@ func (s *ec2Ops) DeviceMappings() (map[string]string, error) {
 		if d.DeviceName != nil && d.Ebs != nil && d.Ebs.VolumeId != nil {
 			devName := *d.DeviceName
 			// Per AWS docs EC instances have the root mounted at
-			// /dev/sda1, this label should be skipped
-			if devName == "/dev/sda1" {
+			// /dev/sda1, /dev/xvda this label should be skipped
+			if devName == "/dev/sda1" || devName == "/dev/xvda" {
 				continue
 			}
 			// AWS EBS volumes get mapped from /dev/sdN -->/dev/xvdN
@@ -306,22 +306,18 @@ func (s *ec2Ops) describe() (*ec2.Instance, error) {
 }
 
 // freeDevices returns list of available device IDs.
-func (s *ec2Ops) freeDevices() ([]string, error) {
+func freeDevices(blockDeviceMappings []*ec2.InstanceBlockDeviceMapping) ([]string, error) {
 	initial := []byte("fghijklmnop")
-	self, err := s.describe()
-	if err != nil {
-		return nil, err
-	}
 	devPrefix := "/dev/sd"
-	for _, dev := range self.BlockDeviceMappings {
+	for _, dev := range blockDeviceMappings {
 		if dev.DeviceName == nil {
 			return nil, fmt.Errorf("Nil device name")
 		}
 		devName := *dev.DeviceName
 
 		// per AWS docs EC instances have the root mounted at /dev/sda1,
-		// this label should be skipped
-		if devName == "/dev/sda1" {
+		// OR /dev/xvda, this label should be skipped
+		if devName == "/dev/sda1" || devName == "/dev/xvda" {
 			continue
 		}
 		if !strings.HasPrefix(devName, devPrefix) {
@@ -331,18 +327,23 @@ func (s *ec2Ops) freeDevices() ([]string, error) {
 			}
 		}
 		letter := devName[len(devPrefix):]
-		if len(letter) != 1 {
-			return nil, fmt.Errorf("too many letters %q", devName)
-		}
-
 		// Reset devPrefix for next devices
 		devPrefix = "/dev/sd"
 
-		index := letter[0] - 'f'
-		if index > ('p' - 'f') {
+		// AWS instances can have the following device names
+		// /dev/xvd[b-c][a-z]
+		if len(letter) == 1 {
+			index := letter[0] - 'f'
+			if index > ('p' - 'f') {
+				continue
+			}
+			initial[index] = '0'
+		} else if len(letter) == 2 {
+			// We do not attach EBS volumes with "/dev/xvdc[a-z]" formats
 			continue
+		} else {
+			return nil, fmt.Errorf("cannot parse device name %q", devName)
 		}
-		initial[index] = '0'
 	}
 	free := make([]string, len(initial))
 	count := 0
@@ -480,7 +481,12 @@ func (s *ec2Ops) Attach(volumeID string) (string, error) {
 	s.mutex.Lock()
 	defer s.mutex.Unlock()
 
-	devices, err := s.freeDevices()
+	self, err := s.describe()
+	if err != nil {
+		return "", err
+	}
+
+	devices, err := freeDevices(self.BlockDeviceMappings)
 	if err != nil {
 		return "", err
 	}

--- a/volume/drivers/aws/aws_test.go
+++ b/volume/drivers/aws/aws_test.go
@@ -36,7 +36,7 @@ func testRemoveTags(t *testing.T, driver volume.VolumeDriver) {
 }
 
 func testFreeDevices(t *testing.T) {
-	deviceNames := []string{"/dev/sda1", "/dev/sdb", "/dev/xvda", "/dev/xvdf", "/dev/xvdg", "/dev/xvdcg"}
+	deviceNames := []string{"/dev/sda1", "/dev/sdb", "/dev/xvdf", "/dev/xvdg", "/dev/xvdcg"}
 	blockDeviceMappings := []*ec2.InstanceBlockDeviceMapping{}
 	for i, _ := range deviceNames {
 		b := &ec2.InstanceBlockDeviceMapping{
@@ -44,7 +44,7 @@ func testFreeDevices(t *testing.T) {
 		}
 		blockDeviceMappings = append(blockDeviceMappings, b)
 	}
-	freeDeviceNames, err := freeDevices(blockDeviceMappings)
+	freeDeviceNames, err := freeDevices(blockDeviceMappings, "/dev/sda1")
 	require.NoError(t, err, "Expected no error")
 	// Free devices : h -> p
 	require.Equal(t, len(freeDeviceNames), 9, "No. of free devices do not match")
@@ -54,7 +54,7 @@ func testFreeDevices(t *testing.T) {
 	}
 
 	blockDeviceMappings = append(blockDeviceMappings, b)
-	freeDeviceNames, err = freeDevices(blockDeviceMappings)
+	freeDeviceNames, err = freeDevices(blockDeviceMappings, "/dev/sda1")
 	require.Error(t, err, "Expected an error")
 }
 


### PR DESCRIPTION
- Previously we were able to parse devices only in "/dev/xvd[f-p]" format and unnecessarily error out for devices like /dev/xvdcg