### PR TITLE
Support for bind mount of fuse mounts.

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -8,10 +8,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/libopenstorage/openstorage/pkg/keylock"
-	"github.com/libopenstorage/openstorage/pkg/options"
-	"github.com/libopenstorage/openstorage/pkg/sched"
-	"go.pedge.io/dlog"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -20,6 +16,11 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/libopenstorage/openstorage/pkg/keylock"
+	"github.com/libopenstorage/openstorage/pkg/options"
+	"github.com/libopenstorage/openstorage/pkg/sched"
+	"go.pedge.io/dlog"
 )
 
 // Manager defines the interface for keep track of volume driver mounts.
@@ -328,8 +329,11 @@ func (m *Mounter) Mount(
 	timeout int,
 	opts map[string]string,
 ) error {
+	// device gets overwritten if opts specifies fuse mount with
+	// options.OptionsDeviceFuseMount.
 	device := devPath
 	if value, ok := opts[options.OptionsDeviceFuseMount]; ok {
+		// fuse mounts show-up with this key as device.
 		device = value
 	}
 
@@ -418,9 +422,12 @@ func (m *Mounter) Unmount(
 	opts map[string]string,
 ) error {
 	m.Lock()
+	// device gets overwritten if opts specifies fuse mount with
+	// options.OptionsDeviceFuseMount.
 	device := devPath
 	path = normalizeMountPath(path)
 	if value, ok := opts[options.OptionsDeviceFuseMount]; ok {
+		// fuse mounts show-up with this key as device.
 		device = value
 	}
 	info, ok := m.mounts[device]

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -17,6 +17,8 @@ const (
 	OptionsWaitBeforeDelete = "WAIT_BEFORE_DELETE"
 	// OptionsRedirectDetach Redirect detach to the node where volume is attached
 	OptionsRedirectDetach = "REDIRECT_DETACH"
+	// OptionsDeviceFuseMount name of fuse mount device
+	OptionsDeviceFuseMount = "DEV_FUSE_MOUNT"
 )
 
 func IsBoolOptionSet(options map[string]string, key string) bool {


### PR DESCRIPTION
Bind mount of fuse mounts show up with fuse name  as device rather than device path being bind mounted. Added mechanism to pass in device name for fuse mounts. 

To elaborate, Mount function is passed with a device parameter and a path to mount the device with. In case of bind mount, both device and mount path are simply paths. After the bind mount, both of them will show with filesystem/device  that is on source path.  So mounter needs to track the mounts with this filesystem "string" passed in the options for bind mounts to reflect the correct mount status.