### PR TITLE
Add implementation to support deleted paths in mount table

### DIFF
--- a/pkg/mount/deleted_mount.go
+++ b/pkg/mount/deleted_mount.go
@@ -1,0 +1,128 @@
+// +build linux
+
+package mount
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	AllDevices = "AllDevices"
+)
+
+// deletedMounter loads mounts that show up as deleted in the mount table.
+type deletedMounter struct {
+	*deviceMounter
+}
+
+// NewDeletedMounter returns a new deletedMounter
+func NewDeletedMounter(
+	rootSubstring string,
+	mountImpl MountImpl,
+) (*deletedMounter, error) {
+
+	devMounter, err := NewDeviceMounter([]string{"/dev/"}, mountImpl, nil, "")
+	if err != nil {
+		return nil, err
+	}
+	deletedMounts := make(DeviceMap)
+	for k, v := range devMounter.mounts {
+		if matchDeleted(rootSubstring, k) {
+			deletedMounts[k] = v
+		} else {
+			for _, p := range v.Mountpoint {
+				if matchDeleted(rootSubstring, p.Root) {
+					addMountpoint(deletedMounts, k, p)
+				}
+			}
+		}
+	}
+	devMounter.mounts = deletedMounts
+	return &deletedMounter{deviceMounter: devMounter}, nil
+}
+
+func matchDeleted(rootSubstring, source string) bool {
+	return strings.Contains(source, "deleted") &&
+		(len(rootSubstring) == 0 || strings.Contains(source, rootSubstring))
+}
+
+func addMountpoint(dm DeviceMap, root string, mp *PathInfo) {
+	info, ok := dm[root]
+	if !ok {
+		info = &Info{
+			Device:     root,
+			Mountpoint: make([]*PathInfo, 0),
+		}
+		dm[root] = info
+	}
+	info.Mountpoint = append(info.Mountpoint, mp)
+}
+
+// Unmount all deleted mounts.
+func (m *deletedMounter) Unmount(
+	sourcePath string,
+	path string,
+	flags int,
+	timeout int,
+	opts map[string]string,
+) error {
+	if sourcePath != AllDevices {
+		return fmt.Errorf("DeletedMounter accepts only %v as sourcePath",
+			AllDevices)
+	}
+
+	m.Lock()
+	defer m.Unlock()
+
+	failedUnmounts := make(DeviceMap)
+	for k, v := range m.mounts {
+		for _, p := range v.Mountpoint {
+			logrus.Warnf("Unmounting deleted mount path %v->%v", k, p)
+			if err := m.mountImpl.Unmount(p.Path, flags, timeout); err != nil {
+				logrus.Warnf("Failed to unmount mount path %v->%v", k, p)
+				addMountpoint(failedUnmounts, k, p)
+			}
+		}
+	}
+	m.mounts = failedUnmounts
+	if len(m.mounts) > 0 {
+		return fmt.Errorf("Not all paths could be unmounted")
+	}
+
+	return nil
+}
+
+func (m *deletedMounter) Mounts(sourcePath string) []string {
+	m.Lock()
+	defer m.Unlock()
+
+	if sourcePath != AllDevices {
+		logrus.Warnf("DeletedMounter accepts only %v as sourcePath",
+			AllDevices)
+		return nil
+	}
+	paths := make([]string, 0)
+	for _, v := range m.mounts {
+		for _, p := range v.Mountpoint {
+			paths = append(paths, p.Path)
+		}
+	}
+
+	return paths
+}
+
+func (m *deletedMounter) Mount(
+	minor int,
+	device string,
+	path string,
+	fs string,
+	flags uintptr,
+	data string,
+	timeout int,
+	opts map[string]string) error {
+
+	return fmt.Errorf("deletedMounter.Mount is not supported")
+}

--- a/pkg/mount/deleted_mount.go
+++ b/pkg/mount/deleted_mount.go
@@ -10,6 +10,7 @@ import (
 )
 
 const (
+	// AllDevices designates all devices that show up as source.
 	AllDevices = "AllDevices"
 )
 
