### PR TITLE
csi: Support for two NodeXXX functions

### DIFF
--- a/csi/node.go
+++ b/csi/node.go
@@ -204,6 +204,54 @@ func (s *OsdCsiServer) NodeUnpublishVolume(
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }
 
+// NodeProbe is a CSI API function which asks the driver to check if the
+// node has all the necessary components to run successfully.
+func (s *OsdCsiServer) NodeProbe(
+	ctx context.Context,
+	req *csi.NodeProbeRequest,
+) (*csi.NodeProbeResponse, error) {
+
+	dlog.Debugf("NodeProbe req[%#v]", req)
+
+	// Check arguments
+	if req.GetVersion() == nil {
+		return nil, status.Error(codes.InvalidArgument, "Version must be provided")
+	}
+
+	// TBD(lpabon) Here we can add support
+	// to scan th system in a future patch.
+
+	// For now return 'ok'.
+	return &csi.NodeProbeResponse{}, nil
+}
+
+// NodeGetCapabilities is a CSI API function which seems to be setup for
+// future patches
+func (s *OsdCsiServer) NodeGetCapabilities(
+	ctx context.Context,
+	req *csi.NodeGetCapabilitiesRequest,
+) (*csi.NodeGetCapabilitiesResponse, error) {
+
+	dlog.Debugf("NodeGetCapabilities req[%#v]", req)
+
+	// Check arguments
+	if req.GetVersion() == nil {
+		return nil, status.Error(codes.InvalidArgument, "Version must be provided")
+	}
+
+	return &csi.NodeGetCapabilitiesResponse{
+		Capabilities: []*csi.NodeServiceCapability{
+			{
+				Type: &csi.NodeServiceCapability_Rpc{
+					Rpc: &csi.NodeServiceCapability_RPC{
+						Type: csi.NodeServiceCapability_RPC_UNKNOWN,
+					},
+				},
+			},
+		},
+	}, nil
+}
+
 func verifyTargetLocation(targetPath string) error {
 	fileInfo, err := os.Stat(targetPath)
 	if err != nil && os.IsNotExist(err) {
@@ -220,12 +268,3 @@ func verifyTargetLocation(targetPath string) error {
 
 	return nil
 }
-
-/*
-type NodeServer interface {
-	NodePublishVolume(context.Context, *NodePublishVolumeRequest) (*NodePublishVolumeResponse, error)
-	NodeUnpublishVolume(context.Context, *NodeUnpublishVolumeRequest) (*NodeUnpublishVolumeResponse, error)
-	NodeProbe(context.Context, *NodeProbeRequest) (*NodeProbeResponse, error)
-	NodeGetCapabilities(context.Context, *NodeGetCapabilitiesRequest) (*NodeGetCapabilitiesResponse, error)
-}
-*/

--- a/csi/node_test.go
+++ b/csi/node_test.go
@@ -739,3 +739,52 @@ func TestNodeUnpublishVolumeUnmount(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, r)
 }
+
+func TestNodeProbe(t *testing.T) {
+	// Create server and client connection
+	s := newTestServer(t)
+	defer s.Stop()
+
+	// Make a call
+	c := csi.NewNodeClient(s.Conn())
+
+	// No version
+	_, err := c.NodeProbe(context.Background(), &csi.NodeProbeRequest{})
+	assert.Error(t, err)
+
+	// Get Capabilities
+	_, err = c.NodeProbe(
+		context.Background(),
+		&csi.NodeProbeRequest{
+			Version: &csi.Version{},
+		})
+	assert.NoError(t, err)
+}
+
+func TestNodeGetCapabilities(t *testing.T) {
+	// Create server and client connection
+	s := newTestServer(t)
+	defer s.Stop()
+
+	// Make a call
+	c := csi.NewNodeClient(s.Conn())
+
+	// No version
+	_, err := c.NodeGetCapabilities(
+		context.Background(),
+		&csi.NodeGetCapabilitiesRequest{})
+	assert.Error(t, err)
+
+	// Get Capabilities
+	r, err := c.NodeGetCapabilities(
+		context.Background(),
+		&csi.NodeGetCapabilitiesRequest{
+			Version: &csi.Version{},
+		})
+	assert.NoError(t, err)
+	assert.Len(t, r.GetCapabilities(), 1)
+	assert.Equal(
+		t,
+		csi.NodeServiceCapability_RPC_UNKNOWN,
+		r.GetCapabilities()[0].GetRpc().GetType())
+}


### PR DESCRIPTION
This adds support for NodeProbe and NodeGetCapabilities.

Closes #239
Closes #240