### PR TITLE
Add a new mounter implementation for bind mounts.

### DIFF
--- a/pkg/mount/bind_mount.go
+++ b/pkg/mount/bind_mount.go
@@ -1,0 +1,82 @@
+// +build linux
+
+package mount
+
+import (
+	"strings"
+
+	"github.com/docker/docker/pkg/mount"
+	"github.com/libopenstorage/openstorage/pkg/keylock"
+)
+
+const (
+	sharedMount = "shared"
+)
+
+// bindMounter loads mounts that are bind mounted in the mount table
+type bindMounter struct {
+	Mounter
+}
+
+// NewBindMounter returns a new bindMounter
+func NewBindMounter(
+	rootSubstrings []string,
+	mountImpl MountImpl,
+	allowedDirs []string,
+	trashLocation string,
+) (*bindMounter, error) {
+	b := &bindMounter{
+		Mounter: Mounter{
+			mountImpl:     mountImpl,
+			mounts:        make(DeviceMap),
+			paths:         make(PathMap),
+			allowedDirs:   allowedDirs,
+			kl:            keylock.New(),
+			trashLocation: trashLocation,
+		},
+	}
+	if err := b.Load(rootSubstrings); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
+func (b *bindMounter) Reload(rootSubstring string) error {
+	newBm, err := NewBindMounter(
+		[]string{rootSubstring},
+		b.mountImpl,
+		b.allowedDirs,
+		b.trashLocation,
+	)
+	if err != nil {
+		return err
+	}
+	return b.reload(rootSubstring, newBm.mounts[rootSubstring])
+}
+
+func (b *bindMounter) Load(rootSubstrings []string) error {
+	return b.load(rootSubstrings, bindFindMountPoint)
+}
+
+func bindFindMountPoint(sInfo *mount.Info, destination string, infos []*mount.Info) (bool, string, string) {
+	for _, dInfo := range infos {
+		if !strings.Contains(dInfo.Mountpoint, destination) {
+			continue
+		}
+		// Check if the root device is the same for the bind mount
+		if dInfo.Root != sInfo.Root {
+			continue
+		}
+		if !strings.Contains(dInfo.Optional, sharedMount) ||
+			!strings.Contains(sInfo.Optional, sharedMount) {
+			continue
+		}
+		// Get the mount peer group
+		sPeerGroup := strings.Split(sInfo.Optional, sharedMount)[1]
+		dPeerGroup := strings.Split(dInfo.Optional, sharedMount)[1]
+		if sPeerGroup == dPeerGroup {
+			return true, dInfo.Mountpoint, dInfo.Source
+		}
+	}
+	return false, "", ""
+}

--- a/pkg/mount/mount_test.go
+++ b/pkg/mount/mount_test.go
@@ -17,8 +17,16 @@ const (
 
 var m Manager
 
-func TestAll(t *testing.T) {
-	setup(t)
+func TestNFSMounter(t *testing.T) {
+	setupNFS(t)
+	allTests(t)
+}
+
+func TestBindMounter(t *testing.T) {
+	setupBindMounter(t)
+	allTests(t)
+}
+func allTests(t *testing.T) {
 	load(t)
 	mountTest(t)
 	inspect(t)
@@ -29,9 +37,19 @@ func TestAll(t *testing.T) {
 	shutdown(t)
 }
 
-func setup(t *testing.T) {
+func setupNFS(t *testing.T) {
 	var err error
 	m, err = New(NFSMount, nil, []string{""}, nil, []string{}, trashLocation)
+	if err != nil {
+		t.Fatalf("Failed to setup test %v", err)
+	}
+	cleandir(source)
+	cleandir(dest)
+}
+
+func setupBindMounter(t *testing.T) {
+	var err error
+	m, err = New(BindMount, nil, []string{""}, nil, []string{}, trashLocation)
 	if err != nil {
 		t.Fatalf("Failed to setup test %v", err)
 	}


### PR DESCRIPTION
- Implement a new Load and Reload functions for bind mounts.
- To detect the source path of a bind mount use PeerGroup and Root field of a mountpoint.

Signed-off-by: Aditya Dani <aditya@portworx.com>

**What this PR does / why we need it**:

It adds a new mounter which could be used for bind mounts.
