### PR TITLE
WIP: Move to zap logging

### DIFF
--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -20,7 +20,7 @@ IF YOU CODE ON OPENSTORAGE, YOU ARE EXPECTED TO KNOW THIS. Just take the 20 minu
 
 ### Items
 
-* Use [dlog](https://go.pedge.io/dlog) for logging.
+* Use [zap](https://github.com/uber-go/zap) for logging.
 
 * File order:
 
@@ -92,7 +92,7 @@ func (r *runner) hello(i int) {
   return r.something.Hello(i)
 }
 ```
-              
+
 * Most structs that have functions attached have a separate file with the private struct definition, private constructor, and public functions, then private functions. The runner struct above is an example.
 
 * Use struct pointers in general instead of structs. It's a debate, but not for now.
@@ -144,7 +144,7 @@ type Volume struct {
 
 //yes
 type Volume struct {
-  VolumeID string  
+  VolumeID string
 }
 ```
 
@@ -177,7 +177,7 @@ if err := foo(); err != nil {
   return nil, err
 }
 ```
-    
+
 * Empty structs:
 
 ```go

--- a/alert/alert_kvdb.go
+++ b/alert/alert_kvdb.go
@@ -3,14 +3,15 @@ package alert
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/libopenstorage/openstorage/api"
-	"github.com/libopenstorage/openstorage/pkg/proto/time"
-	"github.com/portworx/kvdb"
-	"go.pedge.io/dlog"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/libopenstorage/openstorage/api"
+	"github.com/libopenstorage/openstorage/pkg/proto/time"
+	"github.com/portworx/kvdb"
+	"go.uber.org/zap"
 )
 
 const (
@@ -285,7 +286,7 @@ func (kva *KvAlert) raiseIfNotExist(a *api.Alert) error {
 	// is able to proceed.
 	kvp, err := kv.Lock(getLockId(a.ResourceId, a.UniqueTag))
 	if err != nil {
-		dlog.Errorf("Failed to get lock for resource %s, err: %s",
+		zap.S().Errorf("Failed to get lock for resource %s, err: %s",
 			a.ResourceId, err.Error())
 		return err
 	}
@@ -293,7 +294,7 @@ func (kva *KvAlert) raiseIfNotExist(a *api.Alert) error {
 
 	alerts, err := kva.getResourceSpecificAlerts(a.Resource, kv)
 	if err != nil {
-		dlog.Infof("Failed to get alerts of type %s, error: %s",
+		zap.S().Infof("Failed to get alerts of type %s, error: %s",
 			a.Resource, err.Error())
 		return err
 	}
@@ -324,7 +325,7 @@ func (kva *KvAlert) ClearByUniqueTag(
 
 	kvp, err := kv.Lock(getLockId(resourceId, uniqueTag))
 	if err != nil {
-		dlog.Errorf("Failed to get lock for resource %s, err: %s",
+		zap.S().Errorf("Failed to get lock for resource %s, err: %s",
 			resourceId, err.Error())
 		return err
 	}
@@ -332,7 +333,7 @@ func (kva *KvAlert) ClearByUniqueTag(
 
 	alerts, err := kva.getResourceSpecificAlerts(resourceType, kv)
 	if err != nil {
-		dlog.Infof("Failed to get alerts of type %s, error: %s",
+		zap.S().Infof("Failed to get alerts of type %s, error: %s",
 			resourceType, err.Error())
 		return err
 	}
@@ -469,18 +470,18 @@ func (kva *KvAlert) getKvdbForCluster(clusterID string) (kvdb.Kvdb, error) {
 }
 
 func processWatchError(err error, watcherKey string, prefix string) error {
-	dlog.Errorf("Alert Watch error for key %v: %v", watcherKey, err)
+	zap.S().Errorf("Alert Watch error for key %v: %v", watcherKey, err)
 	w := watcherMap[watcherKey]
 	w.status = watchError
 	if w.watchErrors == 5 {
-		dlog.Warnf("Too many watch errors for key (%v). Error: %s. Stopping the watch!!", watcherKey, err.Error())
+		zap.S().Warnf("Too many watch errors for key (%v). Error: %s. Stopping the watch!!", watcherKey, err.Error())
 		w.cb(nil, api.AlertActionType_ALERT_ACTION_TYPE_NONE, prefix, "")
 		// Too many watch errors. Stop the watch
 		return err
 	}
 	w.watchErrors++
 	if err := subscribeWatch(watcherKey); err != nil {
-		dlog.Warnf("Failed to resubscribe alert watch for key: %s: %s", watcherKey, err.Error())
+		zap.S().Warnf("Failed to resubscribe alert watch for key: %s: %s", watcherKey, err.Error())
 	}
 	return err
 }

--- a/alert/alert_kvdb_test.go
+++ b/alert/alert_kvdb_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/libopenstorage/openstorage/pkg/proto/time"
 	"github.com/portworx/kvdb"
 	"github.com/portworx/kvdb/mem"
 	"github.com/stretchr/testify/require"
-	"go.pedge.io/dlog"
 )
 
 var (
@@ -45,7 +46,7 @@ func TestAll(t *testing.T) {
 func setup(t *testing.T) {
 	kv := kvdb.Instance()
 	if kv == nil {
-		kv, err := kvdb.New(mem.Name, kvdbDomain+"/"+clusterName, []string{}, nil, dlog.Panicf)
+		kv, err := kvdb.New(mem.Name, kvdbDomain+"/"+clusterName, []string{}, nil, zap.S().Panicf)
 		if err != nil {
 			t.Fatalf("Failed to set default KV store : (%v): %v", mem.Name, err)
 		}

--- a/api/flexvolume/flexvolume.go
+++ b/api/flexvolume/flexvolume.go
@@ -6,14 +6,14 @@ import (
 	"math"
 	"net"
 
+	"go.uber.org/zap"
+
 	"google.golang.org/grpc"
 
 	"github.com/libopenstorage/openstorage/pkg/flexvolume"
 	"github.com/libopenstorage/openstorage/pkg/mount"
 	"github.com/libopenstorage/openstorage/volume"
 	"github.com/libopenstorage/openstorage/volume/drivers"
-
-	"go.pedge.io/dlog"
 )
 
 const (
@@ -63,7 +63,7 @@ func (c *flexVolumeClient) Attach(jsonOptions map[string]string) error {
 func (c *flexVolumeClient) Detach(mountDevice string, options map[string]string) error {
 	driverName, ok := deviceDriverMap[mountDevice]
 	if !ok {
-		dlog.Infof("Could not find driver for (%v). Resorting to default driver ", mountDevice)
+		zap.S().Infof("Could not find driver for (%v). Resorting to default driver ", mountDevice)
 		driverName = c.defaultDriver
 	}
 	driver, err := c.getVolumeDriver(driverName)
@@ -96,7 +96,7 @@ func (c *flexVolumeClient) Mount(targetMountDir string, mountDevice string,
 	// Update the deviceDriverMap
 	mountManager, err := mount.New(mount.DeviceMount, nil, []string{""}, nil, []string{}, "")
 	if err != nil {
-		dlog.Infof("Could not read mountpoints from /proc/self/mountinfo. Device - Driver mapping not saved!")
+		zap.S().Infof("Could not read mountpoints from /proc/self/mountinfo. Device - Driver mapping not saved!")
 		return nil
 	}
 	sourcePath, err := mountManager.GetSourcePath(targetMountDir)
@@ -119,7 +119,7 @@ func (c *flexVolumeClient) Unmount(mountDir string, options map[string]string) e
 	}
 	driverName, ok := deviceDriverMap[mountDevice]
 	if !ok {
-		dlog.Infof("Could not find driver for (%v). Resorting to default driver. ", mountDevice)
+		zap.S().Infof("Could not find driver for (%v). Resorting to default driver. ", mountDevice)
 		driverName = c.defaultDriver
 	}
 	driver, err := c.getVolumeDriver(driverName)
@@ -152,7 +152,7 @@ func StartFlexVolumeAPI(port uint16, defaultDriver string) error {
 	}
 	go func() {
 		if err := grpcServer.Serve(listener); err != nil {
-			dlog.Errorln(err.Error())
+			zap.S().Error(err.Error())
 		}
 	}()
 	return nil

--- a/api/testing/restapi_test.go
+++ b/api/testing/restapi_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/libopenstorage/openstorage/api"
 	volumeclient "github.com/libopenstorage/openstorage/api/client/volume"
 	"github.com/libopenstorage/openstorage/api/server"
 	"github.com/libopenstorage/openstorage/volume"
 	"github.com/stretchr/testify/assert"
-	"go.pedge.io/dlog"
 
 	"github.com/golang/mock/gomock"
 )
@@ -42,7 +43,7 @@ func startServer() {
 		volume.DriverAPIBase,
 		mgmtPort,
 	); err != nil {
-		dlog.Errorf("Error starting the server")
+		zap.S().Errorf("Error starting the server")
 	}
 
 	// adding sleep to avoid race condition of connection refused.

--- a/api/testing/testServer.go
+++ b/api/testing/testServer.go
@@ -3,7 +3,7 @@ package testing
 import (
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-csi/csi-test/utils"
-	"go.pedge.io/dlog"
+	"go.uber.org/zap"
 
 	client "github.com/libopenstorage/openstorage/api/client"
 	mockcluster "github.com/libopenstorage/openstorage/cluster/mock"
@@ -35,7 +35,7 @@ func newTestServer(driver string) *testServer {
 	})
 
 	if err != nil {
-		dlog.Errorf("Failed to add the driver [%s] for tests", driver)
+		zap.S().Errorf("Failed to add the driver [%s] for tests", driver)
 	}
 
 	// Register the mock driver

--- a/api/testing/testing_test.go
+++ b/api/testing/testing_test.go
@@ -5,8 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"go.pedge.io/dlog"
-
 	"github.com/libopenstorage/openstorage/api"
 	volumeclient "github.com/libopenstorage/openstorage/api/client/volume"
 	"github.com/libopenstorage/openstorage/api/server"
@@ -19,10 +17,6 @@ import (
 var (
 	testPath = string("/tmp/openstorage_client_test")
 )
-
-func init() {
-	dlog.SetLevel(dlog.LevelDebug)
-}
 
 func makeRequest(t *testing.T) {
 	versions, err := volumeclient.GetSupportedDriverVersions(nfs.Name, "")

--- a/cluster/database.go
+++ b/cluster/database.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	"go.pedge.io/dlog"
+	"go.uber.org/zap"
 
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/portworx/kvdb"
@@ -28,19 +28,19 @@ func snapAndReadClusterInfo() (*ClusterInitState, error) {
 	)
 	for i := 0; i < 3; i++ {
 		if i > 0 {
-			dlog.Infof("Retrying snapshot")
+			zap.S().Infof("Retrying snapshot")
 		}
 		// Start the watch before the snapshot
 		collector, err = kvdb.NewUpdatesCollector(kv, "", 0)
 		if err != nil {
-			dlog.Errorf("Failed to start collector for cluster db: %v", err)
+			zap.S().Errorf("Failed to start collector for cluster db: %v", err)
 			collector = nil
 			continue
 		}
 		// Create the snapshot
 		snap, version, err = kv.Snapshot("")
 		if err != nil {
-			dlog.Errorf("Snapshot failed for cluster db: %v", err)
+			zap.S().Errorf("Snapshot failed for cluster db: %v", err)
 			collector.Stop()
 			collector = nil
 		} else {
@@ -50,11 +50,11 @@ func snapAndReadClusterInfo() (*ClusterInitState, error) {
 	if err != nil {
 		return nil, err
 	}
-	dlog.Infof("Cluster db snapshot at: %v", version)
+	zap.S().Infof("Cluster db snapshot at: %v", version)
 
 	clusterDB, err := snap.Get(ClusterDBKey)
 	if err != nil && !strings.Contains(err.Error(), "Key not found") {
-		dlog.Warnln("Warning, could not read cluster database")
+		zap.S().Warn("Warning, could not read cluster database")
 		return nil, err
 	}
 
@@ -70,11 +70,11 @@ func snapAndReadClusterInfo() (*ClusterInitState, error) {
 	}
 
 	if clusterDB == nil || bytes.Compare(clusterDB.Value, []byte("{}")) == 0 {
-		dlog.Infoln("Cluster is uninitialized...")
+		zap.S().Info("Cluster is uninitialized...")
 		return state, nil
 	}
 	if err := json.Unmarshal(clusterDB.Value, &db); err != nil {
-		dlog.Warnln("Fatal, Could not parse cluster database ", kv)
+		zap.S().Warn("Fatal, Could not parse cluster database ", kv)
 		return state, err
 	}
 
@@ -91,16 +91,16 @@ func readClusterInfo() (ClusterInfo, uint64, error) {
 	kv, err := kvdb.Get(ClusterDBKey)
 
 	if err != nil && !strings.Contains(err.Error(), "Key not found") {
-		dlog.Warnln("Warning, could not read cluster database")
+		zap.S().Warn("Warning, could not read cluster database")
 		return db, 0, err
 	}
 
 	if kv == nil || bytes.Compare(kv.Value, []byte("{}")) == 0 {
-		dlog.Infoln("Cluster is uninitialized...")
+		zap.S().Info("Cluster is uninitialized...")
 		return db, 0, nil
 	}
 	if err := json.Unmarshal(kv.Value, &db); err != nil {
-		dlog.Warnln("Fatal, Could not parse cluster database ", kv)
+		zap.S().Warn("Fatal, Could not parse cluster database ", kv)
 		return db, 0, err
 	}
 
@@ -111,13 +111,13 @@ func writeClusterInfo(db *ClusterInfo) (*kvdb.KVPair, error) {
 	kvdb := kvdb.Instance()
 	b, err := json.Marshal(db)
 	if err != nil {
-		dlog.Warnf("Fatal, Could not marshal cluster database to JSON: %v", err)
+		zap.S().Warnf("Fatal, Could not marshal cluster database to JSON: %v", err)
 		return nil, err
 	}
 
 	kvp, err := kvdb.Put(ClusterDBKey, b, 0)
 	if err != nil {
-		dlog.Warnf("Fatal, Could not marshal cluster database to JSON: %v", err)
+		zap.S().Warnf("Fatal, Could not marshal cluster database to JSON: %v", err)
 		return nil, err
 	}
 	return kvp, nil

--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/libopenstorage/openstorage/volume"
-	"go.pedge.io/dlog/logrus"
 )
 
 const (
@@ -25,8 +24,6 @@ const (
 func init() {
 	os.MkdirAll(volume.MountBase, 0755)
 	os.MkdirAll(GraphDriverAPIBase, 0755)
-	// TODO(pedge) eventually move to osd main.go when everyone is comfortable with dlog
-	dlog_logrus.Register()
 }
 
 type ClusterConfig struct {

--- a/csi/csi.go
+++ b/csi/csi.go
@@ -21,8 +21,9 @@ import (
 	"net"
 	"sync"
 
+	"go.uber.org/zap"
+
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"go.pedge.io/dlog"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 
@@ -108,7 +109,7 @@ func (s *OsdCsiServer) Start() error {
 	reflection.Register(s.server)
 
 	// Start listening for requests
-	dlog.Infof("CSI Server ready on %s", s.Address())
+	zap.S().Infof("CSI Server ready on %s", s.Address())
 	waitForServer := make(chan bool)
 	s.goServe(waitForServer)
 	<-waitForServer
@@ -154,7 +155,7 @@ func (s *OsdCsiServer) goServe(started chan<- bool) {
 		started <- true
 		err := s.server.Serve(s.listener)
 		if err != nil {
-			dlog.Fatalf("ERROR: Unable to start gRPC server: %s\n", err.Error())
+			zap.S().Fatalf("ERROR: Unable to start gRPC server: %s\n", err.Error())
 		}
 	}()
 }

--- a/csi/csisanity_test.go
+++ b/csi/csisanity_test.go
@@ -22,13 +22,14 @@ import (
 	"os"
 	"testing"
 
+	"go.uber.org/zap"
+
 	"github.com/libopenstorage/openstorage/cluster"
 	"github.com/libopenstorage/openstorage/config"
 	"github.com/libopenstorage/openstorage/volume"
 	"github.com/libopenstorage/openstorage/volume/drivers"
 
 	"github.com/kubernetes-csi/csi-test/pkg/sanity"
-	"go.pedge.io/dlog"
 
 	"github.com/portworx/kvdb"
 	"github.com/portworx/kvdb/mem"
@@ -45,7 +46,7 @@ var (
 
 func TestCSISanity(t *testing.T) {
 
-	kv, err := kvdb.New(mem.Name, "driver_test", []string{}, nil, dlog.Panicf)
+	kv, err := kvdb.New(mem.Name, "driver_test", []string{}, nil, zap.S().Panicf)
 	if err != nil {
 		t.Fatalf("Failed to initialize KVDB")
 	}

--- a/csi/identity.go
+++ b/csi/identity.go
@@ -18,7 +18,7 @@ package csi
 
 import (
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"go.pedge.io/dlog"
+	"go.uber.org/zap"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -54,7 +54,7 @@ func (s *OsdCsiServer) GetPluginInfo(
 	ctx context.Context,
 	req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 
-	dlog.Debugf("GetPluginInfo req[%#v]", req)
+	zap.S().Debugf("GetPluginInfo req[%#v]", req)
 
 	// Check arguments
 	if req.GetVersion() == nil {

--- a/csi/node.go
+++ b/csi/node.go
@@ -20,12 +20,13 @@ import (
 	"fmt"
 	"os"
 
+	"go.uber.org/zap"
+
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/libopenstorage/openstorage/pkg/options"
 	"github.com/libopenstorage/openstorage/pkg/util"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
-	"go.pedge.io/dlog"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -33,7 +34,7 @@ import (
 
 // GetNodeID is a CSI API which gets the PX NodeId for the local node
 func (s *OsdCsiServer) GetNodeID(ctx context.Context, req *csi.GetNodeIDRequest) (*csi.GetNodeIDResponse, error) {
-	dlog.Debugf("GetNodeID req[%#v]", req)
+	zap.S().Debugf("GetNodeID req[%#v]", req)
 
 	// Check arguments
 	if req.GetVersion() == nil {
@@ -49,7 +50,7 @@ func (s *OsdCsiServer) GetNodeID(ctx context.Context, req *csi.GetNodeIDRequest)
 		NodeId: clus.NodeId,
 	}
 
-	dlog.Infof("NodeId is %s", result.NodeId)
+	zap.S().Infof("NodeId is %s", result.NodeId)
 
 	return result, nil
 }
@@ -64,7 +65,7 @@ func (s *OsdCsiServer) NodePublishVolume(
 	req *csi.NodePublishVolumeRequest,
 ) (*csi.NodePublishVolumeResponse, error) {
 
-	dlog.Debugf("NodePublishVolume req[%#v]", req)
+	zap.S().Debugf("NodePublishVolume req[%#v]", req)
 
 	// Check arguments
 	if req.GetVersion() == nil {
@@ -128,7 +129,7 @@ func (s *OsdCsiServer) NodePublishVolume(
 		// Detach on error
 		detachErr := s.driver.Detach(v.GetId(), opts)
 		if detachErr != nil {
-			dlog.Errorf("Unable to detach volume %s: %s",
+			zap.S().Errorf("Unable to detach volume %s: %s",
 				v.GetId(),
 				detachErr.Error())
 		}
@@ -140,7 +141,7 @@ func (s *OsdCsiServer) NodePublishVolume(
 			err.Error())
 	}
 
-	dlog.Infof("Volume %s mounted on %s",
+	zap.S().Infof("Volume %s mounted on %s",
 		req.GetVolumeId(),
 		req.GetTargetPath())
 
@@ -153,7 +154,7 @@ func (s *OsdCsiServer) NodeUnpublishVolume(
 	req *csi.NodeUnpublishVolumeRequest,
 ) (*csi.NodeUnpublishVolumeResponse, error) {
 
-	dlog.Debugf("NodeUnPublishVolume req[%#v]", req)
+	zap.S().Debugf("NodeUnPublishVolume req[%#v]", req)
 
 	// Check arguments
 	if req.GetVersion() == nil {
@@ -199,7 +200,7 @@ func (s *OsdCsiServer) NodeUnpublishVolume(
 		}
 	}
 
-	dlog.Infof("Volume %s unmounted", req.GetVolumeId())
+	zap.S().Infof("Volume %s unmounted", req.GetVolumeId())
 
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }
@@ -211,7 +212,7 @@ func (s *OsdCsiServer) NodeProbe(
 	req *csi.NodeProbeRequest,
 ) (*csi.NodeProbeResponse, error) {
 
-	dlog.Debugf("NodeProbe req[%#v]", req)
+	zap.S().Debugf("NodeProbe req[%#v]", req)
 
 	// Check arguments
 	if req.GetVersion() == nil {
@@ -232,7 +233,7 @@ func (s *OsdCsiServer) NodeGetCapabilities(
 	req *csi.NodeGetCapabilitiesRequest,
 ) (*csi.NodeGetCapabilitiesResponse, error) {
 
-	dlog.Debugf("NodeGetCapabilities req[%#v]", req)
+	zap.S().Debugf("NodeGetCapabilities req[%#v]", req)
 
 	// Check arguments
 	if req.GetVersion() == nil {

--- a/graph/drivers/chainfs/chainfs.go
+++ b/graph/drivers/chainfs/chainfs.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"path"
 
-	"go.pedge.io/dlog"
+	"go.uber.org/zap"
 
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/libopenstorage/openstorage/graph"
@@ -44,7 +44,7 @@ type Driver struct {
 }
 
 func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
-	dlog.Infof("Initializing libchainfs at home: %s and storage: %v...", home, virtPath)
+	zap.S().Infof("Initializing libchainfs at home: %s and storage: %v...", home, virtPath)
 
 	cVirtPath := C.CString(virtPath)
 	go C.start_chainfs(1, cVirtPath)
@@ -62,7 +62,7 @@ func (d *Driver) String() string {
 // held by the driver, e.g., unmounting all layered filesystems
 // known to this driver.
 func (d *Driver) Cleanup() error {
-	dlog.Infof("Stopping libchainfs at %s", virtPath)
+	zap.S().Infof("Stopping libchainfs at %s", virtPath)
 	C.stop_chainfs()
 	return nil
 }
@@ -79,9 +79,9 @@ func (d *Driver) Status() [][2]string {
 // specified id and parent and mountLabel. Parent and mountLabel may be "".
 func (d *Driver) Create(id string, parent string, ml string, storageOpts map[string]string) error {
 	if parent != "" {
-		dlog.Infof("Creating layer %s with parent %s", id, parent)
+		zap.S().Infof("Creating layer %s with parent %s", id, parent)
 	} else {
-		dlog.Infof("Creating parent layer %s", id)
+		zap.S().Infof("Creating parent layer %s", id)
 	}
 
 	cID := C.CString(id)
@@ -89,7 +89,7 @@ func (d *Driver) Create(id string, parent string, ml string, storageOpts map[str
 
 	ret, err := C.create_layer(cID, cParent)
 	if int(ret) != 0 {
-		dlog.Warnf("Error while creating layer %s", id)
+		zap.S().Warnf("Error while creating layer %s", id)
 		return err
 	}
 
@@ -98,12 +98,12 @@ func (d *Driver) Create(id string, parent string, ml string, storageOpts map[str
 
 // Remove attempts to remove the filesystem layer with this id.
 func (d *Driver) Remove(id string) error {
-	dlog.Infof("Removing layer %s", id)
+	zap.S().Infof("Removing layer %s", id)
 
 	cID := C.CString(id)
 	ret, err := C.remove_layer(cID)
 	if int(ret) != 0 {
-		dlog.Warnf("Error while removing layer %s", id)
+		zap.S().Warnf("Error while removing layer %s", id)
 		return err
 	}
 
@@ -124,10 +124,10 @@ func (d *Driver) Get(id, mountLabel string) (string, error) {
 
 	ret, err := C.alloc_chainfs(cID)
 	if int(ret) != 0 {
-		dlog.Warnf("Error while creating a chain FS for %s", id)
+		zap.S().Warnf("Error while creating a chain FS for %s", id)
 		return "", err
 	} else {
-		dlog.Debugf("Created a chain FS for %s", id)
+		zap.S().Debugf("Created a chain FS for %s", id)
 		chainPath := path.Join(virtPath, id)
 		return chainPath, err
 	}
@@ -136,7 +136,7 @@ func (d *Driver) Get(id, mountLabel string) (string, error) {
 // Put releases the system resources for the specified id,
 // e.g, unmounting layered filesystem.
 func (d *Driver) Put(id string) error {
-	dlog.Debugf("Releasing chain FS for %s", id)
+	zap.S().Debugf("Releasing chain FS for %s", id)
 
 	cID := C.CString(id)
 	_, err := C.release_chainfs(cID)
@@ -169,17 +169,17 @@ func (d *Driver) ApplyDiff(id string, parent string, diff archive.Reader) (size 
 	dir := path.Join(virtPath, id)
 	// dir := path.Join("/tmp/chainfs/", id)
 
-	dlog.Infof("Applying diff at path %s\n", dir)
+	zap.S().Infof("Applying diff at path %s\n", dir)
 
 	if err := chrootarchive.UntarUncompressed(diff, dir, nil); err != nil {
-		dlog.Warnf("Error while applying diff to %s: %v", id, err)
+		zap.S().Warnf("Error while applying diff to %s: %v", id, err)
 		return 0, err
 	}
 
 	// show invalid whiteouts warning.
 	files, err := ioutil.ReadDir(path.Join(dir, archive.WhiteoutLinkDir))
 	if err == nil && len(files) > 0 {
-		dlog.Warnf("Archive contains aufs hardlink references that are not supported.")
+		zap.S().Warnf("Archive contains aufs hardlink references that are not supported.")
 	}
 
 	return d.DiffSize(id, parent)

--- a/graph/drivers/layer0/layer0.go
+++ b/graph/drivers/layer0/layer0.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"go.pedge.io/dlog"
+	"go.uber.org/zap"
 
 	"github.com/docker/docker/daemon/graphdriver"
 	"github.com/docker/docker/daemon/graphdriver/overlay"
@@ -85,7 +85,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 			return nil, fmt.Errorf("Unknown option %s\n", key)
 		}
 	}
-	dlog.Infof("Layer0 volume driver: %v", volumeDriver)
+	zap.S().Infof("Layer0 volume driver: %v", volumeDriver)
 	volDriver, err := volumedrivers.Get(volumeDriver)
 	if err != nil {
 		return nil, err
@@ -155,7 +155,7 @@ func (l *Layer0) create(id, parent string) (string, *Layer0Vol, error) {
 
 	vol, ok := l.volumes[id]
 	if !ok {
-		dlog.Warnf("Failed to find layer0 volume for id %v", id)
+		zap.S().Warnf("Failed to find layer0 volume for id %v", id)
 		return id, nil, nil
 	}
 
@@ -165,7 +165,7 @@ func (l *Layer0) create(id, parent string) (string, *Layer0Vol, error) {
 	// If we don't find a volume configured for this image,
 	// then don't track layer0
 	if err != nil || vols == nil {
-		dlog.Infof("Failed to find configured volume for id %v", vol.parent)
+		zap.S().Infof("Failed to find configured volume for id %v", vol.parent)
 		delete(l.volumes, id)
 		return id, nil, nil
 	}
@@ -179,7 +179,7 @@ func (l *Layer0) create(id, parent string) (string, *Layer0Vol, error) {
 		}
 	}
 	if index == -1 {
-		dlog.Infof("Failed to find free volume for id %v", vol.parent)
+		zap.S().Infof("Failed to find free volume for id %v", vol.parent)
 		delete(l.volumes, id)
 		return id, nil, nil
 	}
@@ -191,14 +191,14 @@ func (l *Layer0) create(id, parent string) (string, *Layer0Vol, error) {
 	if l.volDriver.Type() == api.DriverType_DRIVER_TYPE_BLOCK {
 		_, err := l.volDriver.Attach(vols[index].Id, nil)
 		if err != nil {
-			dlog.Errorf("Failed to attach volume %v", vols[index].Id)
+			zap.S().Errorf("Failed to attach volume %v", vols[index].Id)
 			delete(l.volumes, id)
 			return id, nil, nil
 		}
 	}
 	err = l.volDriver.Mount(vols[index].Id, mountPath, nil)
 	if err != nil {
-		dlog.Errorf("Failed to mount volume %v at path %v",
+		zap.S().Errorf("Failed to mount volume %v at path %v",
 			vols[index].Id, mountPath)
 		delete(l.volumes, id)
 		return id, nil, nil
@@ -249,7 +249,7 @@ func (l *Layer0) Remove(id string) error {
 			upperDir := path.Join(path.Join(l.home, l.realID(id)), "upper")
 			err := os.Rename(upperDir, path.Join(v.path, "upper"))
 			if err != nil {
-				dlog.Warnf("Failed in rename(%v): %v", id, err)
+				zap.S().Warnf("Failed in rename(%v): %v", id, err)
 			}
 			l.Driver.Remove(l.realID(id))
 
@@ -264,7 +264,7 @@ func (l *Layer0) Remove(id string) error {
 			delete(l.volumes, v.id)
 		}
 	} else {
-		dlog.Warnf("Failed to find layer0 vol for id %v", id)
+		zap.S().Warnf("Failed to find layer0 vol for id %v", id)
 	}
 	return err
 }

--- a/pkg/chattr/chattr.go
+++ b/pkg/chattr/chattr.go
@@ -8,7 +8,7 @@ import (
 	"path"
 	"strings"
 
-	"go.pedge.io/dlog"
+	"go.uber.org/zap"
 )
 
 const (
@@ -49,13 +49,13 @@ func RemoveImmutable(path string) error {
 func IsImmutable(path string) bool {
 	lsattrBin := which(lsattrCmd)
 	if _, err := os.Stat(path); err != nil {
-		dlog.Errorf("Failed to stat mount path:%v", err)
+		zap.S().Errorf("Failed to stat mount path:%v", err)
 		return true
 	}
 	op, err := exec.Command(lsattrBin, "-d", path).CombinedOutput()
 	if err != nil {
 		// Cannot get path status, return true so that immutable bit is not reverted
-		dlog.Errorf("Error listing attrs for %v err:%v", path, string(op))
+		zap.S().Errorf("Error listing attrs for %v err:%v", path, string(op))
 		return true
 	}
 	// 'lsattr -d' output is a single line with 2 fields separated by space; 1st one
@@ -65,11 +65,11 @@ func IsImmutable(path string) bool {
 	attrs := strings.Split(string(op), " ")
 	if len(attrs) != 2 {
 		// Cannot get path status, return true so that immutable bit is not reverted
-		dlog.Errorf("Invalid lsattr output %v", string(op))
+		zap.S().Errorf("Invalid lsattr output %v", string(op))
 		return true
 	}
 	if strings.Contains(attrs[0], "i") {
-		dlog.Warnf("Path %v already set to immutable", path)
+		zap.S().Warnf("Path %v already set to immutable", path)
 		return true
 	}
 

--- a/pkg/flexvolume/api_server.go
+++ b/pkg/flexvolume/api_server.go
@@ -3,9 +3,10 @@ package flexvolume
 import (
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/empty"
-	"go.pedge.io/dlog"
 	"golang.org/x/net/context"
 )
 
@@ -51,10 +52,10 @@ func checkClientError(err error) (*empty.Empty, error) {
 
 func log(methodName string, request proto.Message, response proto.Message, err error, duration time.Duration) {
 	if err != nil {
-		dlog.Errorf("Method: %v Request: %v Response: %v Error: %v Duration: %v",
+		zap.S().Errorf("Method: %v Request: %v Response: %v Error: %v Duration: %v",
 			methodName, request.String(), response.String(), err.Error(), duration.String())
 	} else {
-		dlog.Infof("Method: %v Request: %v Response: %v Error: %v Duration: %v",
+		zap.S().Infof("Method: %v Request: %v Response: %v Error: %v Duration: %v",
 			methodName, request.String(), response.String(), err.Error(), duration.String())
 	}
 }

--- a/pkg/flexvolume/client.go
+++ b/pkg/flexvolume/client.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"os"
 
+	"go.uber.org/zap"
+
 	"github.com/golang/protobuf/ptypes/empty"
-	"go.pedge.io/dlog"
 	"golang.org/x/net/context"
 )
 
@@ -104,6 +105,6 @@ func newAttachSuccessOutput(deviceID string) []byte {
 
 func writeOutput(output []byte) {
 	if _, err := os.Stdout.Write(output); err != nil {
-		dlog.Warnf("Unable to write output to stdout : %s", err.Error())
+		zap.S().Warnf("Unable to write output to stdout : %s", err.Error())
 	}
 }

--- a/pkg/flexvolume/cmd/flexvolume/main.go
+++ b/pkg/flexvolume/cmd/flexvolume/main.go
@@ -4,8 +4,8 @@ import (
 	"github.com/libopenstorage/openstorage/pkg/flexvolume"
 	"github.com/spf13/cobra"
 	"go.pedge.io/env"
-	"go.pedge.io/lion/env"
 	"go.pedge.io/pkg/cobra"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
 
@@ -19,9 +19,12 @@ func main() {
 
 func do(appEnvObj interface{}) error {
 	appEnv := appEnvObj.(*appEnv)
-	if err := envlion.Setup(); err != nil {
-		return err
+
+	logger, err := zap.NewProduction()
+	if err != nil {
+		panic(err.Error())
 	}
+	zap.ReplaceGlobals(logger)
 
 	initCmd := &cobra.Command{
 		Use: "init",

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -15,11 +15,12 @@ import (
 	"syscall"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/libopenstorage/openstorage/pkg/chattr"
 	"github.com/libopenstorage/openstorage/pkg/keylock"
 	"github.com/libopenstorage/openstorage/pkg/options"
 	"github.com/libopenstorage/openstorage/pkg/sched"
-	"go.pedge.io/dlog"
 )
 
 // Manager defines the interface for keep track of volume driver mounts.
@@ -349,7 +350,7 @@ func (m *Mounter) Mount(
 	}
 	dev, ok := m.hasPath(path)
 	if ok && dev != device {
-		dlog.Warnf("cannot mount %q,  device %q is mounted at %q", device, dev, path)
+		zap.S().Warnf("cannot mount %q,  device %q is mounted at %q", device, dev, path)
 		return ErrExist
 	}
 	m.Lock()
@@ -369,7 +370,7 @@ func (m *Mounter) Mount(
 
 	// Validate input params
 	if fs != info.Fs {
-		dlog.Warnf("%s Existing mountpoint has fs %q cannot change to %q",
+		zap.S().Warnf("%s Existing mountpoint has fs %q cannot change to %q",
 			device, info.Fs, fs)
 		return ErrEinval
 	}
@@ -444,7 +445,7 @@ func (m *Mounter) Unmount(
 			return err
 		}
 		if pathExists := m.deletePath(path); !pathExists {
-			dlog.Warnf("Path %q for device %q does not exist in pathMap",
+			zap.S().Warnf("Path %q for device %q does not exist in pathMap",
 				path, device)
 		}
 		// Blow away this mountpoint.
@@ -457,7 +458,7 @@ func (m *Mounter) Unmount(
 
 		return nil
 	}
-	dlog.Warnf("Device %q is not mounted at path %q", path, device)
+	zap.S().Warnf("Device %q is not mounted at path %q", path, device)
 	return nil
 }
 
@@ -467,18 +468,18 @@ func (m *Mounter) removeMountPath(path string) error {
 
 	if devicePath, mounted := m.HasTarget(path); !mounted {
 		if err := m.makeMountpathWriteable(path); err != nil {
-			dlog.Warnf("Failed to make path: %v writeable. Err: %v", path, err)
+			zap.S().Warnf("Failed to make path: %v writeable. Err: %v", path, err)
 			return err
 		}
 	} else {
-		dlog.Infof("Not making %v writeable as %v is mounted on it", path, devicePath)
+		zap.S().Infof("Not making %v writeable as %v is mounted on it", path, devicePath)
 		return nil
 	}
 
 	if _, err := os.Stat(path); err == nil {
-		dlog.Infof("Removing mount path directory: %v", path)
+		zap.S().Infof("Removing mount path directory: %v", path)
 		if err = os.Remove(path); err != nil {
-			dlog.Warnf("Failed to remove path: %v Err: %v", path, err)
+			zap.S().Warnf("Failed to remove path: %v Err: %v", path, err)
 			return err
 		}
 	}
@@ -496,7 +497,7 @@ func (m *Mounter) RemoveMountPath(mountPath string, opts map[string]string) erro
 
 			if err = os.Symlink(mountPath, symlinkPath); err != nil {
 				if !os.IsExist(err) {
-					dlog.Errorf("Error creating sym link %s => %s. Err: %v", symlinkPath, mountPath, err)
+					zap.S().Errorf("Error creating sym link %s => %s. Err: %v", symlinkPath, mountPath, err)
 				}
 			}
 
@@ -513,7 +514,7 @@ func (m *Mounter) RemoveMountPath(mountPath string, opts map[string]string) erro
 				sched.Periodic(time.Second),
 				time.Now().Add(mountPathRemoveDelay),
 				true /* run only once */); err != nil {
-				dlog.Errorf("Failed to schedule task to remove path:%v. Err: %v", mountPath, err)
+				zap.S().Errorf("Failed to schedule task to remove path:%v. Err: %v", mountPath, err)
 				return err
 			}
 		} else {
@@ -527,7 +528,7 @@ func (m *Mounter) RemoveMountPath(mountPath string, opts map[string]string) erro
 func (m *Mounter) EmptyTrashDir() error {
 	files, err := ioutil.ReadDir(m.trashLocation)
 	if err != nil {
-		dlog.Errorf("failed to read trash dir: %s. Err: %v", m.trashLocation, err)
+		zap.S().Errorf("failed to read trash dir: %s. Err: %v", m.trashLocation, err)
 		return err
 	}
 
@@ -536,7 +537,7 @@ func (m *Mounter) EmptyTrashDir() error {
 			func(sched.Interval) {
 				e := m.removeSoftlinkAndTarget(path.Join(m.trashLocation, file.Name()))
 				if e != nil {
-					dlog.Errorf("failed to remove link: %s. Err: %v", path.Join(m.trashLocation, file.Name()), e)
+					zap.S().Errorf("failed to remove link: %s. Err: %v", path.Join(m.trashLocation, file.Name()), e)
 					err = e
 					// continue with other directories
 				}
@@ -544,7 +545,7 @@ func (m *Mounter) EmptyTrashDir() error {
 			sched.Periodic(time.Second),
 			time.Now().Add(mountPathRemoveDelay),
 			true /* run only once */); err != nil {
-			dlog.Errorf("Failed to cleanup of trash dir. Err: %v", err)
+			zap.S().Errorf("Failed to cleanup of trash dir. Err: %v", err)
 			return err
 		}
 	}

--- a/volume/drivers/aws/aws.go
+++ b/volume/drivers/aws/aws.go
@@ -9,6 +9,8 @@ import (
 	"syscall"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -22,7 +24,6 @@ import (
 	"github.com/libopenstorage/openstorage/volume"
 	"github.com/libopenstorage/openstorage/volume/drivers/common"
 	"github.com/portworx/kvdb"
-	"go.pedge.io/dlog"
 )
 
 const (
@@ -71,7 +72,7 @@ func Init(params map[string]string) (volume.VolumeDriver, error) {
 	if err != nil {
 		return nil, err
 	}
-	dlog.Infof("AWS instance %v zone %v", instance, zone)
+	zap.S().Infof("AWS instance %v zone %v", instance, zone)
 
 	accessKey, secretKey, err := authKeys(params)
 	if err != nil {
@@ -208,7 +209,7 @@ func (d *Driver) Create(
 	}
 	resp, err := d.ops.Create(ec2Vol, locator.VolumeLabels)
 	if err != nil {
-		dlog.Warnf("Failed in CreateVolumeRequest :%v", err)
+		zap.S().Warnf("Failed in CreateVolumeRequest :%v", err)
 		return "", err
 	}
 
@@ -234,7 +235,7 @@ func (d *Driver) Create(
 		return "", err
 	}
 
-	dlog.Infof("aws preparing volume %s...", *vol.VolumeId)
+	zap.S().Infof("aws preparing volume %s...", *vol.VolumeId)
 	if err := d.Format(volume.Id); err != nil {
 		return "", err
 	}
@@ -392,7 +393,7 @@ func (d *Driver) volumeState(ec2VolState *string) api.VolumeState {
 	case ec2.VolumeAttachmentStateAttaching, ec2.VolumeAttachmentStateDetaching:
 		return api.VolumeState_VOLUME_STATE_PENDING
 	default:
-		dlog.Warnf("Failed to translate EC2 volume status %v", ec2VolState)
+		zap.S().Warnf("Failed to translate EC2 volume status %v", ec2VolState)
 	}
 	return api.VolumeState_VOLUME_STATE_ERROR
 }
@@ -426,7 +427,7 @@ func (d *Driver) Format(volumeID string) error {
 	cmd := "/sbin/mkfs." + volume.Spec.Format.SimpleString()
 	o, err := exec.Command(cmd, devicePath).Output()
 	if err != nil {
-		dlog.Warnf("Failed to run command %v %v: %v", cmd, devicePath, o)
+		zap.S().Warnf("Failed to run command %v %v: %v", cmd, devicePath, o)
 		return err
 	}
 	volume.Format = volume.Spec.Format
@@ -439,11 +440,11 @@ func (d *Driver) Detach(volumeID string, options map[string]string) error {
 	}
 	volume, err := d.GetVol(volumeID)
 	if err != nil {
-		dlog.Warnf("Volume %s could not be located, attempting to detach anyway", volumeID)
+		zap.S().Warnf("Volume %s could not be located, attempting to detach anyway", volumeID)
 	} else {
 		volume.DevicePath = ""
 		if err := d.UpdateVol(volume); err != nil {
-			dlog.Warnf("Failed to update volume", volumeID)
+			zap.S().Warnf("Failed to update volume", volumeID)
 		}
 	}
 	return nil
@@ -491,7 +492,7 @@ func (d *Driver) Unmount(volumeID string, mountpath string, options map[string]s
 }
 
 func (d *Driver) Shutdown() {
-	dlog.Printf("%s Shutting down", Name)
+	zap.S().Infof("%s Shutting down", Name)
 }
 
 func (d *Driver) Set(volumeID string, locator *api.VolumeLocator, spec *api.VolumeSpec) error {

--- a/volume/drivers/buse/buse.go
+++ b/volume/drivers/buse/buse.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"syscall"
 
-	"go.pedge.io/dlog"
+	"go.uber.org/zap"
 
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/libopenstorage/openstorage/cluster"
@@ -117,19 +117,19 @@ func Init(params map[string]string) (volume.VolumeDriver, error) {
 			}
 		}
 	} else {
-		dlog.Println("Could not enumerate Volumes, ", err)
+		zap.S().Info("Could not enumerate Volumes, ", err)
 	}
 
 	inst.cl = &clusterListener{}
 	c, err := cluster.Inst()
 	if err != nil {
-		dlog.Println("BUSE initializing in single node mode")
+		zap.S().Info("BUSE initializing in single node mode")
 	} else {
-		dlog.Println("BUSE initializing in clustered mode")
+		zap.S().Info("BUSE initializing in clustered mode")
 		c.AddEventListener(inst.cl)
 	}
 
-	dlog.Println("BUSE initialized and driver mounted at: ", BuseMountPath)
+	zap.S().Info("BUSE initialized and driver mounted at: ", BuseMountPath)
 	return inst, nil
 }
 
@@ -171,12 +171,12 @@ func (d *driver) Create(
 	buseFile := path.Join(BuseMountPath, volumeID)
 	f, err := os.Create(buseFile)
 	if err != nil {
-		dlog.Println(err)
+		zap.S().Info(err)
 		return "", err
 	}
 
 	if err := f.Truncate(int64(spec.Size)); err != nil {
-		dlog.Println(err)
+		zap.S().Info(err)
 		return "", err
 	}
 
@@ -187,22 +187,22 @@ func (d *driver) Create(
 	nbd := Create(bd, volumeID, int64(spec.Size))
 	bd.nbd = nbd
 
-	dlog.Infof("Connecting to NBD...")
+	zap.S().Infof("Connecting to NBD...")
 	dev, err := bd.nbd.Connect()
 	if err != nil {
-		dlog.Println(err)
+		zap.S().Info(err)
 		return "", err
 	}
 
-	dlog.Infof("Formatting %s with %v", dev, spec.Format)
+	zap.S().Infof("Formatting %s with %v", dev, spec.Format)
 	cmd := "/sbin/mkfs." + spec.Format.SimpleString()
 	o, err := exec.Command(cmd, dev).Output()
 	if err != nil {
-		dlog.Warnf("Failed to run command %v %v: %v", cmd, dev, o)
+		zap.S().Warnf("Failed to run command %v %v: %v", cmd, dev, o)
 		return "", err
 	}
 
-	dlog.Infof("BUSE mapped NBD device %s (size=%v) to block file %s", dev,
+	zap.S().Infof("BUSE mapped NBD device %s (size=%v) to block file %s", dev,
 		spec.Size, buseFile)
 
 	v := common.NewVolume(
@@ -226,14 +226,14 @@ func (d *driver) Create(
 func (d *driver) Delete(volumeID string) error {
 	v, err := d.GetVol(volumeID)
 	if err != nil {
-		dlog.Println(err)
+		zap.S().Info(err)
 		return err
 	}
 
 	bd, ok := d.buseDevices[v.DevicePath]
 	if !ok {
 		err = fmt.Errorf("Cannot locate a BUSE device for %s", v.DevicePath)
-		dlog.Println(err)
+		zap.S().Info(err)
 		return err
 	}
 
@@ -242,11 +242,11 @@ func (d *driver) Delete(volumeID string) error {
 	bd.f.Close()
 	bd.nbd.Disconnect()
 
-	dlog.Infof("BUSE deleted volume %v at NBD device %s", volumeID,
+	zap.S().Infof("BUSE deleted volume %v at NBD device %s", volumeID,
 		v.DevicePath)
 
 	if err := d.DeleteVol(volumeID); err != nil {
-		dlog.Println(err)
+		zap.S().Info(err)
 		return err
 	}
 
@@ -269,7 +269,7 @@ func (d *driver) Mount(volumeID string, mountpath string, options map[string]str
 		return fmt.Errorf("Failed to mount %v at %v: %v", v.DevicePath, mountpath, err)
 	}
 
-	dlog.Infof("BUSE mounted NBD device %s at %s", v.DevicePath, mountpath)
+	zap.S().Infof("BUSE mounted NBD device %s at %s", v.DevicePath, mountpath)
 
 	if v.AttachPath == nil {
 		v.AttachPath = make([]string, 1)
@@ -351,7 +351,7 @@ func (d *driver) Detach(volumeID string, options map[string]string) error {
 }
 
 func (d *driver) Shutdown() {
-	dlog.Printf("%s Shutting down", Name)
+	zap.S().Infof("%s Shutting down", Name)
 	syscall.Unmount(BuseMountPath, 0)
 }
 

--- a/volume/drivers/buse/nbd.go
+++ b/volume/drivers/buse/nbd.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"syscall"
 
-	"go.pedge.io/dlog"
+	"go.uber.org/zap"
 )
 
 const (
@@ -101,7 +101,7 @@ var (
 // Create creates a NBD type interface
 func Create(device Device, id string, size int64) *NBD {
 	if shuttingDown {
-		dlog.Warnf("Cannot create NBD device during shutdown")
+		zap.S().Warnf("Cannot create NBD device during shutdown")
 		return nil
 	}
 
@@ -171,7 +171,7 @@ func (nbd *NBD) Connect() (dev string, err error) {
 			continue // Busy.
 		}
 
-		dlog.Infof("Attempting to open device %v", dev)
+		zap.S().Infof("Attempting to open device %v", dev)
 		if nbd.deviceFile, err = os.Open(dev); err == nil {
 			// Possible candidate.
 			ioctl(nbd.deviceFile.Fd(), BLKROSET, 0)
@@ -206,28 +206,28 @@ func (nbd *NBD) Disconnect() {
 	nbd.mutex.Lock()
 	defer nbd.mutex.Unlock()
 
-	dlog.Infof("Disconnecting device %v...", nbd.devicePath)
+	zap.S().Infof("Disconnecting device %v...", nbd.devicePath)
 
 	syscall.Unmount(nbd.devicePath, 0)
 	if nbd.IsConnected() {
-		dlog.Infof("Issuing a disconnect on %v", nbd.devicePath)
+		zap.S().Infof("Issuing a disconnect on %v", nbd.devicePath)
 		ioctl(nbd.deviceFile.Fd(), NBD_DISCONNECT, 0)
-		dlog.Infof("Clearing NBD queue %v", nbd.devicePath)
+		zap.S().Infof("Clearing NBD queue %v", nbd.devicePath)
 		ioctl(nbd.deviceFile.Fd(), NBD_CLEAR_QUE, 0)
-		dlog.Infof("Clearing NBD socket %v", nbd.devicePath)
+		zap.S().Infof("Clearing NBD socket %v", nbd.devicePath)
 		ioctl(nbd.deviceFile.Fd(), NBD_CLEAR_SOCK, 0)
-		dlog.Infof("Closing NBD device file %v", nbd.devicePath)
+		zap.S().Infof("Closing NBD device file %v", nbd.devicePath)
 		nbd.deviceFile.Close()
 		nbd.deviceFile = nil
 
 		dummy := make([]byte, 1)
-		dlog.Infof("Waking up control socket for %v", nbd.devicePath)
+		zap.S().Infof("Waking up control socket for %v", nbd.devicePath)
 		syscall.Write(nbd.socket, dummy)
-		dlog.Infof("Closing control socket for %v", nbd.devicePath)
+		zap.S().Infof("Closing control socket for %v", nbd.devicePath)
 		syscall.Close(nbd.socket)
 		nbd.socket = 0
 	}
-	dlog.Infof("Disconnected device %v", nbd.devicePath)
+	zap.S().Infof("Disconnected device %v", nbd.devicePath)
 }
 
 func (nbd *NBD) connect() {
@@ -237,7 +237,7 @@ func (nbd *NBD) connect() {
 	// NBD_CONNECT does not return until disconnect.
 	ioctl(nbd.deviceFile.Fd(), NBD_CONNECT, 0)
 
-	dlog.Infof("Closing device file %s", nbd.devicePath)
+	zap.S().Infof("Closing device file %s", nbd.devicePath)
 }
 
 // Handle block requests.
@@ -248,12 +248,12 @@ func (nbd *NBD) handle() {
 	for {
 		bytes, err := syscall.Read(nbd.socket, buf[0:28])
 		if nbd.deviceFile == nil {
-			dlog.Infof("Disconnecting device %s", nbd.devicePath)
+			zap.S().Infof("Disconnecting device %s", nbd.devicePath)
 			return
 		}
 
 		if bytes < 0 || err != nil {
-			dlog.Errorf("Error reading from device %s", nbd.devicePath)
+			zap.S().Errorf("Error reading from device %s", nbd.devicePath)
 			nbd.Disconnect()
 			return
 		}
@@ -285,7 +285,7 @@ func (nbd *NBD) handle() {
 				binary.BigEndian.PutUint32(buf[4:8], 0)
 				syscall.Write(nbd.socket, buf[0:16])
 			case NBD_CMD_DISC:
-				dlog.Infof("Disconnecting device %s", nbd.devicePath)
+				zap.S().Infof("Disconnecting device %s", nbd.devicePath)
 				nbd.Disconnect()
 				return
 			case NBD_CMD_FLUSH:
@@ -295,12 +295,12 @@ func (nbd *NBD) handle() {
 				binary.BigEndian.PutUint32(buf[4:8], 1)
 				syscall.Write(nbd.socket, buf[0:16])
 			default:
-				dlog.Errorf("Unknown command received on device %s", nbd.devicePath)
+				zap.S().Errorf("Unknown command received on device %s", nbd.devicePath)
 				nbd.Disconnect()
 				return
 			}
 		default:
-			dlog.Errorf("Invalid packet command received on device %s", nbd.devicePath)
+			zap.S().Errorf("Invalid packet command received on device %s", nbd.devicePath)
 			nbd.Disconnect()
 			return
 		}
@@ -340,16 +340,16 @@ done:
 		signal.Notify(c, os.Interrupt)
 		<-c
 
-		dlog.Infof("NBD shutting down due to SIGINT")
+		zap.S().Infof("NBD shutting down due to SIGINT")
 		shuttingDown = true
 		globalMutex.Lock()
 		defer globalMutex.Unlock()
 
 		for id, d := range nbdDevices {
-			dlog.Infof("Disconnecting device %v", id)
+			zap.S().Infof("Disconnecting device %v", id)
 			d.Disconnect()
 		}
-		dlog.Infof("Done cleaning up NBD devices")
+		zap.S().Infof("Done cleaning up NBD devices")
 		os.Exit(0)
 	}()
 }

--- a/volume/drivers/common/default_store_enumerator_test.go
+++ b/volume/drivers/common/default_store_enumerator_test.go
@@ -3,7 +3,7 @@ package common
 import (
 	"testing"
 
-	"go.pedge.io/dlog"
+	"go.uber.org/zap"
 
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/libopenstorage/openstorage/volume"
@@ -18,12 +18,12 @@ var (
 )
 
 func init() {
-	kv, err := kvdb.New(mem.Name, "driver_test", []string{}, nil, dlog.Panicf)
+	kv, err := kvdb.New(mem.Name, "driver_test", []string{}, nil, zap.S().Panicf)
 	if err != nil {
-		dlog.Panicf("Failed to initialize KVDB")
+		zap.S().Panicf("Failed to initialize KVDB")
 	}
 	if err := kvdb.SetInstance(kv); err != nil {
-		dlog.Panicf("Failed to set KVDB instance")
+		zap.S().Panicf("Failed to set KVDB instance")
 	}
 	testEnumerator = NewDefaultStoreEnumerator("enumerator_test", kv)
 }

--- a/volume/drivers/coprhd/coprhd.go
+++ b/volume/drivers/coprhd/coprhd.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"gopkg.in/jmcvetta/napping.v3"
+	"go.uber.org/zap"
 
-	"go.pedge.io/dlog"
+	"gopkg.in/jmcvetta/napping.v3"
 
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/libopenstorage/openstorage/volume"
@@ -150,7 +150,7 @@ func (d *driver) Create(
 	s, err := d.getAuthSession()
 
 	if err != nil {
-		dlog.Errorf("Failed to create session: %s", err.Error())
+		zap.S().Errorf("Failed to create session: %s", err.Error())
 		return "", err
 	}
 
@@ -215,7 +215,7 @@ func (d *driver) Set(
 }
 
 func (d *driver) Shutdown() {
-	dlog.Infof("%s Shutting down", Name)
+	zap.S().Infof("%s Shutting down", Name)
 }
 
 func (d *driver) Snapshot(

--- a/volume/drivers/test/driver.go
+++ b/volume/drivers/test/driver.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"go.pedge.io/dlog"
+	"go.uber.org/zap"
 
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/libopenstorage/openstorage/volume"
@@ -18,13 +18,13 @@ import (
 )
 
 func init() {
-	kv, err := kvdb.New(mem.Name, "driver_test", []string{}, nil, dlog.Panicf)
+	kv, err := kvdb.New(mem.Name, "driver_test", []string{}, nil, zap.S().Panicf)
 	if err != nil {
-		dlog.Panicf("Failed to intialize KVDB")
+		zap.S().Panicf("Failed to intialize KVDB")
 	}
 	err = kvdb.SetInstance(kv)
 	if err != nil {
-		dlog.Panicf("Failed to set KVDB instance")
+		zap.S().Panicf("Failed to set KVDB instance")
 	}
 }
 

--- a/volume/drivers/vfs/vfs.go
+++ b/volume/drivers/vfs/vfs.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"time"
 
-	"go.pedge.io/dlog"
+	"go.uber.org/zap"
 
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/libopenstorage/openstorage/volume"
@@ -99,7 +99,7 @@ func (d *driver) MountedAt(mountpath string) string {
 func (d *driver) Mount(volumeID string, mountpath string, options map[string]string) error {
 	v, err := d.GetVol(volumeID)
 	if err != nil {
-		dlog.Println(err)
+		zap.S().Info(err)
 		return err
 	}
 	if len(v.AttachPath) > 0 && len(v.AttachPath) > 0 {
@@ -112,7 +112,7 @@ func (d *driver) Mount(volumeID string, mountpath string, options map[string]str
 		string(v.Spec.Format),
 		syscall.MS_BIND, "",
 	); err != nil {
-		dlog.Printf("Cannot mount %s at %s because %+v",
+		zap.S().Infof("Cannot mount %s at %s because %+v",
 			filepath.Join(volume.VolumeBase, string(volumeID)),
 			mountpath,
 			err,
@@ -166,7 +166,7 @@ func (d *driver) Shutdown() {}
 func (d *driver) fsFreeze(volumeID string, freeze bool) error {
 	v, err := d.GetVol(volumeID)
 	if err != nil {
-		dlog.Println(err)
+		zap.S().Info(err)
 		return err
 	}
 	if len(v.AttachPath) == 0 {


### PR DESCRIPTION
This starts the work to move to github.com/uber-go/zap. **Vendor still needs to be done, as well as verification that everything works as expected.**

Zap exposes a `*Logger` object, which works with the primary Zap API, and a `*SugaredLogger` object, which exposes a logger more similar to other Golang loggers. By default, a no-op logger is the global logger, so you have to register a logger at startup.

There's a lot of configuration options, but two loggers are easily created with https://godoc.org/go.uber.org/zap#NewDevelopment and https://godoc.org/go.uber.org/zap#NewProduction. I've set this up to use `NewProduction`, but `NewDevelopment` might be closer to what you would expect.