@@ -122,7 +123,8 @@ func (m *deletedMounter) Mount(
 	flags uintptr,
 	data string,
 	timeout int,
-	opts map[string]string) error {
+	opts map[string]string,
+) error {
 
 	return fmt.Errorf("deletedMounter.Mount is not supported")
 }

--- a/pkg/mount/deleted_mount_test.go
+++ b/pkg/mount/deleted_mount_test.go
@@ -1,0 +1,102 @@
+package mount
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func bindMount(src, dest string) error {
+	return syscall.Mount(src, dest, "", syscall.MS_BIND, "")
+}
+
+func makeMounts(t *testing.T, srcBase, dstBase string, srcCount, dstCount int) {
+	for i := 0; i < srcCount; i++ {
+		src := fmt.Sprintf("%s.%d", srcBase, i)
+		cleandir(src)
+		for j := 0; j < dstCount; j++ {
+			dst := fmt.Sprintf("%s.%d.%d", dstBase, i, j)
+			os.MkdirAll(dst, 0755)
+			require.NoError(t, bindMount(src, dst), "bindMount")
+		}
+	}
+
+}
+
+func cleanup(srcBase, dstBase string, srcCount, dstCount int) {
+	for i := 0; i < srcCount; i++ {
+		src := fmt.Sprintf("%s.%d", srcBase, i)
+		cleandir(src)
+		for j := 0; j < dstCount; j++ {
+			dst := fmt.Sprintf("%s.%d.%d", dstBase, i, j)
+			cleandir(dst)
+		}
+	}
+}
+
+func testLoadUnmount(t *testing.T, srcBase, dstBase string, srcCount, dstCount int) {
+	cleanup(srcBase, dstBase, srcCount, dstCount)
+	makeMounts(t, srcBase, dstBase, srcCount, dstCount)
+	dm, err := NewDeletedMounter("/tmp", &DefaultMounter{})
+	require.NoError(t, err, "NewDeletedMount")
+	mounts := len(dm.Mounts(AllDevices))
+	require.Equal(t, srcCount*dstCount, mounts,
+		fmt.Sprintf("%v", dm.Mounts(AllDevices)))
+	testUnmount(t, dm)
+	cleanup(srcBase, dstBase, srcCount, dstCount)
+}
+
+func failUnmount(t *testing.T, srcBase, dstBase string, srcCount, dstCount int) {
+	cleanup(srcBase, dstBase, srcCount, dstCount)
+	makeMounts(t, srcBase, dstBase, srcCount, dstCount)
+	dm, err := NewDeletedMounter("/tmp/", &DefaultMounter{})
+	require.NoError(t, err, "NewDeletedMount")
+	mounts := dm.Mounts(AllDevices)
+	for i, m := range mounts {
+		if (i % 2) == 0 {
+			syscall.Unmount(m, 0)
+		}
+	}
+	require.Error(t, dm.Unmount(AllDevices, "", 0, 0, nil), "dm.Unmount")
+	mounts = dm.Mounts(AllDevices)
+	require.NotEqual(t, srcCount*dstCount, len(mounts),
+		fmt.Sprintf("%v", dm.Mounts(AllDevices)))
+}
+
+func testUnmount(t *testing.T, dm *deletedMounter) {
+	require.NoError(t, dm.Unmount(AllDevices, "", 0, 0, nil), "dm.Unmount")
+	mounts := len(dm.Mounts(AllDevices))
+	require.Equal(t, mounts, 0, "Non zero mounts after Unmount")
+}
+
+func TestLoadUnmount(t *testing.T) {
+	srcBase := "/tmp/test_mount_deleted"
+	dstBase := "/tmp/dest_bind_mount"
+
+	cleanup(srcBase, dstBase, 10, 10)
+
+	testLoadUnmount(t, srcBase, dstBase, 1, 1)
+	testLoadUnmount(t, srcBase, dstBase, 1, 3)
+	testLoadUnmount(t, srcBase, dstBase, 5, 1)
+	testLoadUnmount(t, srcBase, dstBase, 5, 3)
+	testLoadUnmount(t, srcBase, dstBase, 5, 5)
+
+	cleanup(srcBase, dstBase, 10, 10)
+}
+
+func TestFailUnmount(t *testing.T) {
+	srcBase := "/tmp/test_mount_deleted"
+	dstBase := "/tmp/dest_bind_mount"
+
+	cleanup(srcBase, dstBase, 10, 10)
+
+	failUnmount(t, srcBase, dstBase, 1, 3)
+	failUnmount(t, srcBase, dstBase, 5, 1)
+	failUnmount(t, srcBase, dstBase, 5, 3)
+	failUnmount(t, srcBase, dstBase, 5, 5)
+
+	cleanup(srcBase, dstBase, 10, 10)
+}

