### PR TITLE
CSI Sanity tests and fixes

### DIFF
--- a/csi/csisanity_test.go
+++ b/csi/csisanity_test.go
@@ -1,0 +1,97 @@
+// +build daemon
+
+/*
+CSI Interface for OSD
+Copyright 2017 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package csi
+
+import (
+	"os"
+	"testing"
+
+	"github.com/libopenstorage/openstorage/cluster"
+	"github.com/libopenstorage/openstorage/config"
+	"github.com/libopenstorage/openstorage/volume"
+	"github.com/libopenstorage/openstorage/volume/drivers"
+
+	"github.com/kubernetes-csi/csi-test/pkg/sanity"
+	"go.pedge.io/dlog"
+
+	"github.com/portworx/kvdb"
+	"github.com/portworx/kvdb/mem"
+)
+
+const (
+	testPath = "/tmp/openstorage_driver_test"
+)
+
+var (
+	testEnumerator volume.StoreEnumerator
+	testLabels     = map[string]string{"Foo": "DEADBEEF"}
+)
+
+func TestCSISanity(t *testing.T) {
+
+	kv, err := kvdb.New(mem.Name, "driver_test", []string{}, nil, dlog.Panicf)
+	if err != nil {
+		t.Fatalf("Failed to initialize KVDB")
+	}
+	if err := kvdb.SetInstance(kv); err != nil {
+		t.Fatalf("Failed to set KVDB instance")
+	}
+
+	err = os.MkdirAll(testPath, 0744)
+	if err != nil {
+		t.Fatalf("Failed to create test path: %v", err)
+	}
+
+	if err := volumedrivers.Register("nfs", map[string]string{"path": testPath}); err != nil {
+		t.Fatalf("Unable to start volume driver nfs")
+	}
+
+	// Initialize the cluster
+	if err := cluster.Init(config.ClusterConfig{
+		ClusterId:     "cluster",
+		NodeId:        "node1",
+		DefaultDriver: "nfs",
+	}); err != nil {
+		t.Fatalf("Unable to init cluster server: %v", err)
+	}
+
+	cm, err := cluster.Inst()
+	if err != nil {
+		t.Fatalf("Unable to find cluster instance: %v", err)
+	}
+	go func() {
+		cm.Start(0, false)
+	}()
+
+	// Start CSI Server
+	server, err := NewOsdCsiServer(&OsdCsiServerConfig{
+		DriverName: "nfs",
+		Net:        "tcp",
+		Address:    "127.0.0.1:0",
+		Cluster:    cm,
+	})
+	if err != nil {
+		t.Fatalf("Unable to start csi server: %v", err)
+	}
+	server.Start()
+	defer server.Stop()
+
+	// Start CSI Sanity test
+	sanity.Test(t, server.Address(), "/mnt/openstorage/mount/nfs")
+}

--- a/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/README.md
+++ b/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/README.md
@@ -1,0 +1,25 @@
+# CSI Driver Sanity Tester
+
+This library provides a simple way to ensure that a CSI driver conforms to
+the CSI specification. There are two ways to leverage this testing framework.
+For CSI drivers written in Golang, the framework provides a simple API function
+to call to test the driver. Another way to run the test suite is to use the
+command line program [csi-sanity](https://github.com/kubernetes-csi/csi-test/tree/master/cmd/csi-sanity).
+
+## For Golang CSI Drivers
+This framework leverages the Ginkgo BDD testing framework to deliver a descriptive
+test suite for your driver. To test your driver, simply call the API in one of your
+Golang `TestXXX` functions. For example:
+
+```go
+func TestMyDriver(t *testing.T) {
+    // Setup the full driver and its environment
+    ... setup driver ...
+
+    // Now call the test suite
+    sanity.Test(t, driverEndpointAddress)
+}
+```
+
+## Command line program
+Please see [csi-sanity](https://github.com/kubernetes-csi/csi-test/tree/master/cmd/csi-sanity)

--- a/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/controller.go
+++ b/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/controller.go
@@ -1,0 +1,794 @@
+/*
+Copyright 2017 Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sanity
+
+import (
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	context "golang.org/x/net/context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func verifyVolumeInfo(v *csi.VolumeInfo) {
+	Expect(v).NotTo(BeNil())
+	Expect(v.GetId()).NotTo(BeEmpty())
+}
+
+func isCapabilitySupported(
+	c csi.ControllerClient,
+	capType csi.ControllerServiceCapability_RPC_Type,
+) bool {
+
+	caps, err := c.ControllerGetCapabilities(
+		context.Background(),
+		&csi.ControllerGetCapabilitiesRequest{
+			Version: csiClientVersion,
+		})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(caps).NotTo(BeNil())
+	Expect(caps.GetCapabilities()).NotTo(BeNil())
+
+	for _, cap := range caps.GetCapabilities() {
+		Expect(cap.GetRpc()).NotTo(BeNil())
+		if cap.GetRpc().GetType() == capType {
+			return true
+		}
+	}
+	return false
+}
+
+var _ = Describe("ControllerGetCapabilities [Controller Server]", func() {
+	var (
+		c csi.ControllerClient
+	)
+
+	BeforeEach(func() {
+		c = csi.NewControllerClient(conn)
+	})
+
+	It("should fail when no version is provided", func() {
+		_, err := c.ControllerGetCapabilities(
+			context.Background(),
+			&csi.ControllerGetCapabilitiesRequest{})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should return appropriate capabilities", func() {
+		caps, err := c.ControllerGetCapabilities(
+			context.Background(),
+			&csi.ControllerGetCapabilitiesRequest{
+				Version: csiClientVersion,
+			})
+
+		By("checking successful response")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(caps).NotTo(BeNil())
+		Expect(caps.GetCapabilities()).NotTo(BeNil())
+
+		for _, cap := range caps.GetCapabilities() {
+			Expect(cap.GetRpc()).NotTo(BeNil())
+
+			switch cap.GetRpc().GetType() {
+			case csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME:
+			case csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME:
+			case csi.ControllerServiceCapability_RPC_LIST_VOLUMES:
+			case csi.ControllerServiceCapability_RPC_GET_CAPACITY:
+			default:
+				Fail(fmt.Sprintf("Unknown capability: %v\n", cap.GetRpc().GetType()))
+			}
+		}
+	})
+})
+
+var _ = Describe("GetCapacity [Controller Server]", func() {
+	var (
+		c csi.ControllerClient
+	)
+
+	BeforeEach(func() {
+		c = csi.NewControllerClient(conn)
+
+		if !isCapabilitySupported(c, csi.ControllerServiceCapability_RPC_GET_CAPACITY) {
+			Skip("GetCapacity not supported")
+		}
+	})
+
+	It("should fail when no version is provided", func() {
+
+		By("failing when there is no version")
+		_, err := c.GetCapacity(
+			context.Background(),
+			&csi.GetCapacityRequest{})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should return capacity (no optional values added)", func() {
+		_, err := c.GetCapacity(
+			context.Background(),
+			&csi.GetCapacityRequest{
+				Version: csiClientVersion,
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Since capacity is uint64 we will not be checking it
+		// The value of zero is a possible value.
+	})
+})
+
+var _ = Describe("ListVolumes [Controller Server]", func() {
+	var (
+		c csi.ControllerClient
+	)
+
+	BeforeEach(func() {
+		c = csi.NewControllerClient(conn)
+
+		if !isCapabilitySupported(c, csi.ControllerServiceCapability_RPC_LIST_VOLUMES) {
+			Skip("ListVolumes not supported")
+		}
+	})
+
+	It("should fail when no version is provided", func() {
+
+		By("failing when there is no version")
+		_, err := c.ListVolumes(
+			context.Background(),
+			&csi.ListVolumesRequest{})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should return appropriate values (no optional values added)", func() {
+		vols, err := c.ListVolumes(
+			context.Background(),
+			&csi.ListVolumesRequest{
+				Version: csiClientVersion,
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(vols).NotTo(BeNil())
+
+		for _, vol := range vols.GetEntries() {
+			verifyVolumeInfo(vol.GetVolumeInfo())
+		}
+	})
+
+	// TODO: Add test to test for tokens
+
+	// TODO: Add test which checks list of volume is there when created,
+	//       and not there when deleted.
+})
+
+var _ = Describe("CreateVolume [Controller Server]", func() {
+	var (
+		c csi.ControllerClient
+	)
+
+	BeforeEach(func() {
+		c = csi.NewControllerClient(conn)
+
+		if !isCapabilitySupported(c, csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME) {
+			Skip("CreateVolume not supported")
+		}
+	})
+
+	It("should fail when no version is provided", func() {
+
+		_, err := c.CreateVolume(
+			context.Background(),
+			&csi.CreateVolumeRequest{})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should fail when no name is provided", func() {
+
+		_, err := c.CreateVolume(
+			context.Background(),
+			&csi.CreateVolumeRequest{
+				Version: csiClientVersion,
+			})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should fail when no volume capabilities are provided", func() {
+
+		_, err := c.CreateVolume(
+			context.Background(),
+			&csi.CreateVolumeRequest{
+				Version: csiClientVersion,
+				Name:    "name",
+			})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should return appropriate values SingleNodeWriter NoCapacity Type:Mount", func() {
+
+		By("creating a volume")
+		name := "sanity"
+		vol, err := c.CreateVolume(
+			context.Background(),
+			&csi.CreateVolumeRequest{
+				Version: csiClientVersion,
+				Name:    name,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					&csi.VolumeCapability{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+					},
+				},
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(vol).NotTo(BeNil())
+		Expect(vol.GetVolumeInfo()).NotTo(BeNil())
+		Expect(vol.GetVolumeInfo().GetId()).NotTo(BeEmpty())
+
+		By("cleaning up deleting the volume")
+		_, err = c.DeleteVolume(
+			context.Background(),
+			&csi.DeleteVolumeRequest{
+				Version:  csiClientVersion,
+				VolumeId: vol.GetVolumeInfo().GetId(),
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	// Pending fix in mock file
+	It("should return appropriate values SingleNodeWriter WithCapacity 1Gi Type:Mount", func() {
+
+		By("creating a volume")
+		name := "sanity"
+		size := uint64(1 * 1024 * 1024 * 1024)
+		vol, err := c.CreateVolume(
+			context.Background(),
+			&csi.CreateVolumeRequest{
+				Version: csiClientVersion,
+				Name:    name,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					&csi.VolumeCapability{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+					},
+				},
+				CapacityRange: &csi.CapacityRange{
+					RequiredBytes: size,
+				},
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(vol).NotTo(BeNil())
+		Expect(vol.GetVolumeInfo()).NotTo(BeNil())
+		Expect(vol.GetVolumeInfo().GetId()).NotTo(BeEmpty())
+		Expect(vol.GetVolumeInfo().GetCapacityBytes()).To(Equal(size))
+
+		By("cleaning up deleting the volume")
+		_, err = c.DeleteVolume(
+			context.Background(),
+			&csi.DeleteVolumeRequest{
+				Version:  csiClientVersion,
+				VolumeId: vol.GetVolumeInfo().GetId(),
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("DeleteVolume [Controller Server]", func() {
+	var (
+		c csi.ControllerClient
+	)
+
+	BeforeEach(func() {
+		c = csi.NewControllerClient(conn)
+
+		if !isCapabilitySupported(c, csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME) {
+			Skip("DeleteVolume not supported")
+		}
+	})
+
+	It("should fail when no version is provided", func() {
+
+		_, err := c.DeleteVolume(
+			context.Background(),
+			&csi.DeleteVolumeRequest{})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should fail when no volume id is provided", func() {
+
+		_, err := c.DeleteVolume(
+			context.Background(),
+			&csi.DeleteVolumeRequest{
+				Version: csiClientVersion,
+			})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should succeed when an invalid volume id is used", func() {
+
+		_, err := c.DeleteVolume(
+			context.Background(),
+			&csi.DeleteVolumeRequest{
+				Version:  csiClientVersion,
+				VolumeId: "reallyfakevolumeid",
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should return appropriate values (no optional values added)", func() {
+
+		// Create Volume First
+		By("creating a volume")
+		name := "sanity"
+		vol, err := c.CreateVolume(
+			context.Background(),
+			&csi.CreateVolumeRequest{
+				Version: csiClientVersion,
+				Name:    name,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					&csi.VolumeCapability{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+					},
+				},
+			})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(vol).NotTo(BeNil())
+		Expect(vol.GetVolumeInfo()).NotTo(BeNil())
+		Expect(vol.GetVolumeInfo().GetId()).NotTo(BeEmpty())
+
+		// Delete Volume
+		By("deleting a volume")
+		_, err = c.DeleteVolume(
+			context.Background(),
+			&csi.DeleteVolumeRequest{
+				Version:  csiClientVersion,
+				VolumeId: vol.GetVolumeInfo().GetId(),
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("ValidateVolumeCapabilities [Controller Server]", func() {
+	var (
+		c csi.ControllerClient
+	)
+
+	BeforeEach(func() {
+		c = csi.NewControllerClient(conn)
+	})
+
+	It("should fail when no version is provided", func() {
+
+		_, err := c.ValidateVolumeCapabilities(
+			context.Background(),
+			&csi.ValidateVolumeCapabilitiesRequest{})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should fail when no volume id is provided", func() {
+
+		_, err := c.ValidateVolumeCapabilities(
+			context.Background(),
+			&csi.ValidateVolumeCapabilitiesRequest{
+				Version: csiClientVersion,
+			})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should fail when no volume capabilities are provided", func() {
+
+		_, err := c.ValidateVolumeCapabilities(
+			context.Background(),
+			&csi.ValidateVolumeCapabilitiesRequest{
+				Version:  csiClientVersion,
+				VolumeId: "id",
+			})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should return appropriate values (no optional values added)", func() {
+
+		// Create Volume First
+		By("creating a single node writer volume")
+		name := "sanity"
+		vol, err := c.CreateVolume(
+			context.Background(),
+			&csi.CreateVolumeRequest{
+				Version: csiClientVersion,
+				Name:    name,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					&csi.VolumeCapability{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+					},
+				},
+			})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(vol).NotTo(BeNil())
+		Expect(vol.GetVolumeInfo()).NotTo(BeNil())
+		Expect(vol.GetVolumeInfo().GetId()).NotTo(BeEmpty())
+
+		// ValidateVolumeCapabilities
+		By("validating volume capabilities")
+		valivolcap, err := c.ValidateVolumeCapabilities(
+			context.Background(),
+			&csi.ValidateVolumeCapabilitiesRequest{
+				Version:  csiClientVersion,
+				VolumeId: vol.GetVolumeInfo().GetId(),
+				VolumeCapabilities: []*csi.VolumeCapability{
+					&csi.VolumeCapability{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+					},
+				},
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(valivolcap).NotTo(BeNil())
+		Expect(valivolcap.GetSupported()).To(BeTrue())
+
+		By("cleaning up deleting the volume")
+		_, err = c.DeleteVolume(
+			context.Background(),
+			&csi.DeleteVolumeRequest{
+				Version:  csiClientVersion,
+				VolumeId: vol.GetVolumeInfo().GetId(),
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("ControllerPublishVolume [Controller Server]", func() {
+	var (
+		c csi.ControllerClient
+		n csi.NodeClient
+	)
+
+	BeforeEach(func() {
+		c = csi.NewControllerClient(conn)
+		n = csi.NewNodeClient(conn)
+
+		if !isCapabilitySupported(c, csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME) {
+			Skip("ControllerPublishVolume not supported")
+		}
+	})
+
+	It("should fail when no version is provided", func() {
+
+		_, err := c.ControllerPublishVolume(
+			context.Background(),
+			&csi.ControllerPublishVolumeRequest{})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should fail when no volume id is provided", func() {
+
+		_, err := c.ControllerPublishVolume(
+			context.Background(),
+			&csi.ControllerPublishVolumeRequest{
+				Version: csiClientVersion,
+			})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should fail when no node id is provided", func() {
+
+		_, err := c.ControllerPublishVolume(
+			context.Background(),
+			&csi.ControllerPublishVolumeRequest{
+				Version:  csiClientVersion,
+				VolumeId: "id",
+			})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should fail when no volume capability is provided", func() {
+
+		_, err := c.ControllerPublishVolume(
+			context.Background(),
+			&csi.ControllerPublishVolumeRequest{
+				Version:  csiClientVersion,
+				VolumeId: "id",
+				NodeId:   "fakenode",
+			})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should return appropriate values (no optional values added)", func() {
+
+		// Create Volume First
+		By("creating a single node writer volume")
+		name := "sanity"
+		vol, err := c.CreateVolume(
+			context.Background(),
+			&csi.CreateVolumeRequest{
+				Version: csiClientVersion,
+				Name:    name,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					&csi.VolumeCapability{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+					},
+				},
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(vol).NotTo(BeNil())
+		Expect(vol.GetVolumeInfo()).NotTo(BeNil())
+		Expect(vol.GetVolumeInfo().GetId()).NotTo(BeEmpty())
+
+		By("getting a node id")
+		nid, err := n.GetNodeID(
+			context.Background(),
+			&csi.GetNodeIDRequest{
+				Version: csiClientVersion,
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nid).NotTo(BeNil())
+		Expect(nid.GetNodeId()).NotTo(BeEmpty())
+
+		// ControllerPublishVolume
+		By("calling controllerpublish on that volume")
+		conpubvol, err := c.ControllerPublishVolume(
+			context.Background(),
+			&csi.ControllerPublishVolumeRequest{
+				Version:  csiClientVersion,
+				VolumeId: vol.GetVolumeInfo().GetId(),
+				NodeId:   nid.GetNodeId(),
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+				Readonly: false,
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(conpubvol).NotTo(BeNil())
+
+		By("cleaning up unpublishing the volume")
+		conunpubvol, err := c.ControllerUnpublishVolume(
+			context.Background(),
+			&csi.ControllerUnpublishVolumeRequest{
+				Version:  csiClientVersion,
+				VolumeId: vol.GetVolumeInfo().GetId(),
+				// NodeID is optional in ControllerUnpublishVolume
+				NodeId: nid.GetNodeId(),
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(conunpubvol).NotTo(BeNil())
+
+		By("cleaning up deleting the volume")
+		_, err = c.DeleteVolume(
+			context.Background(),
+			&csi.DeleteVolumeRequest{
+				Version:  csiClientVersion,
+				VolumeId: vol.GetVolumeInfo().GetId(),
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("ControllerUnpublishVolume [Controller Server]", func() {
+	var (
+		c csi.ControllerClient
+		n csi.NodeClient
+	)
+
+	BeforeEach(func() {
+		c = csi.NewControllerClient(conn)
+		n = csi.NewNodeClient(conn)
+
+		if !isCapabilitySupported(c, csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME) {
+			Skip("ControllerUnpublishVolume not supported")
+		}
+	})
+
+	It("should fail when no version is provided", func() {
+
+		_, err := c.ControllerUnpublishVolume(
+			context.Background(),
+			&csi.ControllerUnpublishVolumeRequest{})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should fail when no volume id is provided", func() {
+
+		_, err := c.ControllerUnpublishVolume(
+			context.Background(),
+			&csi.ControllerUnpublishVolumeRequest{
+				Version: csiClientVersion,
+			})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should return appropriate values (no optional values added)", func() {
+
+		// Create Volume First
+		By("creating a single node writer volume")
+		name := "sanity"
+		vol, err := c.CreateVolume(
+			context.Background(),
+			&csi.CreateVolumeRequest{
+				Version: csiClientVersion,
+				Name:    name,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					&csi.VolumeCapability{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+					},
+				},
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(vol).NotTo(BeNil())
+		Expect(vol.GetVolumeInfo()).NotTo(BeNil())
+		Expect(vol.GetVolumeInfo().GetId()).NotTo(BeEmpty())
+
+		By("getting a node id")
+		nid, err := n.GetNodeID(
+			context.Background(),
+			&csi.GetNodeIDRequest{
+				Version: csiClientVersion,
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nid).NotTo(BeNil())
+		Expect(nid.GetNodeId()).NotTo(BeEmpty())
+
+		// ControllerPublishVolume
+		By("calling controllerpublish on that volume")
+		conpubvol, err := c.ControllerPublishVolume(
+			context.Background(),
+			&csi.ControllerPublishVolumeRequest{
+				Version:  csiClientVersion,
+				VolumeId: vol.GetVolumeInfo().GetId(),
+				NodeId:   nid.GetNodeId(),
+				VolumeCapability: &csi.VolumeCapability{
+					AccessType: &csi.VolumeCapability_Mount{
+						Mount: &csi.VolumeCapability_MountVolume{},
+					},
+					AccessMode: &csi.VolumeCapability_AccessMode{
+						Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+					},
+				},
+				Readonly: false,
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(conpubvol).NotTo(BeNil())
+
+		// ControllerUnpublishVolume
+		By("calling controllerunpublish on that volume")
+		conunpubvol, err := c.ControllerUnpublishVolume(
+			context.Background(),
+			&csi.ControllerUnpublishVolumeRequest{
+				Version:  csiClientVersion,
+				VolumeId: vol.GetVolumeInfo().GetId(),
+				// NodeID is optional in ControllerUnpublishVolume
+				NodeId: nid.GetNodeId(),
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(conunpubvol).NotTo(BeNil())
+
+		By("cleaning up deleting the volume")
+		_, err = c.DeleteVolume(
+			context.Background(),
+			&csi.DeleteVolumeRequest{
+				Version:  csiClientVersion,
+				VolumeId: vol.GetVolumeInfo().GetId(),
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/identity.go
+++ b/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/identity.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2017 Luis Pabón luis@portworx.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sanity
+
+import (
+	"regexp"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	context "golang.org/x/net/context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	csiClientVersion = &csi.Version{
+		Major: 0,
+		Minor: 1,
+		Patch: 0,
+	}
+)
+
+var _ = Describe("GetSupportedVersions [Identity Server]", func() {
+	var (
+		c csi.IdentityClient
+	)
+
+	BeforeEach(func() {
+		c = csi.NewIdentityClient(conn)
+	})
+
+	It("should return an array of supported versions", func() {
+		res, err := c.GetSupportedVersions(
+			context.Background(),
+			&csi.GetSupportedVersionsRequest{})
+
+		By("checking response to have supported versions list")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res.GetSupportedVersions()).NotTo(BeNil())
+		Expect(len(res.GetSupportedVersions()) >= 1).To(BeTrue())
+
+		By("checking each version")
+		for _, version := range res.GetSupportedVersions() {
+			Expect(version).NotTo(BeNil())
+			Expect(version.GetMajor()).To(BeNumerically("<", 100))
+			Expect(version.GetMinor()).To(BeNumerically("<", 100))
+			Expect(version.GetPatch()).To(BeNumerically("<", 100))
+		}
+	})
+})
+
+var _ = Describe("GetPluginInfo [Identity Server]", func() {
+	var (
+		c csi.IdentityClient
+	)
+
+	BeforeEach(func() {
+		c = csi.NewIdentityClient(conn)
+	})
+
+	It("should fail when no version is provided", func() {
+		_, err := c.GetPluginInfo(context.Background(), &csi.GetPluginInfoRequest{})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should return appropriate information", func() {
+		req := &csi.GetPluginInfoRequest{
+			Version: csiClientVersion,
+		}
+		res, err := c.GetPluginInfo(context.Background(), req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(res).NotTo(BeNil())
+
+		By("verifying name size and characters")
+		Expect(res.GetName()).ToNot(HaveLen(0))
+		Expect(len(res.GetName())).To(BeNumerically("<=", 63))
+		Expect(regexp.
+			MustCompile("^[a-zA-Z][A-Za-z0-9-\\.\\_]{0,61}[a-zA-Z]$").
+			MatchString(res.GetName())).To(BeTrue())
+	})
+})

--- a/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/node.go
+++ b/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/node.go
@@ -1,0 +1,491 @@
+/*
+Copyright 2017 Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sanity
+
+import (
+	"fmt"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	context "golang.org/x/net/context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("NodeGetCapabilities [Node Server]", func() {
+	var (
+		c csi.NodeClient
+	)
+
+	BeforeEach(func() {
+		c = csi.NewNodeClient(conn)
+	})
+
+	It("should fail when no version is provided", func() {
+		_, err := c.NodeGetCapabilities(
+			context.Background(),
+			&csi.NodeGetCapabilitiesRequest{})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should return appropriate capabilities", func() {
+		caps, err := c.NodeGetCapabilities(
+			context.Background(),
+			&csi.NodeGetCapabilitiesRequest{
+				Version: csiClientVersion,
+			})
+
+		By("checking successful response")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(caps).NotTo(BeNil())
+		Expect(caps.GetCapabilities()).NotTo(BeNil())
+
+		for _, cap := range caps.GetCapabilities() {
+			Expect(cap.GetRpc()).NotTo(BeNil())
+
+			switch cap.GetRpc().GetType() {
+			case csi.NodeServiceCapability_RPC_UNKNOWN:
+			default:
+				Fail(fmt.Sprintf("Unknown capability: %v\n", cap.GetRpc().GetType()))
+			}
+		}
+	})
+})
+
+var _ = Describe("NodeProbe [Node Server]", func() {
+	var (
+		c csi.NodeClient
+	)
+
+	BeforeEach(func() {
+		c = csi.NewNodeClient(conn)
+	})
+
+	It("should fail when no version is provided", func() {
+		_, err := c.NodeProbe(
+			context.Background(),
+			&csi.NodeProbeRequest{})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should return appropriate values", func() {
+		pro, err := c.NodeProbe(
+			context.Background(),
+			&csi.NodeProbeRequest{
+				Version: csiClientVersion,
+			})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pro).NotTo(BeNil())
+	})
+})
+
+var _ = Describe("GetNodeID [Node Server]", func() {
+	var (
+		c csi.NodeClient
+	)
+
+	BeforeEach(func() {
+		c = csi.NewNodeClient(conn)
+	})
+
+	It("should fail when no version is provided", func() {
+		_, err := c.GetNodeID(
+			context.Background(),
+			&csi.GetNodeIDRequest{})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should return appropriate values", func() {
+		nid, err := c.GetNodeID(
+			context.Background(),
+			&csi.GetNodeIDRequest{
+				Version: csiClientVersion,
+			})
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nid).NotTo(BeNil())
+		Expect(nid.GetNodeId()).NotTo(BeEmpty())
+	})
+})
+
+var _ = Describe("NodePublishVolume [Node Server]", func() {
+	var (
+		s                          csi.ControllerClient
+		c                          csi.NodeClient
+		controllerPublishSupported bool
+	)
+
+	BeforeEach(func() {
+		s = csi.NewControllerClient(conn)
+		c = csi.NewNodeClient(conn)
+		controllerPublishSupported = isCapabilitySupported(
+			s,
+			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME)
+	})
+
+	It("should fail when no version is provided", func() {
+
+		_, err := c.NodePublishVolume(
+			context.Background(),
+			&csi.NodePublishVolumeRequest{})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should fail when no volume id is provided", func() {
+
+		_, err := c.NodePublishVolume(
+			context.Background(),
+			&csi.NodePublishVolumeRequest{
+				Version: csiClientVersion,
+			})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should fail when no target path is provided", func() {
+
+		_, err := c.NodePublishVolume(
+			context.Background(),
+			&csi.NodePublishVolumeRequest{
+				Version:  csiClientVersion,
+				VolumeId: "id",
+			})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should fail when no volume capability is provided", func() {
+
+		_, err := c.NodePublishVolume(
+			context.Background(),
+			&csi.NodePublishVolumeRequest{
+				Version:    csiClientVersion,
+				VolumeId:   "id",
+				TargetPath: csiTargetPath,
+			})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should return appropriate values (no optional values added)", func() {
+
+		// Create Volume First
+		By("creating a single node writer volume")
+		name := "sanity"
+		vol, err := s.CreateVolume(
+			context.Background(),
+			&csi.CreateVolumeRequest{
+				Version: csiClientVersion,
+				Name:    name,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					&csi.VolumeCapability{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+					},
+				},
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(vol).NotTo(BeNil())
+		Expect(vol.GetVolumeInfo()).NotTo(BeNil())
+		Expect(vol.GetVolumeInfo().GetId()).NotTo(BeEmpty())
+
+		By("getting a node id")
+		nid, err := c.GetNodeID(
+			context.Background(),
+			&csi.GetNodeIDRequest{
+				Version: csiClientVersion,
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nid).NotTo(BeNil())
+		Expect(nid.GetNodeId()).NotTo(BeEmpty())
+
+		var conpubvol *csi.ControllerPublishVolumeResponse
+		if controllerPublishSupported {
+			By("controller publishing volume")
+			conpubvol, err = s.ControllerPublishVolume(
+				context.Background(),
+				&csi.ControllerPublishVolumeRequest{
+					Version:  csiClientVersion,
+					VolumeId: vol.GetVolumeInfo().GetId(),
+					NodeId:   nid.GetNodeId(),
+					VolumeCapability: &csi.VolumeCapability{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+					},
+					Readonly: false,
+				})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(conpubvol).NotTo(BeNil())
+		}
+
+		// NodePublishVolume
+		By("publishing the volume on a node")
+		nodepubvolRequest := &csi.NodePublishVolumeRequest{
+			Version:    csiClientVersion,
+			VolumeId:   vol.GetVolumeInfo().GetId(),
+			TargetPath: csiTargetPath,
+			VolumeCapability: &csi.VolumeCapability{
+				AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{},
+				},
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+			},
+		}
+		if controllerPublishSupported {
+			nodepubvolRequest.PublishVolumeInfo = conpubvol.GetPublishVolumeInfo()
+		}
+		nodepubvol, err := c.NodePublishVolume(context.Background(), nodepubvolRequest)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodepubvol).NotTo(BeNil())
+
+		// NodeUnpublishVolume
+		By("cleaning up calling nodeunpublish")
+		nodeunpubvol, err := c.NodeUnpublishVolume(
+			context.Background(),
+			&csi.NodeUnpublishVolumeRequest{
+				Version:    csiClientVersion,
+				VolumeId:   vol.GetVolumeInfo().GetId(),
+				TargetPath: csiTargetPath,
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodeunpubvol).NotTo(BeNil())
+
+		if controllerPublishSupported {
+			By("cleaning up calling controllerunpublishing the volume")
+			nodeunpubvol, err := c.NodeUnpublishVolume(
+				context.Background(),
+				&csi.NodeUnpublishVolumeRequest{
+					Version:    csiClientVersion,
+					VolumeId:   vol.GetVolumeInfo().GetId(),
+					TargetPath: csiTargetPath,
+				})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nodeunpubvol).NotTo(BeNil())
+		}
+
+		By("cleaning up deleting the volume")
+		_, err = s.DeleteVolume(
+			context.Background(),
+			&csi.DeleteVolumeRequest{
+				Version:  csiClientVersion,
+				VolumeId: vol.GetVolumeInfo().GetId(),
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})
+
+var _ = Describe("NodeUnpublishVolume [Node Server]", func() {
+	var (
+		s                          csi.ControllerClient
+		c                          csi.NodeClient
+		controllerPublishSupported bool
+	)
+
+	BeforeEach(func() {
+		s = csi.NewControllerClient(conn)
+		c = csi.NewNodeClient(conn)
+		controllerPublishSupported = isCapabilitySupported(
+			s,
+			csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME)
+	})
+
+	It("should fail when no version is provided", func() {
+
+		_, err := c.NodeUnpublishVolume(
+			context.Background(),
+			&csi.NodeUnpublishVolumeRequest{})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should fail when no volume id is provided", func() {
+
+		_, err := c.NodeUnpublishVolume(
+			context.Background(),
+			&csi.NodeUnpublishVolumeRequest{
+				Version: csiClientVersion,
+			})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should fail when no target path is provided", func() {
+
+		_, err := c.NodeUnpublishVolume(
+			context.Background(),
+			&csi.NodeUnpublishVolumeRequest{
+				Version:  csiClientVersion,
+				VolumeId: "id",
+			})
+		Expect(err).To(HaveOccurred())
+
+		serverError, ok := status.FromError(err)
+		Expect(ok).To(BeTrue())
+		Expect(serverError.Code()).To(Equal(codes.InvalidArgument))
+	})
+
+	It("should return appropriate values (no optional values added)", func() {
+
+		// Create Volume First
+		By("creating a single node writer volume")
+		name := "sanity"
+		vol, err := s.CreateVolume(
+			context.Background(),
+			&csi.CreateVolumeRequest{
+				Version: csiClientVersion,
+				Name:    name,
+				VolumeCapabilities: []*csi.VolumeCapability{
+					&csi.VolumeCapability{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+					},
+				},
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(vol).NotTo(BeNil())
+		Expect(vol.GetVolumeInfo()).NotTo(BeNil())
+		Expect(vol.GetVolumeInfo().GetId()).NotTo(BeEmpty())
+
+		// ControllerPublishVolume
+		var conpubvol *csi.ControllerPublishVolumeResponse
+		if controllerPublishSupported {
+			By("calling controllerpublish on the volume")
+			conpubvol, err = s.ControllerPublishVolume(
+				context.Background(),
+				&csi.ControllerPublishVolumeRequest{
+					Version:  csiClientVersion,
+					VolumeId: vol.GetVolumeInfo().GetId(),
+					NodeId:   "foobar",
+					VolumeCapability: &csi.VolumeCapability{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{},
+						},
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+						},
+					},
+					Readonly: false,
+				})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(conpubvol).NotTo(BeNil())
+		}
+
+		// NodePublishVolume
+		By("publishing the volume on a node")
+		nodepubvolRequest := &csi.NodePublishVolumeRequest{
+			Version:    csiClientVersion,
+			VolumeId:   vol.GetVolumeInfo().GetId(),
+			TargetPath: csiTargetPath,
+			VolumeCapability: &csi.VolumeCapability{
+				AccessType: &csi.VolumeCapability_Mount{
+					Mount: &csi.VolumeCapability_MountVolume{},
+				},
+				AccessMode: &csi.VolumeCapability_AccessMode{
+					Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+				},
+			},
+		}
+		if controllerPublishSupported {
+			nodepubvolRequest.PublishVolumeInfo = conpubvol.GetPublishVolumeInfo()
+		}
+		nodepubvol, err := c.NodePublishVolume(context.Background(), nodepubvolRequest)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodepubvol).NotTo(BeNil())
+
+		// NodeUnpublishVolume
+		nodeunpubvol, err := c.NodeUnpublishVolume(
+			context.Background(),
+			&csi.NodeUnpublishVolumeRequest{
+				Version:    csiClientVersion,
+				VolumeId:   vol.GetVolumeInfo().GetId(),
+				TargetPath: csiTargetPath,
+			})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nodeunpubvol).NotTo(BeNil())
+
+		if controllerPublishSupported {
+			By("cleaning up unpublishing the volume")
+			nodeunpubvol, err := c.NodeUnpublishVolume(
+				context.Background(),
+				&csi.NodeUnpublishVolumeRequest{
+					Version:    csiClientVersion,
+					VolumeId:   vol.GetVolumeInfo().GetId(),
+					TargetPath: csiTargetPath,
+				})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nodeunpubvol).NotTo(BeNil())
+		}
+
+		By("cleaning up deleting the volume")
+		_, err = s.DeleteVolume(
+			context.Background(),
+			&csi.DeleteVolumeRequest{
+				Version:  csiClientVersion,
+				VolumeId: vol.GetVolumeInfo().GetId(),
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/sanity.go
+++ b/vendor/github.com/kubernetes-csi/csi-test/pkg/sanity/sanity.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2017 Luis Pabón luis@portworx.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sanity
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/kubernetes-csi/csi-test/utils"
+
+	"google.golang.org/grpc"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var (
+	driverAddress string
+	csiTargetPath string
+	conn          *grpc.ClientConn
+	lock          sync.Mutex
+)
+
+// Test will test the CSI driver at the specified address
+func Test(t *testing.T, address, mountPoint string) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	driverAddress = address
+	csiTargetPath = mountPoint
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CSI Driver Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	var err error
+
+	By("connecting to CSI driver")
+	conn, err = utils.Connect(driverAddress)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("creating mount directory")
+	err = createMountTargetLocation(csiTargetPath)
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	conn.Close()
+	os.Remove(csiTargetPath)
+})
+
+func createMountTargetLocation(targetPath string) error {
+	fileInfo, err := os.Stat(targetPath)
+	if err != nil && os.IsNotExist(err) {
+		return os.Mkdir(targetPath, 0755)
+	} else if err != nil {
+		return err
+	}
+	if !fileInfo.IsDir() {
+		return fmt.Errorf("Target location %s is not a directory", targetPath)
+	}
+
+	return nil
+}

--- a/vendor/github.com/kubernetes-csi/csi-test/utils/grpcutil.go
+++ b/vendor/github.com/kubernetes-csi/csi-test/utils/grpcutil.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/url"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+)
+
+// Connect address by grpc
+func Connect(address string) (*grpc.ClientConn, error) {
+	dialOptions := []grpc.DialOption{
+		grpc.WithInsecure(),
+	}
+	u, err := url.Parse(address)
+	if err == nil && (!u.IsAbs() || u.Scheme == "unix") {
+		dialOptions = append(dialOptions,
+			grpc.WithDialer(
+				func(addr string, timeout time.Duration) (net.Conn, error) {
+					return net.DialTimeout("unix", u.Path, timeout)
+				}))
+	}
+
+	conn, err := grpc.Dial(address, dialOptions...)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	for {
+		if !conn.WaitForStateChange(ctx, conn.GetState()) {
+			return conn, fmt.Errorf("Connection timed out")
+		}
+		if conn.GetState() == connectivity.Ready {
+			return conn, nil
+		}
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -855,10 +855,16 @@
 			"revisionTime": "2016-09-07T12:20:59Z"
 		},
 		{
-			"checksumSHA1": "rPWrzbO5s9QFUG5pERhAWnPRIC8=",
+			"checksumSHA1": "+Nbih0imB0vL5dMaQWfKk1q0E0k=",
+			"path": "github.com/kubernetes-csi/csi-test/pkg/sanity",
+			"revision": "6189194c5afb6b1a8e890324cb40a99ca43ab8aa",
+			"revisionTime": "2018-01-25T18:03:08Z"
+		},
+		{
+			"checksumSHA1": "u9bObWdPHfMHx7GURJ2El86Lkp0=",
 			"path": "github.com/kubernetes-csi/csi-test/utils",
-			"revision": "fdd7859858f9f4db4f64563e45996382d39b58f4",
-			"revisionTime": "2017-11-14T15:52:15Z"
+			"revision": "6189194c5afb6b1a8e890324cb40a99ca43ab8aa",
+			"revisionTime": "2018-01-25T18:03:08Z"
 		},
 		{
 			"checksumSHA1": "XxSculDWJ8paPj2VbSbbxPDSb7Q=",


### PR DESCRIPTION
**What this PR does / why we need it**:
With the new csi-sanity tool and pkg we can now test the CSI APIs act as expected. This PR fixes issues found by csi-sanity and also adds it to the CI system to be used on every `docker-test` run.

**Special notes for your reviewer**:
* Added support to run CSI drivers from `cmd/osd/main.go`
* Added new `csi/csisanity_test.go` which may not be perfectly setting up NFS as the server. Please make sure I did the right thing.

