### PR TITLE
Node delete added in osdconfig

### DIFF
--- a/api/client/cluster/client.go
+++ b/api/client/cluster/client.go
@@ -324,3 +324,11 @@ func (c *clusterClient) SetNodeConf(config *osdconfig.NodeConfig) error {
 	}
 	return nil
 }
+
+func (c *clusterClient) UnsetNodeConf(nodeID string) error {
+	request := c.c.Delete().Resource(clusterPath + UriNode + "/" + nodeID)
+	if err := request.Do().Error(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/api/server/cluster.go
+++ b/api/server/cluster.go
@@ -49,6 +49,7 @@ func (c *clusterApi) Routes() []*Route {
 		{verb: "GET", path: clusterPath(client.UriNode+"/{id}", cluster.APIVersion), fn: c.getNodeConf},
 		{verb: "POST", path: clusterPath(client.UriCluster, cluster.APIVersion), fn: c.setClusterConf},
 		{verb: "POST", path: clusterPath(client.UriNode, cluster.APIVersion), fn: c.setNodeConf},
+		{verb: "DELETE", path: clusterPath(client.UriNode+"/{id}", cluster.APIVersion), fn: c.delNodeConf},
 	}
 }
 
@@ -95,7 +96,7 @@ func (c *clusterApi) getClusterConf(w http.ResponseWriter, r *http.Request) {
 //   in: path
 //   description: id to get node with
 //   required: true
-//   type: integer
+//   type: string
 // responses:
 //   '200':
 //      description: a node
@@ -115,6 +116,37 @@ func (c *clusterApi) getNodeConf(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	json.NewEncoder(w).Encode(config)
+}
+
+// swagger:operation DELETE /config/node/{id} config getNodeConfig
+//
+// Get node configuration.
+//
+// This will delete the requested node configuration object
+//
+// ---
+// produces:
+// - application/json
+// parameters:
+// - name: id
+//   in: path
+//   description: id to reference node
+//   required: true
+//   type: string
+// responses:
+//   '200'
+func (c *clusterApi) delNodeConf(w http.ResponseWriter, r *http.Request) {
+	method := "delNodeConf"
+	inst, err := cluster.Inst()
+	if err != nil {
+		c.sendError(c.name, method, w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	vars := mux.Vars(r)
+	if err := inst.UnsetNodeConf(vars["id"]); err != nil {
+		c.sendError(c.name, method, w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 }
 
 // swagger:operation POST /config/cluster config setClusterConfig

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -1825,3 +1825,7 @@ func (c *ClusterManager) SetClusterConf(config *osdconfig.ClusterConfig) error {
 func (c *ClusterManager) SetNodeConf(config *osdconfig.NodeConfig) error {
 	return c.configManager.SetNodeConf(config)
 }
+
+func (c *ClusterManager) UnsetNodeConf(nodeID string) error {
+	return c.configManager.UnsetNodeConf(nodeID)
+}

--- a/cluster/mock/cluster.mock.go
+++ b/cluster/mock/cluster.mock.go
@@ -60,6 +60,18 @@ func (mr *MockClusterMockRecorder) ClearAlert(arg0, arg1 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearAlert", reflect.TypeOf((*MockCluster)(nil).ClearAlert), arg0, arg1)
 }
 
+// DelNodeConf mocks base method
+func (m *MockCluster) DelNodeConf(arg0 string) error {
+	ret := m.ctrl.Call(m, "DelNodeConf", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DelNodeConf indicates an expected call of DelNodeConf
+func (mr *MockClusterMockRecorder) DelNodeConf(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelNodeConf", reflect.TypeOf((*MockCluster)(nil).DelNodeConf), arg0)
+}
+
 // DisableUpdates mocks base method
 func (m *MockCluster) DisableUpdates() error {
 	ret := m.ctrl.Call(m, "DisableUpdates")

--- a/cluster/mock/cluster.mock.go
+++ b/cluster/mock/cluster.mock.go
@@ -60,18 +60,6 @@ func (mr *MockClusterMockRecorder) ClearAlert(arg0, arg1 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearAlert", reflect.TypeOf((*MockCluster)(nil).ClearAlert), arg0, arg1)
 }
 
-// DelNodeConf mocks base method
-func (m *MockCluster) DelNodeConf(arg0 string) error {
-	ret := m.ctrl.Call(m, "DelNodeConf", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DelNodeConf indicates an expected call of DelNodeConf
-func (mr *MockClusterMockRecorder) DelNodeConf(arg0 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DelNodeConf", reflect.TypeOf((*MockCluster)(nil).DelNodeConf), arg0)
-}
-
 // DisableUpdates mocks base method
 func (m *MockCluster) DisableUpdates() error {
 	ret := m.ctrl.Call(m, "DisableUpdates")
@@ -364,6 +352,18 @@ func (m *MockCluster) Start(arg0 int, arg1 bool, arg2 string) error {
 // Start indicates an expected call of Start
 func (mr *MockClusterMockRecorder) Start(arg0, arg1, arg2 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockCluster)(nil).Start), arg0, arg1, arg2)
+}
+
+// UnsetNodeConf mocks base method
+func (m *MockCluster) UnsetNodeConf(arg0 string) error {
+	ret := m.ctrl.Call(m, "UnsetNodeConf", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UnsetNodeConf indicates an expected call of UnsetNodeConf
+func (mr *MockClusterMockRecorder) UnsetNodeConf(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnsetNodeConf", reflect.TypeOf((*MockCluster)(nil).UnsetNodeConf), arg0)
 }
 
 // UpdateData mocks base method

--- a/osdconfig/api.go
+++ b/osdconfig/api.go
@@ -74,6 +74,20 @@ func (manager *configManager) SetNodeConf(config *NodeConfig) error {
 	return err
 }
 
+// UnsetNodeConf deletes node config data in kvdb
+func (manager *configManager) UnsetNodeConf(nodeID string) error {
+	manager.Lock()
+	defer manager.Unlock()
+
+	if len(nodeID) == 0 {
+		return fmt.Errorf("node id cannot be nil")
+	}
+
+	// remove dode data from kvdb
+	_, err := manager.cc.Delete(getNodeKeyFromNodeID(nodeID))
+	return err
+}
+
 // WatchCluster registers user defined function as callback and sets a watch for changes
 // to cluster configuration
 func (manager *configManager) WatchCluster(name string, cb func(config *ClusterConfig) error) error {

--- a/osdconfig/api_test.go
+++ b/osdconfig/api_test.go
@@ -75,6 +75,17 @@ func TestSetGetNode(t *testing.T) {
 	if !reflect.DeepEqual(expectedConf, receivedConf) {
 		t.Fatal("expected and received values are not deep equal")
 	}
+
+	// now delete the node
+	if err := manager.UnsetNodeConf(expectedConf.NodeId); err != nil {
+		t.Fatal("error in deleting node config")
+	}
+
+	// get the cluster config value
+	_, err = manager.GetNodeConf(expectedConf.NodeId)
+	if err == nil {
+		t.Fatal("node does not exist, so this should error out")
+	}
 }
 
 func TestCallback(t *testing.T) {

--- a/osdconfig/interface.go
+++ b/osdconfig/interface.go
@@ -24,6 +24,9 @@ type ConfigCaller interface {
 	// It is assumed that the backend will notify the implementor of this interface
 	// when a change is triggered
 	SetNodeConf(config *NodeConfig) error
+
+	// UnsetNodeConf removes node config for a particular node
+	UnsetNodeConf(nodeID string) error
 }
 
 // ConfigWatcher defines watches on cluster and nodes

--- a/pkg/dbg/profile_dump.go
+++ b/pkg/dbg/profile_dump.go
@@ -26,7 +26,7 @@ func DumpGoMemoryTrace() {
 
 // DumpGoProfile output goroutines to file.
 func DumpGoProfile() error {
-	trace := make([]byte, 1024*1024)
+	trace := make([]byte, 5120*1024)
 	len := runtime.Stack(trace, true)
 	return ioutil.WriteFile(path+time.Now().String()+".stack", trace[:len], 0644)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Added node delete method in osdconfig interface. It is required for cleanup of data that in etcd
