### PR TITLE
Fix leaky http client when using HTTPS

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -143,7 +143,8 @@ func newHTTPClient(
 	responseTimeout time.Duration,
 ) *http.Client {
 	httpTransport := &http.Transport{
-		TLSClientConfig: tlsConfig,
+		DisableKeepAlives: true,
+		TLSClientConfig:   tlsConfig,
 	}
 
 	switch u.Scheme {


### PR DESCRIPTION
Signed-off-by: Paul Theunis <paul@portworx.com>

**What this PR does / why we need it**:
When doing alot of concurrent Attaches/Detaches i saw a ridiculous increase in go-routines.
After doing some research it seems net/http standard client is pretty leaky in this regard because it is trying to re-use connections and keeps them open.

