### PR TITLE
Add logs in mounter for error conditions.

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -389,6 +389,8 @@ func (m *Mounter) Mount(
 	// Try to find the mountpoint. If it already exists, do nothing
 	for _, p := range info.Mountpoint {
 		if p.Path == path {
+			logrus.Warnf("%q mountpoint for device %q already exists",
+				device, path)
 			return nil
 		}
 	}
@@ -441,6 +443,8 @@ func (m *Mounter) Unmount(
 	info, ok := m.mounts[device]
 	if !ok {
 		m.Unlock()
+		logrus.Warnf("Unable to unmount device %q path %q: %v",
+			devPath, path, ErrEnoent.Error())
 		return ErrEnoent
 	}
 	m.Unlock()


### PR DESCRIPTION
- Log when we return error in Unmount for ErrEnoEnt.
- Log when we return nil and do not perform a Mount when mountpoint exists.

Signed-off-by: Aditya Dani <aditya@portworx.com>

**What this PR does / why we need it**:

Adds logs for better debugging.

