### PR TITLE
Revert "Cleanup Volume Client REST Golang Interface"

### DIFF
--- a/api/client/volume/client.go
+++ b/api/client/volume/client.go
@@ -1,7 +1,11 @@
 package volume
 
 import (
+	"bytes"
 	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
 	"strconv"
 
 	"github.com/libopenstorage/openstorage/api"
@@ -17,22 +21,104 @@ const (
 	backupPath = "/osd-backup"
 )
 
-// Interface check
-var _ volume.VolumeClient = &VolumeClient{}
-
-// VolumeClient provides a Golang client for the OpenStorage REST server.
-type VolumeClient struct {
+type volumeClient struct {
+	volume.IODriver
 	c *client.Client
 }
 
-// New returns a Golang client to an OpenStorage REST server.
-func New(c *client.Client) *VolumeClient {
-	return &VolumeClient{c}
+func newVolumeClient(c *client.Client) volume.VolumeDriver {
+	return &volumeClient{volume.IONotSupported, c}
+}
+
+// String description of this driver.
+func (v *volumeClient) Name() string {
+	return "VolumeDriver"
+}
+
+func (v *volumeClient) Type() api.DriverType {
+	// Block drivers implement the superset.
+	return api.DriverType_DRIVER_TYPE_BLOCK
+}
+
+func (v *volumeClient) GraphDriverCreate(id string, parent string) error {
+	response := ""
+	if err := v.c.Put().Resource(graphPath + "/create").Instance(id).Do().Unmarshal(&response); err != nil {
+		return err
+	}
+	if response != id {
+		return fmt.Errorf("Invalid response: %s", response)
+	}
+	return nil
+}
+
+func (v *volumeClient) GraphDriverRemove(id string) error {
+	response := ""
+	if err := v.c.Put().Resource(graphPath + "/remove").Instance(id).Do().Unmarshal(&response); err != nil {
+		return err
+	}
+	if response != id {
+		return fmt.Errorf("Invalid response: %s", response)
+	}
+	return nil
+}
+
+func (v *volumeClient) GraphDriverGet(id string, mountLabel string) (string, error) {
+	response := ""
+	if err := v.c.Get().Resource(graphPath + "/inspect").Instance(id).Do().Unmarshal(&response); err != nil {
+		return "", err
+	}
+	return response, nil
+}
+
+func (v *volumeClient) GraphDriverRelease(id string) error {
+	response := ""
+	if err := v.c.Put().Resource(graphPath + "/release").Instance(id).Do().Unmarshal(&response); err != nil {
+		return err
+	}
+	if response != id {
+		return fmt.Errorf("Invalid response: %v", response)
+	}
+	return nil
+}
+
+func (v *volumeClient) GraphDriverExists(id string) bool {
+	response := false
+	v.c.Get().Resource(graphPath + "/exists").Instance(id).Do().Unmarshal(&response)
+	return response
+}
+
+func (v *volumeClient) GraphDriverDiff(id string, parent string) io.Writer {
+	body, _ := v.c.Get().Resource(graphPath + "/diff?id=" + id + "&parent=" + parent).Do().Body()
+	return bytes.NewBuffer(body)
+}
+
+func (v *volumeClient) GraphDriverChanges(id string, parent string) ([]api.GraphDriverChanges, error) {
+	var changes []api.GraphDriverChanges
+	err := v.c.Get().Resource(graphPath + "/changes").Instance(id).Do().Unmarshal(&changes)
+	return changes, err
+}
+
+func (v *volumeClient) GraphDriverApplyDiff(id string, parent string, diff io.Reader) (int, error) {
+	b, err := ioutil.ReadAll(diff)
+	if err != nil {
+		return 0, err
+	}
+	response := 0
+	if err = v.c.Put().Resource(graphPath + "/diff?id=" + id + "&parent=" + parent).Instance(id).Body(b).Do().Unmarshal(&response); err != nil {
+		return 0, err
+	}
+	return response, nil
+}
+
+func (v *volumeClient) GraphDriverDiffSize(id string, parent string) (int, error) {
+	size := 0
+	err := v.c.Get().Resource(graphPath + "/diffsize").Instance(id).Do().Unmarshal(&size)
+	return size, err
 }
 
 // Create a new Vol for the specific volume spev.c.
 // It returns a system generated VolumeID that uniquely identifies the volume
-func (v *VolumeClient) Create(locator *api.VolumeLocator, source *api.Source,
+func (v *volumeClient) Create(locator *api.VolumeLocator, source *api.Source,
 	spec *api.VolumeSpec) (string, error) {
 	response := &api.VolumeCreateResponse{}
 	request := &api.VolumeCreateRequest{
@@ -49,9 +135,14 @@ func (v *VolumeClient) Create(locator *api.VolumeLocator, source *api.Source,
 	return response.Id, nil
 }
 
+// Status diagnostic information
+func (v *volumeClient) Status() [][2]string {
+	return [][2]string{}
+}
+
 // Inspect specified volumes.
 // Errors ErrEnoEnt may be returned.
-func (v *VolumeClient) Inspect(ids []string) ([]*api.Volume, error) {
+func (v *volumeClient) Inspect(ids []string) ([]*api.Volume, error) {
 	if len(ids) == 0 {
 		return nil, nil
 	}
@@ -68,7 +159,7 @@ func (v *VolumeClient) Inspect(ids []string) ([]*api.Volume, error) {
 
 // Delete volume.
 // Errors ErrEnoEnt, ErrVolHasSnaps may be returned.
-func (v *VolumeClient) Delete(volumeID string) error {
+func (v *volumeClient) Delete(volumeID string) error {
 	response := &api.VolumeResponse{}
 	if err := v.c.Delete().Resource(volumePath).Instance(volumeID).Do().Unmarshal(response); err != nil {
 		return err
@@ -79,10 +170,10 @@ func (v *VolumeClient) Delete(volumeID string) error {
 	return nil
 }
 
-// Snapshot specified volume. IO to the underlying volume should be quiesced before
+// Snap specified volume. IO to the underlying volume should be quiesced before
 // calling this function.
 // Errors ErrEnoEnt may be returned
-func (v *VolumeClient) Snapshot(volumeID string, readonly bool,
+func (v *volumeClient) Snapshot(volumeID string, readonly bool,
 	locator *api.VolumeLocator) (string, error) {
 	response := &api.SnapCreateResponse{}
 	request := &api.SnapCreateRequest{
@@ -107,7 +198,7 @@ func (v *VolumeClient) Snapshot(volumeID string, readonly bool,
 }
 
 // Restore specified volume to given snapshot state
-func (v *VolumeClient) Restore(volumeID string, snapID string) error {
+func (v *volumeClient) Restore(volumeID string, snapID string) error {
 	response := &api.VolumeResponse{}
 	req := v.c.Post().Resource(snapPath + "/restore").Instance(volumeID)
 	req.QueryOption(api.OptSnapID, snapID)
@@ -123,7 +214,7 @@ func (v *VolumeClient) Restore(volumeID string, snapID string) error {
 
 // Stats for specified volume.
 // Errors ErrEnoEnt may be returned
-func (v *VolumeClient) Stats(
+func (v *volumeClient) Stats(
 	volumeID string,
 	cumulative bool,
 ) (*api.Stats, error) {
@@ -138,7 +229,7 @@ func (v *VolumeClient) Stats(
 
 // UsedSize returns allocated volume size.
 // Errors ErrEnoEnt may be returned
-func (v *VolumeClient) UsedSize(
+func (v *volumeClient) UsedSize(
 	volumeID string,
 ) (uint64, error) {
 	var usedSize uint64
@@ -148,7 +239,7 @@ func (v *VolumeClient) UsedSize(
 }
 
 // Active Requests on all volume.
-func (v *VolumeClient) GetActiveRequests() (*api.ActiveRequests, error) {
+func (v *volumeClient) GetActiveRequests() (*api.ActiveRequests, error) {
 
 	requests := &api.ActiveRequests{}
 	resp := v.c.Get().Resource(volumePath + "/requests").Instance("vol_id").Do()
@@ -164,9 +255,12 @@ func (v *VolumeClient) GetActiveRequests() (*api.ActiveRequests, error) {
 	return requests, nil
 }
 
+// Shutdown and cleanup.
+func (v *volumeClient) Shutdown() {}
+
 // Enumerate volumes that map to the volumeLocator. Locator fields may be regexp.
 // If locator fields are left blank, this will return all volumes.
-func (v *VolumeClient) Enumerate(locator *api.VolumeLocator,
+func (v *volumeClient) Enumerate(locator *api.VolumeLocator,
 	labels map[string]string) ([]*api.Volume, error) {
 	var volumes []*api.Volume
 	req := v.c.Get().Resource(volumePath)
@@ -192,7 +286,7 @@ func (v *VolumeClient) Enumerate(locator *api.VolumeLocator,
 
 // Enumerate snaps for specified volume
 // Count indicates the number of snaps populated.
-func (v *VolumeClient) SnapEnumerate(ids []string,
+func (v *volumeClient) SnapEnumerate(ids []string,
 	snapLabels map[string]string) ([]*api.Volume, error) {
 	var volumes []*api.Volume
 	request := v.c.Get().Resource(snapPath)
@@ -211,7 +305,7 @@ func (v *VolumeClient) SnapEnumerate(ids []string,
 // Attach map device to the host.
 // On success the devicePath specifies location where the device is exported
 // Errors ErrEnoEnt, ErrVolAttached may be returned.
-func (v *VolumeClient) Attach(volumeID string, attachOptions map[string]string) (string, error) {
+func (v *volumeClient) Attach(volumeID string, attachOptions map[string]string) (string, error) {
 	response, err := v.doVolumeSetGetResponse(
 		volumeID,
 		&api.VolumeSetRequest{
@@ -236,7 +330,7 @@ func (v *VolumeClient) Attach(volumeID string, attachOptions map[string]string) 
 
 // Detach device from the host.
 // Errors ErrEnoEnt, ErrVolDetached may be returned.
-func (v *VolumeClient) Detach(volumeID string, options map[string]string) error {
+func (v *volumeClient) Detach(volumeID string, options map[string]string) error {
 	return v.doVolumeSet(
 		volumeID,
 		&api.VolumeSetRequest{
@@ -248,9 +342,13 @@ func (v *VolumeClient) Detach(volumeID string, options map[string]string) error 
 	)
 }
 
+func (v *volumeClient) MountedAt(mountPath string) string {
+	return ""
+}
+
 // Mount volume at specified path
 // Errors ErrEnoEnt, ErrVolDetached may be returned.
-func (v *VolumeClient) Mount(volumeID string, mountPath string, options map[string]string) error {
+func (v *volumeClient) Mount(volumeID string, mountPath string, options map[string]string) error {
 	return v.doVolumeSet(
 		volumeID,
 		&api.VolumeSetRequest{
@@ -265,7 +363,7 @@ func (v *VolumeClient) Mount(volumeID string, mountPath string, options map[stri
 
 // Unmount volume at specified path
 // Errors ErrEnoEnt, ErrVolDetached may be returned.
-func (v *VolumeClient) Unmount(volumeID string, mountPath string, options map[string]string) error {
+func (v *volumeClient) Unmount(volumeID string, mountPath string, options map[string]string) error {
 	return v.doVolumeSet(
 		volumeID,
 		&api.VolumeSetRequest{
@@ -279,7 +377,7 @@ func (v *VolumeClient) Unmount(volumeID string, mountPath string, options map[st
 }
 
 // Update volume
-func (v *VolumeClient) Set(volumeID string, locator *api.VolumeLocator,
+func (v *volumeClient) Set(volumeID string, locator *api.VolumeLocator,
 	spec *api.VolumeSpec) error {
 	return v.doVolumeSet(
 		volumeID,
@@ -290,13 +388,13 @@ func (v *VolumeClient) Set(volumeID string, locator *api.VolumeLocator,
 	)
 }
 
-func (v *VolumeClient) doVolumeSet(volumeID string,
+func (v *volumeClient) doVolumeSet(volumeID string,
 	request *api.VolumeSetRequest) error {
 	_, err := v.doVolumeSetGetResponse(volumeID, request)
 	return err
 }
 
-func (v *VolumeClient) doVolumeSetGetResponse(volumeID string,
+func (v *volumeClient) doVolumeSetGetResponse(volumeID string,
 	request *api.VolumeSetRequest) (*api.VolumeSetResponse, error) {
 	response := &api.VolumeSetResponse{}
 	if err := v.c.Put().Resource(volumePath).Instance(volumeID).Body(request).Do().Unmarshal(response); err != nil {
@@ -309,7 +407,7 @@ func (v *VolumeClient) doVolumeSetGetResponse(volumeID string,
 }
 
 // Quiesce quiesces volume i/o
-func (v *VolumeClient) Quiesce(
+func (v *volumeClient) Quiesce(
 	volumeID string,
 	timeoutSec uint64,
 	quiesceID string,
@@ -328,7 +426,7 @@ func (v *VolumeClient) Quiesce(
 }
 
 // Unquiesce un-quiesces volume i/o
-func (v *VolumeClient) Unquiesce(volumeID string) error {
+func (v *volumeClient) Unquiesce(volumeID string) error {
 	response := &api.VolumeResponse{}
 	req := v.c.Post().Resource(volumePath + "/unquiesce").Instance(volumeID)
 	if err := req.Do().Unmarshal(response); err != nil {
@@ -341,14 +439,14 @@ func (v *VolumeClient) Unquiesce(volumeID string) error {
 }
 
 // CredsEnumerate enumerates configured credentials in the cluster
-func (v *VolumeClient) CredsEnumerate() (map[string]interface{}, error) {
+func (v *volumeClient) CredsEnumerate() (map[string]interface{}, error) {
 	creds := make(map[string]interface{}, 0)
 	err := v.c.Get().Resource(credsPath).Do().Unmarshal(&creds)
 	return creds, err
 }
 
 // CredsCreate creates credentials for a given cloud provider
-func (v *VolumeClient) CredsCreate(params map[string]string) (string, error) {
+func (v *volumeClient) CredsCreate(params map[string]string) (string, error) {
 	createResponse := api.CredCreateResponse{}
 	request := &api.CredCreateRequest{
 		InputParams: params,
@@ -365,7 +463,7 @@ func (v *VolumeClient) CredsCreate(params map[string]string) (string, error) {
 }
 
 // CredsDelete deletes the credential with given UUID
-func (v *VolumeClient) CredsDelete(uuid string) error {
+func (v *volumeClient) CredsDelete(uuid string) error {
 	req := v.c.Delete().Resource(credsPath).Instance(uuid)
 	response := req.Do()
 	if response.Error() != nil {
@@ -376,7 +474,7 @@ func (v *VolumeClient) CredsDelete(uuid string) error {
 
 // CredsValidate validates the credential by accessuing the cloud
 // provider with the given credential
-func (v *VolumeClient) CredsValidate(uuid string) error {
+func (v *volumeClient) CredsValidate(uuid string) error {
 	req := v.c.Put().Resource(credsPath + "/validate").Instance(uuid)
 	response := req.Do()
 	if response.Error() != nil {
@@ -386,7 +484,7 @@ func (v *VolumeClient) CredsValidate(uuid string) error {
 }
 
 // CloudBackupCreate uploads snapshot of a volume to cloud
-func (v *VolumeClient) CloudBackupCreate(
+func (v *volumeClient) CloudBackupCreate(
 	input *api.CloudBackupCreateRequest,
 ) error {
 	req := v.c.Post().Resource(backupPath).Body(input)
@@ -398,7 +496,7 @@ func (v *VolumeClient) CloudBackupCreate(
 }
 
 // CloudBackupRestore downloads a cloud backup to a newly created volume
-func (v *VolumeClient) CloudBackupRestore(
+func (v *volumeClient) CloudBackupRestore(
 	input *api.CloudBackupRestoreRequest,
 ) (*api.CloudBackupRestoreResponse, error) {
 	restoreResponse := &api.CloudBackupRestoreResponse{}
@@ -415,7 +513,7 @@ func (v *VolumeClient) CloudBackupRestore(
 }
 
 // CloudBackupEnumerate lists the backups for a given cluster/credential/volumeID
-func (v *VolumeClient) CloudBackupEnumerate(
+func (v *volumeClient) CloudBackupEnumerate(
 	input *api.CloudBackupEnumerateRequest,
 ) (*api.CloudBackupEnumerateResponse, error) {
 	enumerateResponse := &api.CloudBackupEnumerateResponse{}
@@ -432,7 +530,7 @@ func (v *VolumeClient) CloudBackupEnumerate(
 }
 
 // CloudBackupDelete deletes the backups in cloud
-func (v *VolumeClient) CloudBackupDelete(
+func (v *volumeClient) CloudBackupDelete(
 	input *api.CloudBackupDeleteRequest,
 ) error {
 	req := v.c.Delete().Resource(backupPath).Body(input)
@@ -444,7 +542,7 @@ func (v *VolumeClient) CloudBackupDelete(
 }
 
 // CloudBackupDeleteAll deletes all the backups for a volume in cloud
-func (v *VolumeClient) CloudBackupDeleteAll(
+func (v *volumeClient) CloudBackupDeleteAll(
 	input *api.CloudBackupDeleteAllRequest,
 ) error {
 	req := v.c.Delete().Resource(backupPath + "/all").Body(input)
@@ -456,7 +554,7 @@ func (v *VolumeClient) CloudBackupDeleteAll(
 }
 
 // CloudBackupStatus gets the most recent status of backup/restores
-func (v *VolumeClient) CloudBackupStatus(
+func (v *volumeClient) CloudBackupStatus(
 	input *api.CloudBackupStatusRequest,
 ) (*api.CloudBackupStatusResponse, error) {
 	statusResponse := &api.CloudBackupStatusResponse{}
@@ -473,7 +571,7 @@ func (v *VolumeClient) CloudBackupStatus(
 }
 
 // CloudBackupCatalog displays listing of backup content
-func (v *VolumeClient) CloudBackupCatalog(
+func (v *volumeClient) CloudBackupCatalog(
 	input *api.CloudBackupCatalogRequest,
 ) (*api.CloudBackupCatalogResponse, error) {
 	catalogResponse := &api.CloudBackupCatalogResponse{}
@@ -490,7 +588,7 @@ func (v *VolumeClient) CloudBackupCatalog(
 }
 
 // CloudBackupHistory displays past backup/restore operations in the cluster
-func (v *VolumeClient) CloudBackupHistory(
+func (v *volumeClient) CloudBackupHistory(
 	input *api.CloudBackupHistoryRequest,
 ) (*api.CloudBackupHistoryResponse, error) {
 	historyResponse := &api.CloudBackupHistoryResponse{}
@@ -508,7 +606,7 @@ func (v *VolumeClient) CloudBackupHistory(
 
 // CloudBackupState allows a current backup
 // state transisions(pause/resume/stop)
-func (v *VolumeClient) CloudBackupStateChange(
+func (v *volumeClient) CloudBackupStateChange(
 	input *api.CloudBackupStateChangeRequest,
 ) error {
 	req := v.c.Put().Resource(backupPath + "/statechange").Body(input)
@@ -520,7 +618,7 @@ func (v *VolumeClient) CloudBackupStateChange(
 }
 
 // CloudBackupSchedCreate for a volume creates a schedule to backup volume to cloud
-func (v *VolumeClient) CloudBackupSchedCreate(
+func (v *volumeClient) CloudBackupSchedCreate(
 	input *api.CloudBackupSchedCreateRequest,
 ) (*api.CloudBackupSchedCreateResponse, error) {
 	createResponse := &api.CloudBackupSchedCreateResponse{}
@@ -537,7 +635,7 @@ func (v *VolumeClient) CloudBackupSchedCreate(
 }
 
 // CloudBackupSchedDelete delete a volume's cloud backup-schedule
-func (v *VolumeClient) CloudBackupSchedDelete(
+func (v *volumeClient) CloudBackupSchedDelete(
 	input *api.CloudBackupSchedDeleteRequest,
 ) error {
 	req := v.c.Delete().Resource(backupPath + "/sched").Body(input)
@@ -549,7 +647,7 @@ func (v *VolumeClient) CloudBackupSchedDelete(
 }
 
 // CloudBackupSchedEnumerate enumerates the configured backup-schedules in the cluster
-func (v *VolumeClient) CloudBackupSchedEnumerate() (*api.CloudBackupSchedEnumerateResponse, error) {
+func (v *volumeClient) CloudBackupSchedEnumerate() (*api.CloudBackupSchedEnumerateResponse, error) {
 	enumerateResponse := &api.CloudBackupSchedEnumerateResponse{}
 	req := v.c.Get().Resource(backupPath + "/sched")
 	response := req.Do()
@@ -562,8 +660,7 @@ func (v *VolumeClient) CloudBackupSchedEnumerate() (*api.CloudBackupSchedEnumera
 	return enumerateResponse, nil
 }
 
-// SnapshotGroup creates a consistency group snapshot across multiple volumes referenced by the label
-func (v *VolumeClient) SnapshotGroup(groupID string, labels map[string]string) (*api.GroupSnapCreateResponse, error) {
+func (v *volumeClient) SnapshotGroup(groupID string, labels map[string]string) (*api.GroupSnapCreateResponse, error) {
 
 	response := &api.GroupSnapCreateResponse{}
 	request := &api.GroupSnapCreateRequest{

--- a/api/client/volume/volume.go
+++ b/api/client/volume/volume.go
@@ -2,15 +2,14 @@ package volume
 
 import (
 	"fmt"
-
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/libopenstorage/openstorage/api/client"
 	"github.com/libopenstorage/openstorage/volume"
 )
 
 // VolumeDriver returns a REST wrapper for the VolumeDriver interface.
-func VolumeDriver(c *client.Client) volume.VolumeClient {
-	return New(c)
+func VolumeDriver(c *client.Client) volume.VolumeDriver {
+	return newVolumeClient(c)
 }
 
 // NewAuthDriverClient returns a new REST client of the supplied version for specified driver.

--- a/pkg/sanity/backup_restore.go
+++ b/pkg/sanity/backup_restore.go
@@ -33,7 +33,7 @@ import (
 var _ = Describe("Volume [Backup Restore Tests]", func() {
 	var (
 		restClient   *client.Client
-		volumedriver volume.VolumeClient
+		volumedriver volume.VolumeDriver
 		credentials  *api.CredCreateRequest
 		credUUID     string
 		credsUUIDMap map[string]string

--- a/pkg/sanity/cluster.go
+++ b/pkg/sanity/cluster.go
@@ -123,7 +123,7 @@ var _ = Describe("Cluster [Cluster Tests]", func() {
 			err              error
 			volumeID         string
 			numVolumesBefore int
-			volumedriver     volume.VolumeClient
+			volumedriver     volume.VolumeDriver
 			restClient       *client.Client
 		)
 

--- a/pkg/sanity/creds.go
+++ b/pkg/sanity/creds.go
@@ -30,7 +30,7 @@ import (
 var _ = Describe("Credentials Tests", func() {
 	var (
 		restClient   *client.Client
-		volumedriver volume.VolumeClient
+		volumedriver volume.VolumeDriver
 		credentials  *api.CredCreateRequest
 	)
 

--- a/pkg/sanity/osd_test_util.go
+++ b/pkg/sanity/osd_test_util.go
@@ -36,7 +36,7 @@ const (
 )
 
 func testIfVolumeCreatedSuccessfully(
-	volumedriver volume.VolumeClient,
+	volumedriver volume.VolumeDriver,
 	volumeID string,
 	numVolumesBefore int,
 	vr *api.VolumeCreateRequest) {

--- a/pkg/sanity/snapshot.go
+++ b/pkg/sanity/snapshot.go
@@ -32,7 +32,7 @@ import (
 var _ = Describe("Volume [Snapshot Tests]", func() {
 	var (
 		restClient   *client.Client
-		volumedriver volume.VolumeClient
+		volumedriver volume.VolumeDriver
 	)
 
 	BeforeEach(func() {

--- a/pkg/sanity/volume.go
+++ b/pkg/sanity/volume.go
@@ -34,7 +34,7 @@ import (
 var _ = Describe("Volume [Volume Tests]", func() {
 	var (
 		restClient   *client.Client
-		volumedriver volume.VolumeClient
+		volumedriver volume.VolumeDriver
 	)
 
 	BeforeEach(func() {

--- a/volume/drivers/pwx/pwx.go
+++ b/volume/drivers/pwx/pwx.go
@@ -18,7 +18,7 @@ const (
 )
 
 type driver struct {
-	volume.VolumeClient
+	volume.VolumeDriver
 }
 
 // Init initialized the Portworx driver.
@@ -38,7 +38,7 @@ func Init(params map[string]string) (volume.VolumeDriver, error) {
 		return nil, err
 	}
 
-	return &driver{VolumeClient: volumeclient.VolumeDriver(c)}, nil
+	return &driver{VolumeDriver: volumeclient.VolumeDriver(c)}, nil
 }
 
 func (d *driver) Name() string {
@@ -48,25 +48,3 @@ func (d *driver) Name() string {
 func (d *driver) Type() api.DriverType {
 	return Type
 }
-
-func (d *driver) Read(volumeID string, buf []byte, sz uint64, offset int64) (int64, error) {
-	return 0, volume.ErrNotSupported
-}
-
-func (d *driver) Write(volumeID string, buf []byte, sz uint64, offset int64) (int64, error) {
-	return 0, volume.ErrNotSupported
-}
-
-func (d *driver) Flush(volumeID string) error {
-	return volume.ErrNotSupported
-}
-
-func (d *driver) MountedAt(mountPath string) string {
-	return ""
-}
-
-func (d *driver) Status() [][2]string {
-	return [][2]string{}
-}
-
-func (d *driver) Shutdown() {}

--- a/volume/drivers/test/driver.go
+++ b/volume/drivers/test/driver.go
@@ -31,7 +31,7 @@ func init() {
 // Context maintains current device state. It gets passed into tests
 // so that tests can build on other tests' work
 type Context struct {
-	volume.VolumeClient
+	volume.VolumeDriver
 	volID         string
 	snapID        string
 	mountPath     string
@@ -45,14 +45,14 @@ type Context struct {
 }
 
 // NewContext returns a new Context
-func NewContext(d volume.VolumeClient) *Context {
+func NewContext(d volume.VolumeDriver) *Context {
 	return &Context{
-		VolumeClient: d,
+		VolumeDriver: d,
 		volID:        "",
 		snapID:       "",
 		Filesystem:   api.FSType_FS_TYPE_NONE,
-		testPath:     path.Join("/mnt/openstorage/mount/volumeDriver"),
-		testFile:     path.Join("/tmp/volumeDriver"),
+		testPath:     path.Join("/mnt/openstorage/mount/", d.Name()),
+		testFile:     path.Join("/tmp/", d.Name()),
 	}
 }
 
@@ -82,6 +82,7 @@ func runEnd(t *testing.T, ctx *Context) {
 	time.Sleep(time.Second * 2)
 	os.RemoveAll(ctx.testPath)
 	os.Remove(ctx.testFile)
+	shutdown(t, ctx)
 }
 
 // RunSnap runs only the snap related tests
@@ -254,6 +255,11 @@ func unmount(t *testing.T, ctx *Context) {
 	require.NoError(t, err, "Failed in unmount %v", ctx.mountPath)
 
 	ctx.mountPath = ""
+}
+
+func shutdown(t *testing.T, ctx *Context) {
+	fmt.Println("shutdown")
+	ctx.Shutdown()
 }
 
 func io(t *testing.T, ctx *Context) {

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -84,18 +84,6 @@ type VolumeDriver interface {
 	Enumerator
 }
 
-// VolumeClient contains the exported functions to external clients.
-type VolumeClient interface {
-	StatsDriver
-	BlockDriver
-	Enumerator
-	SnapshotDriver
-	QuiesceDriver
-	CredsDriver
-	CloudBackupDriver
-	ProtoDriverClient
-}
-
 // IODriver interfaces applicable to object store interfaces.
 type IODriver interface {
 	// Read sz bytes from specified volume at specified offset.
@@ -172,23 +160,18 @@ type CloudBackupDriver interface {
 	CloudBackupSchedEnumerate() (*api.CloudBackupSchedEnumerateResponse, error)
 }
 
-// ProtoDriverServer contains the non-exported functions
-type ProtoDriverServer interface {
+// ProtoDriver must be implemented by all volume drivers.  It specifies the
+// most basic functionality, such as creating and deleting volumes.
+type ProtoDriver interface {
+	SnapshotDriver
+	StatsDriver
+	QuiesceDriver
+	CredsDriver
+	CloudBackupDriver
 	// Name returns the name of the driver.
 	Name() string
 	// Type of this driver
 	Type() api.DriverType
-	// MountedAt return volume mounted at specified mountpath.
-	MountedAt(mountPath string) string
-	// Status returns a set of key-value pairs which give low
-	// level diagnostic status about this driver.
-	Status() [][2]string
-	// Shutdown and cleanup.
-	Shutdown()
-}
-
-// ProtoDriverClient contains the interfaces to functions which are exported to clients
-type ProtoDriverClient interface {
 	// Create a new Vol for the specific volume spec.
 	// It returns a system generated VolumeID that uniquely identifies the volume
 	Create(locator *api.VolumeLocator, Source *api.Source, spec *api.VolumeSpec) (string, error)
@@ -198,24 +181,19 @@ type ProtoDriverClient interface {
 	// Mount volume at specified path
 	// Errors ErrEnoEnt, ErrVolDetached may be returned.
 	Mount(volumeID string, mountPath string, options map[string]string) error
+	// MountedAt return volume mounted at specified mountpath.
+	MountedAt(mountPath string) string
 	// Unmount volume at specified path
 	// Errors ErrEnoEnt, ErrVolDetached may be returned.
 	Unmount(volumeID string, mountPath string, options map[string]string) error
 	// Update not all fields of the spec are supported, ErrNotSupported will be thrown for unsupported
 	// updates.
 	Set(volumeID string, locator *api.VolumeLocator, spec *api.VolumeSpec) error
-}
-
-// ProtoDriver must be implemented by all volume drivers.  It specifies the
-// most basic functionality, such as creating and deleting volumes.
-type ProtoDriver interface {
-	SnapshotDriver
-	StatsDriver
-	QuiesceDriver
-	CredsDriver
-	CloudBackupDriver
-	ProtoDriverClient
-	ProtoDriverServer
+	// Status returns a set of key-value pairs which give low
+	// level diagnostic status about this driver.
+	Status() [][2]string
+	// Shutdown and cleanup.
+	Shutdown()
 }
 
 // Enumerator provides a set of interfaces to get details on a set of volumes.


### PR DESCRIPTION
Reverts libopenstorage/openstorage#399

While moving this forward to Px, it looks like the "internal" functions are not used. Looks like it would be easier to just clean up VolumeDriver from the functions we do not use.