### PR TITLE
Additional keys for extra info needed to get the secrets

### DIFF
--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -7,8 +7,12 @@ import (
 // Options specifies keys from a key-value pair
 // that can be passed in to the APIS
 const (
-	// OptionsSecret Key to use for secure devices
-	OptionsSecret = "SECRET_KEY"
+	// OptionsSecret Secret used to get secret for secure devices
+	OptionsSecret = "SECRET_NAME"
+	// OptionsSecretKey Key used to secure devices
+	OptionsSecretKey = "SECRET_KEY"
+	// OptionsSecretContext Context used to provide additional info to retrive secret
+	OptionsSecretContext = "SECRET_CONTEXT"
 	// OptionsUnmountBeforeDetach Issue an Unmount before trying the detach
 	OptionsUnmountBeforeDetach = "UNMOUNT_BEFORE_DETACH"
 	// OptionsDeleteAfterUnmount Delete the mount path after Unmount


### PR DESCRIPTION
In case of kubernetes secrets, we need namespace, the secret name
and the key that is used to encrypt volumes.

Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
These extra keys are needed especially for kubernetes secrets, but can be used 
by other secrets stores if they have namespaces

**Which issue(s) this PR fixes** (optional)

**Special notes for your reviewer**:

