### PR TITLE
Add a new utility package for setting/unsetting chattr attributes on a given path.

### DIFF
--- a/pkg/chattr/chattr.go
+++ b/pkg/chattr/chattr.go
@@ -1,0 +1,87 @@
+package chattr
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	"go.pedge.io/dlog"
+)
+
+const (
+	chattrCmd = "chattr"
+	lsattrCmd = "lsattr"
+)
+
+func AddImmutable(path string) error {
+	chattrBin := which(chattrCmd)
+	if _, err := os.Stat(path); err == nil {
+		cmd := exec.Command(chattrBin, "+i", path)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+
+		if err = cmd.Run(); err != nil {
+			return fmt.Errorf("%s +i failed: %s. Err: %v", chattrBin, stderr.String(), err)
+		}
+	}
+
+	return nil
+}
+
+func RemoveImmutable(path string) error {
+	chattrBin := which(chattrCmd)
+	if _, err := os.Stat(path); err == nil {
+		cmd := exec.Command(chattrBin, "-i", path)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+
+		if err = cmd.Run(); err != nil {
+			return fmt.Errorf("%s -i failed: %s. Err: %v", chattrBin, stderr.String(), err)
+		}
+	}
+
+	return nil
+}
+
+func IsImmutable(path string) bool {
+	lsattrBin := which(lsattrCmd)
+	if _, err := os.Stat(path); err != nil {
+		dlog.Errorf("Failed to stat mount path:%v", err)
+		return true
+	}
+	op, err := exec.Command(lsattrBin, "-d", path).CombinedOutput()
+	if err != nil {
+		// Cannot get path status, return true so that immutable bit is not reverted
+		dlog.Errorf("Error listing attrs for %v err:%v", path, string(op))
+		return true
+	}
+	// 'lsattr -d' output is a single line with 2 fields separated by space; 1st one
+	// is list of applicable attrs and 2nd field is the path itself.Sample output below.
+	// lsattr -d /mnt/vol2
+	// ----i--------e-- /mnt/vol2
+	attrs := strings.Split(string(op), " ")
+	if len(attrs) != 2 {
+		// Cannot get path status, return true so that immutable bit is not reverted
+		dlog.Errorf("Invalid lsattr output %v", string(op))
+		return true
+	}
+	if strings.Contains(attrs[0], "i") {
+		dlog.Warnf("Path %v already set to immutable", path)
+		return true
+	}
+
+	return false
+}
+
+func which(bin string) string {
+	pathList := []string{"/usr/bin", "/sbin", "/usr/sbin", "/usr/local/bin"}
+	for _, p := range pathList {
+		if _, err := os.Stat(path.Join(p, bin)); err == nil {
+			return path.Join(p, bin)
+		}
+	}
+	return bin
+}

