### PR TITLE
Make gossip port configurable

### DIFF
--- a/api/client/cluster/client.go
+++ b/api/client/cluster/client.go
@@ -132,7 +132,7 @@ func (c *clusterClient) Shutdown() error {
 	return nil
 }
 
-func (c *clusterClient) Start(int, bool) error {
+func (c *clusterClient) Start(int, bool, string) error {
 	return nil
 }
 

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -260,7 +260,7 @@ type Cluster interface {
 	// It also causes this node to join the cluster.
 	// nodeInitialized indicates if the caller of this method expects the node
 	// to have been in an already-initialized state.
-	Start(clusterSize int, nodeInitialized bool) error
+	Start(clusterSize int, nodeInitialized bool, gossipPort string) error
 
 	ClusterData
 	ClusterRemove

--- a/cluster/mock/cluster.mock.go
+++ b/cluster/mock/cluster.mock.go
@@ -343,15 +343,15 @@ func (mr *MockClusterMockRecorder) Shutdown() *gomock.Call {
 }
 
 // Start mocks base method
-func (m *MockCluster) Start(arg0 int, arg1 bool) error {
-	ret := m.ctrl.Call(m, "Start", arg0, arg1)
+func (m *MockCluster) Start(arg0 int, arg1 bool, arg2 string) error {
+	ret := m.ctrl.Call(m, "Start", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Start indicates an expected call of Start
-func (mr *MockClusterMockRecorder) Start(arg0, arg1 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockCluster)(nil).Start), arg0, arg1)
+func (mr *MockClusterMockRecorder) Start(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockCluster)(nil).Start), arg0, arg1, arg2)
 }
 
 // UpdateData mocks base method

--- a/cmd/osd/main.go
+++ b/cmd/osd/main.go
@@ -270,7 +270,7 @@ func start(c *cli.Context) error {
 		if err != nil {
 			return fmt.Errorf("Unable to find cluster instance: %v", err)
 		}
-		if err := cm.Start(0, false); err != nil {
+		if err := cm.Start(0, false, "9002"); err != nil {
 			return fmt.Errorf("Unable to start cluster manager: %v", err)
 		}
 	}

--- a/csi/csisanity_test.go
+++ b/csi/csisanity_test.go
@@ -76,7 +76,7 @@ func TestCSISanity(t *testing.T) {
 		t.Fatalf("Unable to find cluster instance: %v", err)
 	}
 	go func() {
-		cm.Start(0, false)
+		cm.Start(0, false, "9002")
 	}()
 
 	// Start CSI Server


### PR DESCRIPTION
Signed-off-by: Paul Theunis <paul@portworx.com>

**What this PR does / why we need it**:
Right now gossip is pinned on 9002. This causes issues for some people if that port is already taken.

If using the library it's now configurable. if using straight OSD we use 9002 still.

