### PR TITLE
storageops: Expose Describe

### DIFF
--- a/pkg/storageops/aws/aws.go
+++ b/pkg/storageops/aws/aws.go
@@ -235,7 +235,11 @@ func (s *ec2Ops) DeviceMappings() (map[string]string, error) {
 	return m, nil
 }
 
-// describe current instance.
+// Describe current instance.
+func (s *ec2Ops) Describe() (interface{}, error) {
+	return s.describe()
+}
+
 func (s *ec2Ops) describe() (*ec2.Instance, error) {
 	request := &ec2.DescribeInstancesInput{
 		InstanceIds: []*string{&s.instance},

--- a/pkg/storageops/gce/gce.go
+++ b/pkg/storageops/gce/gce.go
@@ -457,6 +457,12 @@ func (s *gceOps) checkSnapStatus(id string, desired string) error {
 
 	return err
 }
+
+// Describe current instance.
+func (s *gceOps) Describe() (interface{}, error) {
+	return s.describeinstance()
+}
+
 func (s *gceOps) describeinstance() (*compute.Instance, error) {
 	return s.service.Instances.Get(s.inst.Project, s.inst.Zone, s.inst.Name).Do()
 }

--- a/pkg/storageops/storageops.go
+++ b/pkg/storageops/storageops.go
@@ -43,6 +43,8 @@ type Ops interface {
 	Detach(volumeID string) error
 	// Delete volumeID.
 	Delete(volumeID string) error
+	// Desribe an instance
+	Describe() (interface{}, error)
 	// FreeDevices returns free block devices on the instance.
 	// blockDeviceMappings is a data structure that contains all block devices on
 	// the instance and where they are mapped to


### PR DESCRIPTION
**What this PR does / why we need it**:
By exposing Describe, the caller can get additional information
on the instance.


