### PR TITLE
Relax fstype checks to prefix checks

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -295,29 +295,6 @@ func (m *Mounter) maybeRemoveDevice(device string) {
 	}
 }
 
-func (m *Mounter) hasPath(path string) (string, bool) {
-	m.Lock()
-	defer m.Unlock()
-	p, ok := m.paths[path]
-	return p, ok
-}
-
-func (m *Mounter) addPath(path, device string) {
-	m.Lock()
-	defer m.Unlock()
-	m.paths[path] = device
-}
-
-func (m *Mounter) deletePath(path string) bool {
-	m.Lock()
-	defer m.Unlock()
-	if _, pathExists := m.paths[path]; pathExists {
-		delete(m.paths, path)
-		return true
-	}
-	return false
-}
-
 // reload from newM
 func (m *Mounter) reload(device string, newM *Info) error {
 	m.Lock()
@@ -381,7 +358,7 @@ func (m *Mounter) Mount(
 			return ErrMountpathNotAllowed
 		}
 	}
-	dev, ok := m.hasPath(path)
+	dev, ok := m.HasTarget(path)
 	if ok && dev != device {
 		logrus.Warnf("cannot mount %q,  device %q is mounted at %q", device, dev, path)
 		return ErrExist
@@ -402,7 +379,8 @@ func (m *Mounter) Mount(
 	defer info.Unlock()
 
 	// Validate input params
-	if fs != info.Fs {
+	// FS check is not needed if it is a bind mount
+	if !strings.HasPrefix(info.Fs, fs) && (flags&syscall.MS_BIND) != syscall.MS_BIND {
 		logrus.Warnf("%s Existing mountpoint has fs %q cannot change to %q",
 			device, info.Fs, fs)
 		return ErrEinval
@@ -438,7 +416,6 @@ func (m *Mounter) Mount(
 	}
 
 	info.Mountpoint = append(info.Mountpoint, &PathInfo{Path: path})
-	m.addPath(path, device)
 
 	return nil
 }
@@ -476,10 +453,6 @@ func (m *Mounter) Unmount(
 		err := m.mountImpl.Unmount(path, flags, timeout)
 		if err != nil {
 			return err
-		}
-		if pathExists := m.deletePath(path); !pathExists {
-			logrus.Warnf("Path %q for device %q does not exist in pathMap",
-				path, device)
 		}
 		// Blow away this mountpoint.
 		info.Mountpoint[i] = info.Mountpoint[len(info.Mountpoint)-1]

--- a/pkg/mount/nfs.go
+++ b/pkg/mount/nfs.go
@@ -97,7 +97,7 @@ MountLoop:
 	for _, v := range info {
 		host := "localhost"
 		if len(m.servers) != 0 {
-			if v.Fstype != "nfs" {
+			if !strings.HasPrefix(v.Fstype, "nfs") {
 				continue
 			}
 			matches := re.FindStringSubmatch(v.VfsOpts)


### PR DESCRIPTION

**What this PR does / why we need it**:
Relax fstype checks to prefix checks. Allows nfs and nfs4 mounts

