### PR TITLE
osdconfig bug fix during init in maintenance mode

### DIFF
--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -1107,6 +1107,12 @@ func (c *ClusterManager) Start(
 	var exist bool
 	kvdb := kvdb.Instance()
 
+	// osdconfig manager should be instantiated as soon as kvdb is ready
+	c.configManager, err = osdconfig.NewManager(c.kv)
+	if err != nil {
+		return err
+	}
+
 	lastIndex, err := c.initializeAndStartHeartbeat(
 		kvdb,
 		clusterMaxSize,
@@ -1120,11 +1126,6 @@ func (c *ClusterManager) Start(
 	c.startClusterDBWatch(lastIndex, kvdb)
 
 	err = c.waitForQuorum(exist)
-	if err != nil {
-		return err
-	}
-
-	c.configManager, err = osdconfig.NewManager(c.kv)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Saurabh Deoras <sdeoras@gmail.com>

**What this PR does / why we need it**:
this pr bumps up the init of osdconfig in cluster manager boot sequence to avoid panics during maintenance mode

**Which issue(s) this PR fixes** (optional)
this is in response to failures seen during initialization of cluster manager during maintenance mode

**Special notes for your reviewer**:

