### PR TITLE
Make a copy of node object

### DIFF
--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -1383,7 +1383,7 @@ func (c *ClusterManager) enumerateNodesFromCache() []api.Node {
 	i := 0
 	for _, n := range c.nodeCache {
 		n, _ := c.getNodeEntry(n.Id, &clusterDB)
-		nodes[i] = n
+		nodes[i] = *n.Copy()
 		i++
 	}
 	return nodes


### PR DESCRIPTION
Signed-off-by: ganesh@portworx.com

**What this PR does / why we need it**:
Fixes a bug. Since the value is modified by gossip, make a copy under lock.
If not enumerate returns the original and can cause concurrent read-write error.

**Which issue(s) this PR fixes** (optional)
Closes #

