### PR TITLE
Add IoProfile to spec handler regex

### DIFF
--- a/api/spec/spec_handler.go
+++ b/api/spec/spec_handler.go
@@ -100,6 +100,7 @@ var (
 	compressedRegex   = regexp.MustCompile(api.SpecCompressed + "=([A-Za-z]+),?")
 	snapScheduleRegex = regexp.MustCompile(api.SpecSnapshotSchedule +
 		`=([A-Za-z0-9:;@=#]+),?`)
+	ioProfileRegex = regexp.MustCompile(api.SpecIoProfile + "=([0-9A-Za-z_-]+),?")
 )
 
 type specHandler struct {
@@ -397,6 +398,9 @@ func (d *specHandler) SpecOptsFromString(
 	if ok, sched := d.getVal(snapScheduleRegex, str); ok {
 		opts[api.SpecSnapshotSchedule] = strings.Replace(sched, "#", ",", -1)
 	}
+	if ok, ioProfile := d.getVal(ioProfileRegex, str); ok {
+		opts[api.SpecIoProfile] = ioProfile
+	}
 
 	return true, opts, name
 }
@@ -408,7 +412,6 @@ func (d *specHandler) SpecFromString(
 	if !ok {
 		return false, d.DefaultSpec(), nil, nil, name
 	}
-
 	spec, locator, source, err := d.SpecFromOpts(opts)
 	if err != nil {
 		return false, d.DefaultSpec(), nil, nil, name

--- a/api/spec/spec_handler_test.go
+++ b/api/spec/spec_handler_test.go
@@ -24,6 +24,12 @@ func testSpecFromString(t *testing.T, opt string, val string) *api.VolumeSpec {
 	return spec
 }
 
+func testSpecFromStringErr(t *testing.T, opt string, errVal string) {
+	s := NewSpecHandler()
+	parsed, _, _, _, _ := s.SpecFromString(fmt.Sprintf("name=volname,foo=bar,%s=%s", opt, errVal))
+	require.False(t, parsed, "Failed to parse spec string")
+}
+
 func TestOptJournal(t *testing.T) {
 	testSpecOptString(t, api.SpecJournal, "true")
 
@@ -35,4 +41,16 @@ func TestOptJournal(t *testing.T) {
 
 	spec = testSpecFromString(t, api.SpecSize, "100")
 	require.False(t, spec.Journal, "Default journal option spec")
+}
+
+func TestOptIoProfile(t *testing.T) {
+	testSpecOptString(t, api.SpecIoProfile, "DB")
+
+	spec := testSpecFromString(t, api.SpecIoProfile, "DB")
+	require.Equal(t, spec.IoProfile, api.IoProfile(2), "Unexpected io_profile value")
+
+	spec = testSpecFromString(t, api.SpecIoProfile, "db")
+	require.Equal(t, spec.IoProfile, api.IoProfile(2), "Unexpected io_profile value")
+
+	testSpecFromStringErr(t, api.SpecIoProfile, "2")
 }


### PR DESCRIPTION
Signed-off-by: Aditya Dani <aditya@portworx.com>

**What this PR does / why we need it**:
- Adds io_profile param parsing in common spec_handler. This enables specifying io_profile as inline spec for docker volume creation.