### PR TITLE
Cleanup Volume Client REST Golang Interface

### DIFF
--- a/api/client/volume/volume.go
+++ b/api/client/volume/volume.go
@@ -2,14 +2,15 @@ package volume
 
 import (
 	"fmt"
+
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/libopenstorage/openstorage/api/client"
 	"github.com/libopenstorage/openstorage/volume"
 )
 
 // VolumeDriver returns a REST wrapper for the VolumeDriver interface.
-func VolumeDriver(c *client.Client) volume.VolumeDriver {
-	return newVolumeClient(c)
+func VolumeDriver(c *client.Client) volume.VolumeClient {
+	return New(c)
 }
 
 // NewAuthDriverClient returns a new REST client of the supplied version for specified driver.

--- a/cli/volumes.go
+++ b/cli/volumes.go
@@ -32,8 +32,8 @@ const (
 	PiB
 )
 
-type volDriver struct {
-	volDriver volume.VolumeDriver
+type volClient struct {
+	volClient volume.VolumeClient
 	name      string
 }
 
@@ -53,17 +53,17 @@ func processLabels(s string) (map[string]string, error) {
 	return m, nil
 }
 
-func (v *volDriver) volumeOptions(context *cli.Context) {
+func (v *volClient) volumeOptions(context *cli.Context) {
 	// Currently we choose the default version
 	clnt, err := volumeclient.NewDriverClient("", v.name, volume.APIVersion, "")
 	if err != nil {
 		fmt.Printf("Failed to initialize client library: %v\n", err)
 		os.Exit(1)
 	}
-	v.volDriver = volumeclient.VolumeDriver(clnt)
+	v.volClient = volumeclient.New(clnt)
 }
 
-func (v *volDriver) volumeCreate(context *cli.Context) {
+func (v *volClient) volumeCreate(context *cli.Context) {
 	var err error
 	var labels map[string]string
 	locator := &api.VolumeLocator{}
@@ -107,7 +107,7 @@ func (v *volDriver) volumeCreate(context *cli.Context) {
 	source := &api.Source{
 		Seed: context.String("seed"),
 	}
-	if id, err = v.volDriver.Create(locator, source, spec); err != nil {
+	if id, err = v.volClient.Create(locator, source, spec); err != nil {
 		cmdError(context, fn, err)
 		return
 	}
@@ -115,7 +115,7 @@ func (v *volDriver) volumeCreate(context *cli.Context) {
 	fmtOutput(context, &Format{UUID: []string{string(id)}})
 }
 
-func (v *volDriver) volumeMount(context *cli.Context) {
+func (v *volClient) volumeMount(context *cli.Context) {
 	v.volumeOptions(context)
 	fn := "mount"
 
@@ -131,7 +131,7 @@ func (v *volDriver) volumeMount(context *cli.Context) {
 		return
 	}
 
-	err := v.volDriver.Mount(string(volumeID), path, nil)
+	err := v.volClient.Mount(string(volumeID), path, nil)
 	if err != nil {
 		cmdError(context, fn, err)
 		return
@@ -140,7 +140,7 @@ func (v *volDriver) volumeMount(context *cli.Context) {
 	fmtOutput(context, &Format{UUID: []string{volumeID}})
 }
 
-func (v *volDriver) volumeUnmount(context *cli.Context) {
+func (v *volClient) volumeUnmount(context *cli.Context) {
 	v.volumeOptions(context)
 	fn := "unmount"
 
@@ -155,7 +155,7 @@ func (v *volDriver) volumeUnmount(context *cli.Context) {
 	opts := make(map[string]string)
 	opts[options.OptionsDeleteAfterUnmount] = "true"
 
-	err := v.volDriver.Unmount(string(volumeID), path, opts)
+	err := v.volClient.Unmount(string(volumeID), path, opts)
 	if err != nil {
 		cmdError(context, fn, err)
 		return
@@ -164,7 +164,7 @@ func (v *volDriver) volumeUnmount(context *cli.Context) {
 	fmtOutput(context, &Format{UUID: []string{volumeID}})
 }
 
-func (v *volDriver) volumeAttach(context *cli.Context) {
+func (v *volClient) volumeAttach(context *cli.Context) {
 	fn := "attach"
 	if len(context.Args()) < 1 {
 		missingParameter(context, fn, "volumeID", "Invalid number of arguments")
@@ -173,7 +173,7 @@ func (v *volDriver) volumeAttach(context *cli.Context) {
 	v.volumeOptions(context)
 	volumeID := context.Args()[0]
 
-	devicePath, err := v.volDriver.Attach(string(volumeID), nil)
+	devicePath, err := v.volClient.Attach(string(volumeID), nil)
 	if err != nil {
 		cmdError(context, fn, err)
 		return
@@ -182,7 +182,7 @@ func (v *volDriver) volumeAttach(context *cli.Context) {
 	fmtOutput(context, &Format{Result: devicePath})
 }
 
-func (v *volDriver) volumeDetach(context *cli.Context) {
+func (v *volClient) volumeDetach(context *cli.Context) {
 	fn := "detach"
 	if len(context.Args()) < 1 {
 		missingParameter(context, fn, "volumeID", "Invalid number of arguments")
@@ -190,7 +190,7 @@ func (v *volDriver) volumeDetach(context *cli.Context) {
 	}
 	volumeID := context.Args()[0]
 	v.volumeOptions(context)
-	err := v.volDriver.Detach(string(volumeID), nil)
+	err := v.volClient.Detach(string(volumeID), nil)
 	if err != nil {
 		cmdError(context, fn, err)
 		return
@@ -199,7 +199,7 @@ func (v *volDriver) volumeDetach(context *cli.Context) {
 	fmtOutput(context, &Format{UUID: []string{context.Args()[0]}})
 }
 
-func (v *volDriver) volumeInspect(context *cli.Context) {
+func (v *volClient) volumeInspect(context *cli.Context) {
 	v.volumeOptions(context)
 	fn := "inspect"
 	if len(context.Args()) < 1 {
@@ -212,7 +212,7 @@ func (v *volDriver) volumeInspect(context *cli.Context) {
 		d[i] = string(v)
 	}
 
-	volumes, err := v.volDriver.Inspect(d)
+	volumes, err := v.volClient.Inspect(d)
 	if err != nil {
 		cmdError(context, fn, err)
 		return
@@ -221,7 +221,7 @@ func (v *volDriver) volumeInspect(context *cli.Context) {
 	cmdOutputVolumes(volumes, context.GlobalBool("raw"))
 }
 
-func (v *volDriver) volumeStats(context *cli.Context) {
+func (v *volClient) volumeStats(context *cli.Context) {
 	v.volumeOptions(context)
 	fn := "stats"
 	if len(context.Args()) != 1 {
@@ -229,7 +229,7 @@ func (v *volDriver) volumeStats(context *cli.Context) {
 		return
 	}
 
-	stats, err := v.volDriver.Stats(string(context.Args()[0]), true)
+	stats, err := v.volClient.Stats(string(context.Args()[0]), true)
 	if err != nil {
 		cmdError(context, fn, err)
 		return
@@ -238,7 +238,7 @@ func (v *volDriver) volumeStats(context *cli.Context) {
 	cmdOutputProto(stats, context.GlobalBool("raw"))
 }
 
-func (v *volDriver) volumeEnumerate(context *cli.Context) {
+func (v *volClient) volumeEnumerate(context *cli.Context) {
 	locator := &api.VolumeLocator{}
 	var err error
 
@@ -253,7 +253,7 @@ func (v *volDriver) volumeEnumerate(context *cli.Context) {
 	}
 
 	v.volumeOptions(context)
-	volumes, err := v.volDriver.Enumerate(locator, nil)
+	volumes, err := v.volClient.Enumerate(locator, nil)
 	if err != nil {
 		cmdError(context, fn, err)
 		return
@@ -261,7 +261,7 @@ func (v *volDriver) volumeEnumerate(context *cli.Context) {
 	cmdOutputVolumes(volumes, context.GlobalBool("raw"))
 }
 
-func (v *volDriver) volumeDelete(context *cli.Context) {
+func (v *volClient) volumeDelete(context *cli.Context) {
 	fn := "delete"
 	if len(context.Args()) < 1 {
 		missingParameter(context, fn, "volumeID", "Invalid number of arguments")
@@ -269,7 +269,7 @@ func (v *volDriver) volumeDelete(context *cli.Context) {
 	}
 	volumeID := context.Args()[0]
 	v.volumeOptions(context)
-	err := v.volDriver.Delete(volumeID)
+	err := v.volClient.Delete(volumeID)
 	if err != nil {
 		cmdError(context, fn, err)
 		return
@@ -278,7 +278,7 @@ func (v *volDriver) volumeDelete(context *cli.Context) {
 	fmtOutput(context, &Format{UUID: []string{context.Args()[0]}})
 }
 
-func (v *volDriver) snapCreate(context *cli.Context) {
+func (v *volClient) snapCreate(context *cli.Context) {
 	var err error
 	var labels map[string]string
 	fn := "snapCreate"
@@ -301,7 +301,7 @@ func (v *volDriver) snapCreate(context *cli.Context) {
 		VolumeLabels: labels,
 	}
 	readonly := context.Bool("readonly")
-	id, err := v.volDriver.Snapshot(volumeID, readonly, locator)
+	id, err := v.volClient.Snapshot(volumeID, readonly, locator)
 	if err != nil {
 		cmdError(context, fn, err)
 		return
@@ -310,7 +310,7 @@ func (v *volDriver) snapCreate(context *cli.Context) {
 	fmtOutput(context, &Format{UUID: []string{string(id)}})
 }
 
-func (v *volDriver) snapEnumerate(context *cli.Context) {
+func (v *volClient) snapEnumerate(context *cli.Context) {
 	locator := &api.VolumeLocator{}
 	var err error
 
@@ -325,7 +325,7 @@ func (v *volDriver) snapEnumerate(context *cli.Context) {
 	}
 
 	v.volumeOptions(context)
-	snaps, err := v.volDriver.Enumerate(locator, nil)
+	snaps, err := v.volClient.Enumerate(locator, nil)
 	if err != nil {
 		cmdError(context, fn, err)
 		return
@@ -337,7 +337,7 @@ func (v *volDriver) snapEnumerate(context *cli.Context) {
 	cmdOutputVolumes(snaps, context.GlobalBool("raw"))
 }
 
-func (v *volDriver) volumeAlerts(context *cli.Context) {
+func (v *volClient) volumeAlerts(context *cli.Context) {
 	v.volumeOptions(context)
 
 	clnt, err := clusterclient.NewClusterClient("", cluster.APIVersion)
@@ -356,7 +356,7 @@ func (v *volDriver) volumeAlerts(context *cli.Context) {
 }
 
 // baseVolumeCommand exports commands common to block and file volume drivers.
-func baseVolumeCommand(v *volDriver) []cli.Command {
+func baseVolumeCommand(v *volClient) []cli.Command {
 
 	commands := []cli.Command{
 		{
@@ -510,7 +510,7 @@ func baseVolumeCommand(v *volDriver) []cli.Command {
 
 // BlockVolumeCommands exports CLI comamnds for a Block VolumeDriver.
 func BlockVolumeCommands(name string) []cli.Command {
-	v := &volDriver{name: name}
+	v := &volClient{name: name}
 
 	blockCommands := []cli.Command{
 		{
@@ -540,7 +540,7 @@ func BlockVolumeCommands(name string) []cli.Command {
 
 // FileVolumeCommands exports CLI comamnds for File VolumeDriver
 func FileVolumeCommands(name string) []cli.Command {
-	v := &volDriver{name: name}
+	v := &volClient{name: name}
 
 	return baseVolumeCommand(v)
 }

--- a/pkg/sanity/backup_restore.go
+++ b/pkg/sanity/backup_restore.go
@@ -33,7 +33,7 @@ import (
 var _ = Describe("Volume [Backup Restore Tests]", func() {
 	var (
 		restClient   *client.Client
-		volumedriver volume.VolumeDriver
+		volumedriver volume.VolumeClient
 		credentials  *api.CredCreateRequest
 		credUUID     string
 		credsUUIDMap map[string]string

--- a/pkg/sanity/cluster.go
+++ b/pkg/sanity/cluster.go
@@ -123,7 +123,7 @@ var _ = Describe("Cluster [Cluster Tests]", func() {
 			err              error
 			volumeID         string
 			numVolumesBefore int
-			volumedriver     volume.VolumeDriver
+			volumedriver     volume.VolumeClient
 			restClient       *client.Client
 		)
 

--- a/pkg/sanity/creds.go
+++ b/pkg/sanity/creds.go
@@ -30,7 +30,7 @@ import (
 var _ = Describe("Credentials Tests", func() {
 	var (
 		restClient   *client.Client
-		volumedriver volume.VolumeDriver
+		volumedriver volume.VolumeClient
 		credentials  *api.CredCreateRequest
 	)
 

--- a/pkg/sanity/osd_test_util.go
+++ b/pkg/sanity/osd_test_util.go
@@ -36,7 +36,7 @@ const (
 )
 
 func testIfVolumeCreatedSuccessfully(
-	volumedriver volume.VolumeDriver,
+	volumedriver volume.VolumeClient,
 	volumeID string,
 	numVolumesBefore int,
 	vr *api.VolumeCreateRequest) {

--- a/pkg/sanity/snapshot.go
+++ b/pkg/sanity/snapshot.go
@@ -32,7 +32,7 @@ import (
 var _ = Describe("Volume [Snapshot Tests]", func() {
 	var (
 		restClient   *client.Client
-		volumedriver volume.VolumeDriver
+		volumedriver volume.VolumeClient
 	)
 
 	BeforeEach(func() {

--- a/pkg/sanity/volume.go
+++ b/pkg/sanity/volume.go
@@ -34,7 +34,7 @@ import (
 var _ = Describe("Volume [Volume Tests]", func() {
 	var (
 		restClient   *client.Client
-		volumedriver volume.VolumeDriver
+		volumedriver volume.VolumeClient
 	)
 
 	BeforeEach(func() {

--- a/volume/drivers/pwx/pwx.go
+++ b/volume/drivers/pwx/pwx.go
@@ -18,7 +18,7 @@ const (
 )
 
 type driver struct {
-	volume.VolumeDriver
+	volume.VolumeClient
 }
 
 // Init initialized the Portworx driver.
@@ -38,7 +38,7 @@ func Init(params map[string]string) (volume.VolumeDriver, error) {
 		return nil, err
 	}
 
-	return &driver{VolumeDriver: volumeclient.VolumeDriver(c)}, nil
+	return &driver{VolumeClient: volumeclient.VolumeDriver(c)}, nil
 }
 
 func (d *driver) Name() string {
@@ -48,3 +48,25 @@ func (d *driver) Name() string {
 func (d *driver) Type() api.DriverType {
 	return Type
 }
+
+func (d *driver) Read(volumeID string, buf []byte, sz uint64, offset int64) (int64, error) {
+	return 0, volume.ErrNotSupported
+}
+
+func (d *driver) Write(volumeID string, buf []byte, sz uint64, offset int64) (int64, error) {
+	return 0, volume.ErrNotSupported
+}
+
+func (d *driver) Flush(volumeID string) error {
+	return volume.ErrNotSupported
+}
+
+func (d *driver) MountedAt(mountPath string) string {
+	return ""
+}
+
+func (d *driver) Status() [][2]string {
+	return [][2]string{}
+}
+
+func (d *driver) Shutdown() {}

--- a/volume/drivers/test/driver.go
+++ b/volume/drivers/test/driver.go
@@ -31,7 +31,7 @@ func init() {
 // Context maintains current device state. It gets passed into tests
 // so that tests can build on other tests' work
 type Context struct {
-	volume.VolumeDriver
+	volume.VolumeClient
 	volID         string
 	snapID        string
 	mountPath     string
@@ -45,14 +45,14 @@ type Context struct {
 }
 
 // NewContext returns a new Context
-func NewContext(d volume.VolumeDriver) *Context {
+func NewContext(d volume.VolumeClient) *Context {
 	return &Context{
-		VolumeDriver: d,
+		VolumeClient: d,
 		volID:        "",
 		snapID:       "",
 		Filesystem:   api.FSType_FS_TYPE_NONE,
-		testPath:     path.Join("/mnt/openstorage/mount/", d.Name()),
-		testFile:     path.Join("/tmp/", d.Name()),
+		testPath:     path.Join("/mnt/openstorage/mount/volumeDriver"),
+		testFile:     path.Join("/tmp/volumeDriver"),
 	}
 }
 
@@ -82,7 +82,6 @@ func runEnd(t *testing.T, ctx *Context) {
 	time.Sleep(time.Second * 2)
 	os.RemoveAll(ctx.testPath)
 	os.Remove(ctx.testFile)
-	shutdown(t, ctx)
 }
 
 // RunSnap runs only the snap related tests
@@ -255,11 +254,6 @@ func unmount(t *testing.T, ctx *Context) {
 	require.NoError(t, err, "Failed in unmount %v", ctx.mountPath)
 
 	ctx.mountPath = ""
-}
-
-func shutdown(t *testing.T, ctx *Context) {
-	fmt.Println("shutdown")
-	ctx.Shutdown()
 }
 
 func io(t *testing.T, ctx *Context) {

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -84,6 +84,18 @@ type VolumeDriver interface {
 	Enumerator
 }
 
+// VolumeClient contains the exported functions to external clients.
+type VolumeClient interface {
+	StatsDriver
+	BlockDriver
+	Enumerator
+	SnapshotDriver
+	QuiesceDriver
+	CredsDriver
+	CloudBackupDriver
+	ProtoDriverClient
+}
+
 // IODriver interfaces applicable to object store interfaces.
 type IODriver interface {
 	// Read sz bytes from specified volume at specified offset.
@@ -160,18 +172,23 @@ type CloudBackupDriver interface {
 	CloudBackupSchedEnumerate() (*api.CloudBackupSchedEnumerateResponse, error)
 }
 
-// ProtoDriver must be implemented by all volume drivers.  It specifies the
-// most basic functionality, such as creating and deleting volumes.
-type ProtoDriver interface {
-	SnapshotDriver
-	StatsDriver
-	QuiesceDriver
-	CredsDriver
-	CloudBackupDriver
+// ProtoDriverServer contains the non-exported functions
+type ProtoDriverServer interface {
 	// Name returns the name of the driver.
 	Name() string
 	// Type of this driver
 	Type() api.DriverType
+	// MountedAt return volume mounted at specified mountpath.
+	MountedAt(mountPath string) string
+	// Status returns a set of key-value pairs which give low
+	// level diagnostic status about this driver.
+	Status() [][2]string
+	// Shutdown and cleanup.
+	Shutdown()
+}
+
+// ProtoDriverClient contains the interfaces to functions which are exported to clients
+type ProtoDriverClient interface {
 	// Create a new Vol for the specific volume spec.
 	// It returns a system generated VolumeID that uniquely identifies the volume
 	Create(locator *api.VolumeLocator, Source *api.Source, spec *api.VolumeSpec) (string, error)
@@ -181,19 +198,24 @@ type ProtoDriver interface {
 	// Mount volume at specified path
 	// Errors ErrEnoEnt, ErrVolDetached may be returned.
 	Mount(volumeID string, mountPath string, options map[string]string) error
-	// MountedAt return volume mounted at specified mountpath.
-	MountedAt(mountPath string) string
 	// Unmount volume at specified path
 	// Errors ErrEnoEnt, ErrVolDetached may be returned.
 	Unmount(volumeID string, mountPath string, options map[string]string) error
 	// Update not all fields of the spec are supported, ErrNotSupported will be thrown for unsupported
 	// updates.
 	Set(volumeID string, locator *api.VolumeLocator, spec *api.VolumeSpec) error
-	// Status returns a set of key-value pairs which give low
-	// level diagnostic status about this driver.
-	Status() [][2]string
-	// Shutdown and cleanup.
-	Shutdown()
+}
+
+// ProtoDriver must be implemented by all volume drivers.  It specifies the
+// most basic functionality, such as creating and deleting volumes.
+type ProtoDriver interface {
+	SnapshotDriver
+	StatsDriver
+	QuiesceDriver
+	CredsDriver
+	CloudBackupDriver
+	ProtoDriverClient
+	ProtoDriverServer
 }
 
 // Enumerator provides a set of interfaces to get details on a set of volumes.


### PR DESCRIPTION
Just like #390, the Volume interface needed to be cleaned up.
VolumeDriver is the internal interface and the new VolumeClient
is the external exported interface. VolumeClient removed the unused
IO, GraphXXX, Shutdown, MountedAt, and other functions/interfaces.

Also removed Type, and Name from VolumeClient since they always
returned a constant and provided no real value.

Example of Godoc output attached.
[outputFile.pdf](https://github.com/libopenstorage/openstorage/files/1920729/outputFile.pdf)


Signed-off-by: Luis Pabón <luis@portworx.com>
