### PR TITLE
Fix nodelist by utilizing semicolons

### DIFF
--- a/api/spec/spec_handler.go
+++ b/api/spec/spec_handler.go
@@ -168,7 +168,7 @@ func (d *specHandler) UpdateSpecFromOpts(opts map[string]string, spec *api.Volum
 	for k, v := range opts {
 		switch k {
 		case api.SpecNodes:
-			inputNodes := strings.Split(v, ",")
+			inputNodes := strings.Split(strings.Replace(v, ";", ",", -1), ",")
 			for _, node := range inputNodes {
 				if len(node) != 0 {
 					nodeList = append(nodeList, node)

--- a/api/spec/spec_handler.go
+++ b/api/spec/spec_handler.go
@@ -77,7 +77,7 @@ type SpecHandler interface {
 
 var (
 	nameRegex       = regexp.MustCompile(api.Name + "=([0-9A-Za-z_-]+),?")
-	nodesRegex      = regexp.MustCompile(api.SpecNodes + "=('[0-9A-Za-z,_-]+'|[0-9A-Za-z_-]+),?")
+	nodesRegex      = regexp.MustCompile(api.SpecNodes + "=([A-Za-z0-9-_;]+),?")
 	parentRegex     = regexp.MustCompile(api.SpecParent + "=([A-Za-z]+),?")
 	sizeRegex       = regexp.MustCompile(api.SpecSize + "=([0-9A-Za-z]+),?")
 	scaleRegex      = regexp.MustCompile(api.SpecScale + "=([0-9]+),?")
@@ -168,7 +168,6 @@ func (d *specHandler) UpdateSpecFromOpts(opts map[string]string, spec *api.Volum
 	for k, v := range opts {
 		switch k {
 		case api.SpecNodes:
-			v = strings.Trim(v, "'")
 			inputNodes := strings.Split(v, ",")
 			for _, node := range inputNodes {
 				if len(node) != 0 {
@@ -338,8 +337,9 @@ func (d *specHandler) SpecOptsFromString(
 	}
 
 	if ok, nodes := d.getVal(nodesRegex, str); ok {
-		opts[api.SpecNodes] = nodes
+		opts[api.SpecNodes] = strings.Replace(nodes, ";", ",", -1)
 	}
+
 	if ok, parent := d.getVal(parentRegex, str); ok {
 		opts[api.SpecParent] = parent
 	}

--- a/api/spec/spec_handler_test.go
+++ b/api/spec/spec_handler_test.go
@@ -11,7 +11,7 @@ import (
 
 func testSpecOptString(t *testing.T, opt string, val string) {
 	s := NewSpecHandler()
-	parsed, m, _ := s.SpecOptsFromString(fmt.Sprintf("name=volname,foo=bar,%s=%s,u=nix", opt, val))
+	parsed, m, _ := s.SpecOptsFromString(fmt.Sprintf("name=volname,foo=bar,%s=%s", opt, val))
 	require.True(t, parsed, "Failed to parse spec string")
 	parsedVal, ok := m[opt]
 	require.True(t, ok, fmt.Sprintf("Failed to set %q string", opt))
@@ -25,13 +25,13 @@ func testSpecNodeOptString(t *testing.T, opt string, val string) {
 
 	parsedVal, ok := m[opt]
 	require.True(t, ok, fmt.Sprintf("Failed to set %q string", opt))
+	parsedVal = strings.Replace(parsedVal, ",", ";", -1)
 	require.Equal(t, parsedVal, fmt.Sprintf("%s", val), fmt.Sprintf("Failed to parse string value %q", val))
 
 	spec, _, _, err := s.UpdateSpecFromOpts(m, &api.VolumeSpec{}, &api.VolumeLocator{}, nil)
 	require.NoError(t, err)
 
-	parsedVal = strings.Trim(parsedVal, "'")
-	nodes := strings.Split(parsedVal, ",")
+	nodes := strings.Split(parsedVal, ";")
 	for i, node := range nodes {
 		require.Equal(t, node, spec.ReplicaSet.Nodes[i])
 	}
@@ -76,6 +76,6 @@ func TestOptIoProfile(t *testing.T) {
 }
 
 func TestOptNodes(t *testing.T) {
-	testSpecNodeOptString(t, api.SpecNodes, "'node1,node2'")
+	testSpecNodeOptString(t, api.SpecNodes, "node1;node2")
 	testSpecNodeOptString(t, api.SpecNodes, "node1")
 }


### PR DESCRIPTION
Signed-off-by: Paul Theunis <paul@portworx.com>

Use Semicolons to delimit nodes for replicaset, comma's cause issues and single quotes get parsed out by docker.

**Special notes for your reviewer**:
When specifying multiple nodes on command line for docker volume create use "item1;item2"
