### PR TITLE
nfs - validate volume names

### DIFF
--- a/volume/drivers/nfs/nfs.go
+++ b/volume/drivers/nfs/nfs.go
@@ -162,7 +162,7 @@ func (d *driver) getNFSPath(v *api.Volume) (string, error) {
 	server, ok := locator.VolumeLabels["server"]
 	if !ok {
 		dlog.Warnf("No server label found on volume")
-		return "", errors.New("No server label found on volume: " + v.Id)
+		return "", fmt.Errorf("No server label found on volume: " + v.Id)
 	}
 
 	return path.Join(nfsMountPath, server), nil
@@ -212,18 +212,18 @@ func (d *driver) Create(
 	source *api.Source,
 	spec *api.VolumeSpec) (string, error) {
 
-	if locator.Name == "" {
-		return "", errors.New("volume name cannot be empty")
+	if len(locator.Name) == 0 {
+		return "", fmt.Errorf("volume name cannot be empty")
 	}
 
 	if hasSpaces := strings.Contains(locator.Name, " "); hasSpaces {
-		return "", errors.New("volume name cannot contain space characters")
+		return "", fmt.Errorf("volume name cannot contain space characters")
 	}
 
 	volumeID := strings.TrimSuffix(uuid.New(), "\n")
 
 	if _, err := d.GetVol(volumeID); err == nil {
-		return "", errors.New("volume with that id already exists")
+		return "", fmt.Errorf("volume with that id already exists")
 	}
 
 	//snapshot passes nil volumelabels


### PR DESCRIPTION
Signed-off-by: bouviti <timothy.bouvier@verizon.com>

**What this PR does / why we need it**:
nfs volume driver doesn't check for empty volume names or spaces in volume name during create. nfs volume driver doesn't use uuid for volume id. This PR fixes those things

**Which issue(s) this PR fixes** (optional)
Closes #321 

**Special notes for your reviewer**:

