### PR TITLE
osdconfig during node decommission

### DIFF
--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -1490,6 +1490,11 @@ func (c *ClusterManager) Remove(nodes []api.Node, forceRemove bool) error {
 				}
 			}
 		}
+
+		// Remove osdconfig data from etcd
+		if err := c.configManager.DeleteNodeConf(n.Id); err != nil {
+			logrus.Warn("error removing node from osdconfig:", err)
+		}
 	}
 
 	return resultErr

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -1509,17 +1509,16 @@ func (c *ClusterManager) NodeRemoveDone(nodeID string, result error) {
 
 	logrus.Infof("Cluster manager node remove done: node ID %s", nodeID)
 
-	err := c.deleteNodeFromDB(nodeID)
-	if err != nil {
+	// Remove osdconfig data from etcd
+	if err := c.configManager.DeleteNodeConf(nodeID); err != nil {
+		logrus.Warn("error removing node from osdconfig:", err)
+	}
+
+	if err := c.deleteNodeFromDB(nodeID); err != nil {
 		msg := fmt.Sprintf("Failed to delete node %s "+
 			"from cluster database, error %s",
 			nodeID, err)
 		logrus.Errorf(msg)
-	}
-
-	// Remove osdconfig data from etcd
-	if err := c.configManager.DeleteNodeConf(nodeID); err != nil {
-		logrus.Warn("error removing node from osdconfig:", err)
 	}
 }
 

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -1490,11 +1490,6 @@ func (c *ClusterManager) Remove(nodes []api.Node, forceRemove bool) error {
 				}
 			}
 		}
-
-		// Remove osdconfig data from etcd
-		if err := c.configManager.DeleteNodeConf(n.Id); err != nil {
-			logrus.Warn("error removing node from osdconfig:", err)
-		}
 	}
 
 	return resultErr
@@ -1520,6 +1515,11 @@ func (c *ClusterManager) NodeRemoveDone(nodeID string, result error) {
 			"from cluster database, error %s",
 			nodeID, err)
 		logrus.Errorf(msg)
+	}
+
+	// Remove osdconfig data from etcd
+	if err := c.configManager.DeleteNodeConf(nodeID); err != nil {
+		logrus.Warn("error removing node from osdconfig:", err)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Saurabh Deoras <sdeoras@gmail.com>

**What this PR does / why we need it**:
When node is decommissioned, it needs to be removed from osdconfig as well. This PR adds that logic
