### PR TITLE
sdk: Create new library for gRPC servers

### DIFF
--- a/csi/csi.go
+++ b/csi/csi.go
@@ -18,16 +18,13 @@ package csi
 
 import (
 	"fmt"
-	"net"
-	"sync"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
-	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/reflection"
 
 	"github.com/libopenstorage/openstorage/api/spec"
 	"github.com/libopenstorage/openstorage/cluster"
+	"github.com/libopenstorage/openstorage/pkg/grpcserver"
 	"github.com/libopenstorage/openstorage/volume"
 	volumedrivers "github.com/libopenstorage/openstorage/volume/drivers"
 )
@@ -44,117 +41,54 @@ type OsdCsiServerConfig struct {
 // OsdCsiServer is a OSD CSI compliant server which
 // proxies CSI requests for a single specific driver
 type OsdCsiServer struct {
-	Server
-	listener    net.Listener
-	server      *grpc.Server
+	csi.ControllerServer
+	csi.NodeServer
+	csi.IdentityServer
+
+	*grpcserver.GrpcServer
+	specHandler spec.SpecHandler
 	driver      volume.VolumeDriver
 	cluster     cluster.Cluster
-	wg          sync.WaitGroup
-	running     bool
-	lock        sync.Mutex
-	specHandler spec.SpecHandler
 }
 
 // NewOsdCsiServer creates a gRPC CSI complient server on the
 // specified port and transport.
-func NewOsdCsiServer(config *OsdCsiServerConfig) (Server, error) {
+func NewOsdCsiServer(config *OsdCsiServerConfig) (grpcserver.Server, error) {
 	if nil == config {
-		return nil, fmt.Errorf("Configuration must be provided")
-	}
-	if len(config.Address) == 0 {
-		return nil, fmt.Errorf("Address must be provided")
-	}
-	if len(config.Net) == 0 {
-		return nil, fmt.Errorf("Net must be provided")
+		return nil, fmt.Errorf("Must supply configuration")
 	}
 	if len(config.DriverName) == 0 {
 		return nil, fmt.Errorf("OSD Driver name must be provided")
 	}
-
 	// Save the driver for future calls
 	d, err := volumedrivers.Get(config.DriverName)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to get driver %s info: %s", config.DriverName, err.Error())
 	}
 
-	l, err := net.Listen(config.Net, config.Address)
+	gServer, err := grpcserver.New(&grpcserver.GrpcServerConfig{
+		Name:    "CSI",
+		Net:     config.Net,
+		Address: config.Address,
+	})
 	if err != nil {
-		return nil, fmt.Errorf("Unable to setup server: %s", err.Error())
+		return nil, fmt.Errorf("Failed to create CSI server: %v", err)
 	}
 
 	return &OsdCsiServer{
-		listener:    l,
+		specHandler: spec.NewSpecHandler(),
+		GrpcServer:  gServer,
 		driver:      d,
 		cluster:     config.Cluster,
-		specHandler: spec.NewSpecHandler(),
 	}, nil
 }
 
 // Start is used to start the server.
 // It will return an error if the server is already running.
 func (s *OsdCsiServer) Start() error {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	if s.running {
-		return fmt.Errorf("Server already running")
-	}
-
-	s.server = grpc.NewServer()
-
-	csi.RegisterIdentityServer(s.server, s)
-	csi.RegisterControllerServer(s.server, s)
-	csi.RegisterNodeServer(s.server, s)
-	reflection.Register(s.server)
-
-	// Start listening for requests
-	logrus.Infof("CSI Server ready on %s", s.Address())
-	waitForServer := make(chan bool)
-	s.goServe(waitForServer)
-	<-waitForServer
-
-	s.running = true
-	return nil
-}
-
-// Stop is used to stop the gRPC CSI complient server.
-// It can be called multiple times. It does nothing if the server
-// has already been stopped.
-func (s *OsdCsiServer) Stop() {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	if !s.running {
-		return
-	}
-
-	s.server.Stop()
-	s.wg.Wait()
-	s.running = false
-}
-
-// Address returns the address of the server which can be
-// used by clients to connect.
-func (s *OsdCsiServer) Address() string {
-	return s.listener.Addr().String()
-}
-
-// IsRunning returns true if the server is currently running
-func (s *OsdCsiServer) IsRunning() bool {
-	s.lock.Lock()
-	defer s.lock.Unlock()
-
-	return s.running
-}
-
-func (s *OsdCsiServer) goServe(started chan<- bool) {
-	s.wg.Add(1)
-	go func() {
-		defer s.wg.Done()
-		started <- true
-		err := s.server.Serve(s.listener)
-		if err != nil {
-			logrus.Fatalf("ERROR: Unable to start gRPC server: %s\n", err.Error())
-		}
-	}()
+	return s.GrpcServer.Start(func(grpcServer *grpc.Server) {
+		csi.RegisterIdentityServer(grpcServer, s)
+		csi.RegisterControllerServer(grpcServer, s)
+		csi.RegisterNodeServer(grpcServer, s)
+	})
 }

--- a/csi/csi_test.go
+++ b/csi/csi_test.go
@@ -28,6 +28,7 @@ import (
 	"golang.org/x/net/context"
 
 	mockcluster "github.com/libopenstorage/openstorage/cluster/mock"
+	"github.com/libopenstorage/openstorage/pkg/grpcserver"
 	"github.com/libopenstorage/openstorage/volume"
 	volumedrivers "github.com/libopenstorage/openstorage/volume/drivers"
 	mockdriver "github.com/libopenstorage/openstorage/volume/drivers/mock"
@@ -41,7 +42,7 @@ const (
 // the creation and setup of the gRPC CSI service
 type testServer struct {
 	conn   *grpc.ClientConn
-	server Server
+	server grpcserver.Server
 	m      *mockdriver.MockVolumeDriver
 	c      *mockcluster.MockCluster
 	mc     *gomock.Controller
@@ -112,7 +113,7 @@ func (s *testServer) Conn() *grpc.ClientConn {
 	return s.conn
 }
 
-func (s *testServer) Server() Server {
+func (s *testServer) Server() grpcserver.Server {
 	return s.server
 }
 

--- a/pkg/grpcserver/grpcserver.go
+++ b/pkg/grpcserver/grpcserver.go
@@ -1,0 +1,139 @@
+/*
+Package grpcserver is a generic gRPC server manager
+Copyright 2018 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package grpcserver
+
+import (
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+)
+
+// GrpcServerConfig provides the configuration to the
+// the gRPC server created by NewGrpcServer()
+type GrpcServerConfig struct {
+	Name    string
+	Net     string
+	Address string
+}
+
+// GrpcServer is a server manager for gRPC implementations
+type GrpcServer struct {
+	name     string
+	listener net.Listener
+	server   *grpc.Server
+	wg       sync.WaitGroup
+	running  bool
+	lock     sync.Mutex
+}
+
+// New creates a gRPC server on the specified port and transport.
+func New(config *GrpcServerConfig) (*GrpcServer, error) {
+	if nil == config {
+		return nil, fmt.Errorf("Configuration must be provided")
+	}
+	if len(config.Name) == 0 {
+		return nil, fmt.Errorf("Name of server must be provided")
+	}
+	if len(config.Address) == 0 {
+		return nil, fmt.Errorf("Address must be provided")
+	}
+	if len(config.Net) == 0 {
+		return nil, fmt.Errorf("Net must be provided")
+	}
+
+	l, err := net.Listen(config.Net, config.Address)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to setup server: %s", err.Error())
+	}
+
+	return &GrpcServer{
+		name:     config.Name,
+		listener: l,
+	}, nil
+}
+
+// Start is used to start the server.
+// It will return an error if the server is already runnig.
+func (s *GrpcServer) Start(register func(grpcServer *grpc.Server)) error {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if s.running {
+		return fmt.Errorf("Server already running")
+	}
+
+	s.server = grpc.NewServer()
+	register(s.server)
+	reflection.Register(s.server)
+
+	// Start listening for requests
+	logrus.Infof("%s gRPC Server ready on %s", s.name, s.Address())
+	waitForServer := make(chan bool)
+	s.goServe(waitForServer)
+	<-waitForServer
+
+	s.running = true
+	return nil
+}
+
+// Stop is used to stop the gRPC server.
+// It can be called multiple times. It does nothing if the server
+// has already been stopped.
+func (s *GrpcServer) Stop() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	if !s.running {
+		return
+	}
+
+	s.server.Stop()
+	s.wg.Wait()
+	s.running = false
+}
+
+// Address returns the address of the server which can be
+// used by clients to connect.
+func (s *GrpcServer) Address() string {
+	return s.listener.Addr().String()
+}
+
+// IsRunning returns true if the server is currently running
+func (s *GrpcServer) IsRunning() bool {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+
+	return s.running
+}
+
+func (s *GrpcServer) goServe(started chan<- bool) {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+		started <- true
+		err := s.server.Serve(s.listener)
+		if err != nil {
+			logrus.Fatalf("ERROR: Unable to start %s gRPC server: %s\n",
+				s.name,
+				err.Error())
+		}
+	}()
+}

--- a/pkg/grpcserver/grpcserver_test.go
+++ b/pkg/grpcserver/grpcserver_test.go
@@ -1,0 +1,152 @@
+/*
+Package grpcserver is a generic gRPC server manager
+Copyright 2018 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package grpcserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+// testServer is a simple struct used abstract
+// the creation and setup of the gRPC service
+type testServer struct {
+	conn   *grpc.ClientConn
+	server *GrpcServer
+}
+
+func newTestServer(t *testing.T) *testServer {
+	tester := &testServer{}
+
+	var err error
+	// Setup simple driver
+	tester.server, err = New(&GrpcServerConfig{
+		Name:    "unit-test",
+		Net:     "tcp",
+		Address: "127.0.0.1:0",
+	})
+	assert.Nil(t, err)
+
+	// Test Start
+	var testGrpcServer *grpc.Server
+	startCalled := false
+	err = tester.server.Start(func(grpcServer *grpc.Server) {
+		testGrpcServer = grpcServer
+		startCalled = true
+	})
+	assert.Nil(t, err)
+	assert.NotNil(t, testGrpcServer)
+	assert.True(t, startCalled)
+
+	// Setup a connection to the driver
+	tester.conn, err = grpc.Dial(tester.server.Address(), grpc.WithInsecure())
+	assert.Nil(t, err)
+
+	return tester
+}
+
+func (s *testServer) Stop() {
+	// Shutdown servers
+	s.conn.Close()
+	s.server.Stop()
+}
+
+func (s *testServer) Conn() *grpc.ClientConn {
+	return s.conn
+}
+
+func (s *testServer) Server() *GrpcServer {
+	return s.server
+}
+
+func TestGrpcServerStartConfig(t *testing.T) {
+	_, err := New(nil)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Configuration")
+
+	_, err = New(&GrpcServerConfig{})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "must be provided")
+
+	_, err = New(&GrpcServerConfig{
+		Name: "name",
+		Net:  "net",
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Address")
+
+	_, err = New(&GrpcServerConfig{
+		Address: "address",
+		Net:     "net",
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Name")
+
+	_, err = New(&GrpcServerConfig{
+		Name:    "name",
+		Address: "address",
+	})
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Net")
+
+}
+
+func TestGrpcServerStart(t *testing.T) {
+	s := newTestServer(t)
+	assert.True(t, s.Server().IsRunning())
+	defer s.Stop()
+
+	// Check if we can still talk to the server
+	// after starting multiple times.
+	called := false
+	err := s.Server().Start(func(grpcserver *grpc.Server) {
+		called = true
+	})
+	assert.False(t, called)
+	assert.True(t, s.Server().IsRunning())
+	assert.NotNil(t, err)
+	err = s.Server().Start(func(grpcserver *grpc.Server) {
+		called = true
+	})
+	assert.False(t, called)
+	assert.True(t, s.Server().IsRunning())
+	assert.NotNil(t, err)
+	err = s.Server().Start(func(grpcserver *grpc.Server) {
+		called = true
+	})
+	assert.False(t, called)
+	assert.True(t, s.Server().IsRunning())
+	assert.NotNil(t, err)
+
+}
+
+func TestServerStop(t *testing.T) {
+	s := newTestServer(t)
+	assert.True(t, s.Server().IsRunning())
+	s.Stop()
+	assert.False(t, s.Server().IsRunning())
+
+	assert.NotPanics(t, s.Stop)
+	assert.False(t, s.Server().IsRunning())
+	assert.NotPanics(t, s.Stop)
+	assert.False(t, s.Server().IsRunning())
+	assert.NotPanics(t, s.Stop)
+	assert.False(t, s.Server().IsRunning())
+	assert.NotPanics(t, s.Stop)
+	assert.False(t, s.Server().IsRunning())
+}

--- a/pkg/grpcserver/server.go
+++ b/pkg/grpcserver/server.go
@@ -1,6 +1,6 @@
 /*
-Package csi is CSI driver interface for OSD
-Copyright 2017 Portworx
+Package grpcserver is a generic gRPC server manager
+Copyright 2018 Portworx
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,20 +14,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package csi
+package grpcserver
 
-import (
-	csi "github.com/container-storage-interface/spec/lib/go/csi/v0"
-)
-
-// Server is an interface to a CSI Compatible gRPC server
-// which implements not only the CSI spec APIs but also
-// server management APIs.
+// Server is an interface to a gRPC server which provides an implementation
+// of an exported gRPC interface
 type Server interface {
-	csi.ControllerServer
-	csi.IdentityServer
-	csi.NodeServer
-
 	// Start the server. If called on a running server it will return an error.
 	Start() error
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This changes provides management of gRPC servers which will be
shared between CSI and SDK.

**Which issue(s) this PR fixes** (optional)
Part of #407