--- a/pkg/chattr/chattr_test.go
+++ b/pkg/chattr/chattr_test.go
@@ -1,0 +1,52 @@
+package chattr
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testFile = "/tmp/osd-test"
+)
+
+func TestImmutable(t *testing.T) {
+	// create a test file
+	_, err := os.Create(testFile)
+	require.NoError(t, err, "Unexpected error on create test file")
+
+	// chattr +i
+	err = AddImmutable(testFile)
+	require.NoError(t, err, "Unexpected error on AddImmutable")
+
+	// check if +i is added on the file
+	isImmutable := IsImmutable(testFile)
+	require.True(t, isImmutable, "Unexpected: Path is not immutable")
+
+	// remove should fail
+	err = os.RemoveAll(testFile)
+	require.Error(t, err, "Expected an error on remove")
+
+	// check if file still exists
+	_, err = os.Stat(testFile)
+	require.NoError(t, err, "Expected the file to be present")
+
+	// chattr -i
+	err = RemoveImmutable(testFile)
+	require.NoError(t, err, "Unexpected error on RemoveImmutable")
+
+	// check if +i is removed on the file
+	isImmutable = IsImmutable(testFile)
+	require.False(t, isImmutable, "Unexpected: Path is not mutable")
+
+	// remove should succeed
+	err = os.RemoveAll(testFile)
+	require.NoError(t, err, "Unexpected an error on remove")
+
+	// check if file still exists
+	_, err = os.Stat(testFile)
+	require.Error(t, err, "Expected the file to be removed")
+	require.True(t, os.IsNotExist(err), "Unexpected error on remove")
+
+}

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -3,20 +3,19 @@
 package mount
 
 import (
-	"bytes"
 	"crypto/md5"
 	"encoding/hex"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path"
 	"strings"
 	"sync"
 	"syscall"
 	"time"
 
+	"github.com/libopenstorage/openstorage/pkg/chattr"
 	"github.com/libopenstorage/openstorage/pkg/keylock"
 	"github.com/libopenstorage/openstorage/pkg/options"
 	"github.com/libopenstorage/openstorage/pkg/sched"
@@ -87,8 +86,6 @@ const (
 )
 
 const mountPathRemoveDelay = 30 * time.Second
-const chattrBin = "/usr/bin/chattr"
-const lsattrBin = "/usr/bin/lsattr"
 
 var (
 	// ErrExist is returned if path is already mounted to a different device.
@@ -577,62 +574,17 @@ func (m *Mounter) removeSoftlinkAndTarget(link string) error {
 // isPathSetImmutable returns true on error in getting path info or if path
 // is immutable .
 func (m *Mounter) isPathSetImmutable(mountpath string) bool {
-	if _, err := os.Stat(mountpath); err != nil {
-		dlog.Errorf("Failed to stat mount path:%v", err)
-		return true
-	}
-	op, err := exec.Command(lsattrBin, "-d", mountpath).CombinedOutput()
-	if err != nil {
-		// Cannot get path status, return true so that immutable bit is not reverted
-		dlog.Errorf("Error listing attrs for %v err:%v", mountpath, string(op))
-		return true
-	}
-	// 'lsattr -d' output is a single line with 2 fields separated by space; 1st one
-	// is list of applicable attrs and 2nd field is the path itself.Sample output below.
-	// lsattr -d /mnt/vol2
-	// ----i--------e-- /mnt/vol2
-	attrs := strings.Split(string(op), " ")
-	if len(attrs) != 2 {
-		// Cannot get path status, return true so that immutable bit is not reverted
-		dlog.Errorf("Invalid lsattr output %v", string(op))
-		return true
-	}
-	if strings.Contains(attrs[0], "i") {
-		dlog.Warnf("Mount path %v already set to immutable", mountpath)
-		return true
-	}
-
-	return false
+	return chattr.IsImmutable(mountpath)
 }
 
 // makeMountpathReadOnly makes given mountpath read-only
 func (m *Mounter) makeMountpathReadOnly(mountpath string) error {
-	if _, err := os.Stat(mountpath); err == nil {
-		cmd := exec.Command(chattrBin, "+i", mountpath)
-		var stderr bytes.Buffer
-		cmd.Stderr = &stderr
-
-		if err = cmd.Run(); err != nil {
-			return fmt.Errorf("%s +i failed: %s. Err: %v", chattrBin, stderr.String(), err)
-		}
-	}
-
-	return nil
+	return chattr.AddImmutable(mountpath)
 }
 
 // makeMountpathWriteable makes given mountpath writeable
 func (m *Mounter) makeMountpathWriteable(mountpath string) error {
-	if _, err := os.Stat(mountpath); err == nil {
-		cmd := exec.Command(chattrBin, "-i", mountpath)
-		var stderr bytes.Buffer
-		cmd.Stderr = &stderr
-
-		if err = cmd.Run(); err != nil {
-			return fmt.Errorf("%s -i failed: %s. Err: %v", chattrBin, stderr.String(), err)
-		}
-	}
-
-	return nil
+	return chattr.RemoveImmutable(mountpath)
 }
 
 // New returns a new Mount Manager


### PR DESCRIPTION
**What this PR does / why we need it**:

We already had chattr utility being used in the mounter package. Moving the logic to its own package so that other components can also use it.

- Adds following three APIs
  - Add +i flag on a path (AddImmutable)
  - Remove +i flag on a path (RemoveImmutable)
  - Checks if +i flag is set on a path (IsImmutable)
- Adds a unit test.

Signed-off-by: Aditya Dani <aditya@portworx.com>