--- a/pkg/mount/deleted_mount_test.go
+++ b/pkg/mount/deleted_mount_test.go
@@ -40,7 +40,7 @@ func cleanup(srcBase, dstBase string, srcCount, dstCount int) {
 func testLoadUnmount(t *testing.T, srcBase, dstBase string, srcCount, dstCount int) {
 	cleanup(srcBase, dstBase, srcCount, dstCount)
 	makeMounts(t, srcBase, dstBase, srcCount, dstCount)
-	dm, err := NewDeletedMounter("/tmp", &DefaultMounter{})
+	dm, err := NewDeletedMounter("/mnt", &DefaultMounter{})
 	require.NoError(t, err, "NewDeletedMount")
 	mounts := len(dm.Mounts(AllDevices))
 	require.Equal(t, srcCount*dstCount, mounts,
@@ -52,7 +52,7 @@ func testLoadUnmount(t *testing.T, srcBase, dstBase string, srcCount, dstCount i
 func failUnmount(t *testing.T, srcBase, dstBase string, srcCount, dstCount int) {
 	cleanup(srcBase, dstBase, srcCount, dstCount)
 	makeMounts(t, srcBase, dstBase, srcCount, dstCount)
-	dm, err := NewDeletedMounter("/tmp/", &DefaultMounter{})
+	dm, err := NewDeletedMounter("/mnt/", &DefaultMounter{})
 	require.NoError(t, err, "NewDeletedMount")
 	mounts := dm.Mounts(AllDevices)
 	for i, m := range mounts {
@@ -73,8 +73,8 @@ func testUnmount(t *testing.T, dm *deletedMounter) {
 }
 
 func TestLoadUnmount(t *testing.T) {
-	srcBase := "/tmp/test_mount_deleted"
-	dstBase := "/tmp/dest_bind_mount"
+	srcBase := "/mnt/test_mount_deleted"
+	dstBase := "/mnt/dest_bind_mount"
 
 	cleanup(srcBase, dstBase, 10, 10)
 
@@ -88,8 +88,8 @@ func TestLoadUnmount(t *testing.T) {
 }
 
 func TestFailUnmount(t *testing.T) {
-	srcBase := "/tmp/test_mount_deleted"
-	dstBase := "/tmp/dest_bind_mount"
+	srcBase := "/mnt/test_mount_deleted"
+	dstBase := "/mnt/dest_bind_mount"
 
 	cleanup(srcBase, dstBase, 10, 10)
 

--- a/pkg/mount/device.go
+++ b/pkg/mount/device.go
@@ -97,6 +97,7 @@ DeviceLoop:
 		mount.Mountpoint = append(
 			mount.Mountpoint,
 			&PathInfo{
+				Root: normalizeMountPath(v.Root),
 				Path: normalizeMountPath(v.Mountpoint),
 			},
 		)

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -110,6 +110,7 @@ type PathMap map[string]string
 
 // PathInfo is a reference counted path
 type PathInfo struct {
+	Root string
 	Path string
 }
 


### PR DESCRIPTION
Signed-off-by: Vinod <jvinod@portworx.com>

**What this PR does / why we need it**:
Support "(deleted)" mount entries in mount table and ability to purge them

replaces https://github.com/libopenstorage/openstorage/pull/373

