### PR TITLE
Enable disk list, create and delete outside of the instance zone for GCE

### DIFF
--- a/pkg/storageops/gce/gce.go
+++ b/pkg/storageops/gce/gce.go
@@ -207,7 +207,7 @@ func (s *gceOps) Delete(id string) error {
 	}
 
 	if !found {
-		return fmt.Errorf("disk: %s as it wasn't found", id)
+		return fmt.Errorf("failed to delete disk: %s as it wasn't found", id)
 	}
 
 	return nil

--- a/pkg/storageops/gce/gce.go
+++ b/pkg/storageops/gce/gce.go
@@ -166,15 +166,15 @@ func (s *gceOps) Create(
 		SourceImage:    v.SourceImage,
 		SourceSnapshot: v.SourceSnapshot,
 		Type:           v.Type,
-		Zone:           s.inst.Zone,
+		Zone:           path.Base(v.Zone),
 	}
 
-	resp, err := s.service.Disks.Insert(s.inst.Project, s.inst.Zone, newDisk).Do()
+	resp, err := s.service.Disks.Insert(s.inst.Project, newDisk.Zone, newDisk).Do()
 	if err != nil {
 		return nil, err
 	}
 
-	if err = s.checkDiskStatus(newDisk.Name, STATUS_READY); err != nil {
+	if err = s.checkDiskStatus(newDisk.Name, newDisk.Zone, STATUS_READY); err != nil {
 		return nil, s.rollbackCreate(resp.Name, err)
 	}
 
@@ -187,8 +187,30 @@ func (s *gceOps) Create(
 }
 
 func (s *gceOps) Delete(id string) error {
-	_, err := s.service.Disks.Delete(s.inst.Project, s.inst.Zone, id).Do()
-	return err
+	ctx := context.Background()
+	found := false
+	req := s.service.Disks.AggregatedList(s.inst.Project)
+	if err := req.Pages(ctx, func(page *compute.DiskAggregatedList) error {
+		for _, diskScopedList := range page.Items {
+			for _, disk := range diskScopedList.Disks {
+				if disk.Name == id {
+					found = true
+					_, err := s.service.Disks.Delete(s.inst.Project, path.Base(disk.Zone), id).Do()
+					return err
+				}
+			}
+		}
+		return nil
+	}); err != nil {
+		logrus.Errorf("failed to list disks: %v", err)
+		return err
+	}
+
+	if !found {
+		return fmt.Errorf("disk: %s as it wasn't found", id)
+	}
+
+	return nil
 }
 
 func (s *gceOps) Detach(devicePath string) error {
@@ -269,35 +291,30 @@ func (s *gceOps) Enumerate(
 	setIdentifier string,
 ) (map[string][]interface{}, error) {
 	sets := make(map[string][]interface{})
-	ctx := context.Background()
 	found := false
 
-	filter := generateListFilterFromLabels(labels)
-	req := s.service.Disks.List(s.inst.Project, s.inst.Zone).Filter(filter)
-	if err := req.Pages(ctx, func(page *compute.DiskList) error {
-		for _, disk := range page.Items {
-			if len(setIdentifier) == 0 {
-				storageops.AddElementToMap(sets, disk, storageops.SetIdentifierNone)
-			} else {
-				found = false
-				for key := range disk.Labels {
-					if key == setIdentifier {
-						storageops.AddElementToMap(sets, disk, key)
-						found = true
-						break
-					}
-				}
+	allDisks, err := s.getDisksFromAllZones(labels)
+	if err != nil {
+		return nil, err
+	}
 
-				if !found {
-					storageops.AddElementToMap(sets, disk, storageops.SetIdentifierNone)
+	for _, disk := range allDisks {
+		if len(setIdentifier) == 0 {
+			storageops.AddElementToMap(sets, disk, storageops.SetIdentifierNone)
+		} else {
+			found = false
+			for key := range disk.Labels {
+				if key == setIdentifier {
+					storageops.AddElementToMap(sets, disk, key)
+					found = true
+					break
 				}
 			}
-		}
 
-		return nil
-	}); err != nil {
-		logrus.Errorf("failed to list disks: %v", err)
-		return nil, err
+			if !found {
+				storageops.AddElementToMap(sets, disk, storageops.SetIdentifierNone)
+			}
+		}
 	}
 
 	return sets, nil
@@ -321,16 +338,18 @@ func (s *gceOps) GetDeviceID(disk interface{}) (string, error) {
 }
 
 func (s *gceOps) Inspect(diskNames []*string) ([]interface{}, error) {
+	allDisks, err := s.getDisksFromAllZones(nil)
+	if err != nil {
+		return nil, err
+	}
+
 	var disks []interface{}
-
 	for _, id := range diskNames {
-		var d *compute.Disk
-		d, err := s.service.Disks.Get(s.inst.Project, s.inst.Zone, *id).Do()
-		if err != nil {
-			return nil, err
+		if d, ok := allDisks[*id]; ok {
+			disks = append(disks, d)
+		} else {
+			return nil, fmt.Errorf("disk %s not found", *id)
 		}
-
-		disks = append(disks, d)
 	}
 
 	return disks, nil
@@ -405,10 +424,10 @@ func (s *gceOps) available(v *compute.Disk) bool {
 	return v.Status == STATUS_READY
 }
 
-func (s *gceOps) checkDiskStatus(id string, desired string) error {
+func (s *gceOps) checkDiskStatus(id string, zone string, desired string) error {
 	_, err := task.DoRetryWithTimeout(
 		func() (interface{}, bool, error) {
-			d, err := s.service.Disks.Get(s.inst.Project, s.inst.Zone, id).Do()
+			d, err := s.service.Disks.Get(s.inst.Project, zone, id).Do()
 			if err != nil {
 				return nil, true, err
 			}
@@ -608,4 +627,32 @@ func generateListFilterFromLabels(labels map[string]string) string {
 	}
 
 	return filter
+}
+
+func (s *gceOps) getDisksFromAllZones(labels map[string]string) (map[string]*compute.Disk, error) {
+	ctx := context.Background()
+	response := make(map[string]*compute.Disk)
+	var req *compute.DisksAggregatedListCall
+
+	if len(labels) > 0 {
+		filter := generateListFilterFromLabels(labels)
+		req = s.service.Disks.AggregatedList(s.inst.Project).Filter(filter)
+	} else {
+		req = s.service.Disks.AggregatedList(s.inst.Project)
+	}
+
+	if err := req.Pages(ctx, func(page *compute.DiskAggregatedList) error {
+		for _, diskScopedList := range page.Items {
+			for _, disk := range diskScopedList.Disks {
+				response[disk.Name] = disk
+			}
+		}
+
+		return nil
+	}); err != nil {
+		logrus.Errorf("failed to list disks: %v", err)
+		return nil, err
+	}
+
+	return response, nil
 }


### PR DESCRIPTION
Signed-off-by: Harsh Desai <harsh@portworx.com>

**Special notes for your reviewer**:

The create, delete and list methods were assuming that the disk was in the same zone as instance. 

