### PR TITLE
Makefile: fix config path used in launch target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,11 +167,11 @@ launch: docker-build-osd
 	docker run \
 		--privileged \
 		-d \
-		-v $(shell pwd):/etc \
+		-v $(shell pwd)/etc:/etc \
 		-v /run/docker/plugins:/run/docker/plugins \
 		-v /var/lib/osd/:/var/lib/osd/ \
 		-p 9005:9005 \
-		openstorage/osd -d -f /etc/config.yaml
+		openstorage/osd -d -f /etc/config/config.yaml
 
 # must set HAVE_BTRFS
 launch-local-btrfs: install


### PR DESCRIPTION

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Fixes the config path used when launching a container.

**Which issue(s) this PR fixes** (optional)
Closes None

**Special notes for your reviewer**:

