### PR TITLE
Increase the goprofile trace limit to 5M.

### DIFF
--- a/pkg/dbg/profile_dump.go
+++ b/pkg/dbg/profile_dump.go
@@ -26,7 +26,7 @@ func DumpGoMemoryTrace() {
 
 // DumpGoProfile output goroutines to file.
 func DumpGoProfile() error {
-	trace := make([]byte, 1024*1024)
+	trace := make([]byte, 5120*1024)
 	len := runtime.Stack(trace, true)
 	return ioutil.WriteFile(path+time.Now().String()+".stack", trace[:len], 0644)
 }


### PR DESCRIPTION
Signed-off-by: Aditya Dani <aditya@portworx.com>

**What this PR does / why we need it**:

This will increase the go profile trace limit from 1M to 5M so that large trace files are not truncated.


