### PR TITLE
Add Cloudbackup Delete API to delete backups

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -296,6 +296,15 @@ type CloudBackupEnumerateResponse struct {
 }
 
 type CloudBackupDeleteRequest struct {
+	// ID is the ID of the cloud backup
+	ID string
+	// CredentialUUID is the credential for cloud to be used for the request
+	CredentialUUID string
+	// Force Delete cloudbackup even if there are dependencies
+	Force bool
+}
+
+type CloudBackupDeleteAllRequest struct {
 	CloudBackupGenericRequest
 }
 

--- a/api/client/volume/client.go
+++ b/api/client/volume/client.go
@@ -540,6 +540,18 @@ func (v *volumeClient) CloudBackupDelete(
 	return nil
 }
 
+// CloudBackupDeleteAll deletes all the backups for a volume in cloud
+func (v *volumeClient) CloudBackupDeleteAll(
+	input *api.CloudBackupDeleteAllRequest,
+) error {
+	req := v.c.Delete().Resource(backupPath + "/all").Body(input)
+	response := req.Do()
+	if response.Error() != nil {
+		return response.FormatError()
+	}
+	return nil
+}
+
 // CloudBackupStatus gets the most recent status of backup/restores
 func (v *volumeClient) CloudBackupStatus(
 	input *api.CloudBackupStatusRequest,

--- a/api/server/backup.go
+++ b/api/server/backup.go
@@ -67,10 +67,10 @@ func (vd *volAPI) cloudBackupRestore(w http.ResponseWriter, r *http.Request) {
 }
 
 func (vd *volAPI) cloudBackupDelete(w http.ResponseWriter, r *http.Request) {
-	backupReq := &api.CloudBackupDeleteRequest{}
+	deleteReq := &api.CloudBackupDeleteRequest{}
 	method := "cloudBackupDelete"
 
-	if err := json.NewDecoder(r.Body).Decode(backupReq); err != nil {
+	if err := json.NewDecoder(r.Body).Decode(deleteReq); err != nil {
 		vd.sendError(method, "", w, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -80,9 +80,31 @@ func (vd *volAPI) cloudBackupDelete(w http.ResponseWriter, r *http.Request) {
 		notFound(w, r)
 		return
 	}
-	err = d.CloudBackupDelete(backupReq)
+	err = d.CloudBackupDelete(deleteReq)
 	if err != nil {
-		vd.sendError(method, backupReq.SrcVolumeID, w, err.Error(), http.StatusInternalServerError)
+		vd.sendError(method, deleteReq.ID, w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (vd *volAPI) cloudBackupDeleteAll(w http.ResponseWriter, r *http.Request) {
+	deleteAllReq := &api.CloudBackupDeleteAllRequest{}
+	method := "cloudBackupDeleteAll"
+
+	if err := json.NewDecoder(r.Body).Decode(deleteAllReq); err != nil {
+		vd.sendError(method, "", w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	d, err := vd.getVolDriver(r)
+	if err != nil {
+		notFound(w, r)
+		return
+	}
+	err = d.CloudBackupDeleteAll(deleteAllReq)
+	if err != nil {
+		vd.sendError(method, deleteAllReq.SrcVolumeID, w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	w.WriteHeader(http.StatusOK)

--- a/api/server/backup_test.go
+++ b/api/server/backup_test.go
@@ -134,21 +134,49 @@ func TestClientBackupDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	goodInput := &api.CloudBackupDeleteRequest{}
-	goodInput.SrcVolumeID = "goodsrc"
+	goodInput.ID = "goodID"
 	goodInput.CredentialUUID = ""
 
 	badInput := &api.CloudBackupDeleteRequest{}
-	badInput.SrcVolumeID = "badsrc"
+	badInput.ID = "badID"
 	badInput.CredentialUUID = ""
 	testVolDriver.MockDriver().EXPECT().CloudBackupDelete(goodInput).
 		Return(nil).Times(1)
 	testVolDriver.MockDriver().EXPECT().CloudBackupDelete(badInput).
-		Return(fmt.Errorf("Src volume not found")).Times(1)
+		Return(fmt.Errorf("BackupID not found")).Times(1)
 
-	// Invoke restore
+	// Invoke Delete
 	err = client.VolumeDriver(cl).CloudBackupDelete(goodInput)
 	require.NoError(t, err)
 	err = client.VolumeDriver(cl).CloudBackupDelete(badInput)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "BackupID not found")
+}
+
+func TestClientBackupDeleteAll(t *testing.T) {
+	ts, testVolDriver := testRestServer(t)
+	defer ts.Close()
+	defer testVolDriver.Stop()
+
+	cl, err := client.NewDriverClient(ts.URL, mockDriverName, "", mockDriverName)
+	require.NoError(t, err)
+
+	goodInput := &api.CloudBackupDeleteAllRequest{}
+	goodInput.SrcVolumeID = "goodsrc"
+	goodInput.CredentialUUID = ""
+
+	badInput := &api.CloudBackupDeleteAllRequest{}
+	badInput.SrcVolumeID = "badsrc"
+	badInput.CredentialUUID = ""
+	testVolDriver.MockDriver().EXPECT().CloudBackupDeleteAll(goodInput).
+		Return(nil).Times(1)
+	testVolDriver.MockDriver().EXPECT().CloudBackupDeleteAll(badInput).
+		Return(fmt.Errorf("Src volume not found")).Times(1)
+
+	// Invoke DeleteAll
+	err = client.VolumeDriver(cl).CloudBackupDeleteAll(goodInput)
+	require.NoError(t, err)
+	err = client.VolumeDriver(cl).CloudBackupDeleteAll(badInput)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "Src volume not found")
 }

--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -1009,6 +1009,7 @@ func (vd *volAPI) Routes() []*Route {
 		{verb: "POST", path: backupPath("/restore", volume.APIVersion), fn: vd.cloudBackupRestore},
 		{verb: "GET", path: backupPath("", volume.APIVersion), fn: vd.cloudBackupEnumerate},
 		{verb: "DELETE", path: backupPath("", volume.APIVersion), fn: vd.cloudBackupDelete},
+		{verb: "DELETE", path: backupPath("/all", volume.APIVersion), fn: vd.cloudBackupDeleteAll},
 		{verb: "GET", path: backupPath("/status", volume.APIVersion), fn: vd.cloudBackupStatus},
 		{verb: "GET", path: backupPath("/catalog", volume.APIVersion), fn: vd.cloudBackupCatalog},
 		{verb: "GET", path: backupPath("/history", volume.APIVersion), fn: vd.cloudBackupHistory},

--- a/volume/drivers/mock/driver.mock.go
+++ b/volume/drivers/mock/driver.mock.go
@@ -83,6 +83,18 @@ func (mr *MockVolumeDriverMockRecorder) CloudBackupDelete(arg0 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudBackupDelete", reflect.TypeOf((*MockVolumeDriver)(nil).CloudBackupDelete), arg0)
 }
 
+// CloudBackupDeleteAll mocks base method
+func (m *MockVolumeDriver) CloudBackupDeleteAll(arg0 *api.CloudBackupDeleteAllRequest) error {
+	ret := m.ctrl.Call(m, "CloudBackupDeleteAll", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CloudBackupDeleteAll indicates an expected call of CloudBackupDeleteAll
+func (mr *MockVolumeDriverMockRecorder) CloudBackupDeleteAll(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloudBackupDeleteAll", reflect.TypeOf((*MockVolumeDriver)(nil).CloudBackupDeleteAll), arg0)
+}
+
 // CloudBackupEnumerate mocks base method
 func (m *MockVolumeDriver) CloudBackupEnumerate(arg0 *api.CloudBackupEnumerateRequest) (*api.CloudBackupEnumerateResponse, error) {
 	ret := m.ctrl.Call(m, "CloudBackupEnumerate", arg0)

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -138,8 +138,10 @@ type CloudBackupDriver interface {
 	CloudBackupRestore(input *api.CloudBackupRestoreRequest) (*api.CloudBackupRestoreResponse, error)
 	// CloudBackupEnumerate enumerates the backups for a given cluster/credential/volumeID
 	CloudBackupEnumerate(input *api.CloudBackupEnumerateRequest) (*api.CloudBackupEnumerateResponse, error)
-	// CloudBackupDelete deletes the backups in cloud
+	// CloudBackupDelete deletes the specified backup in cloud
 	CloudBackupDelete(input *api.CloudBackupDeleteRequest) error
+	// CloudBackupDelete deletes all the backups for a given volume in cloud
+	CloudBackupDeleteAll(input *api.CloudBackupDeleteAllRequest) error
 	// CloudBackupStatus indicates the most recent status of backup/restores
 	CloudBackupStatus(input *api.CloudBackupStatusRequest) (*api.CloudBackupStatusResponse, error)
 	// CloudBackupCatalog displays listing of backup content

--- a/volume/volume_not_supported.go
+++ b/volume/volume_not_supported.go
@@ -146,6 +146,12 @@ func (cl *cloudBackupNotSupported) CloudBackupDelete(
 	return ErrNotSupported
 }
 
+func (cl *cloudBackupNotSupported) CloudBackupDeleteAll(
+	input *api.CloudBackupDeleteAllRequest,
+) error {
+	return ErrNotSupported
+}
+
 func (cl *cloudBackupNotSupported) CloudBackupStatus(
 	input *api.CloudBackupStatusRequest,
 ) (*api.CloudBackupStatusResponse, error) {


### PR DESCRIPTION
The previous Delete has been renamed to DeleteAll to delete all backups for a
given volume

Signed-off-by: Dinesh Israni <disrani@portworx.com>


