### PR TITLE
Remove lint from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ services:
   - docker
 language: go
 go:
-  - 1.8.5
-  - 1.9.2
+  - 1.9.5
+  - 1.x
 before_install:
   - sudo apt-get update -yq
   - sudo apt-get -o Dpkg::Options::="--force-confnew" install -yq docker-ce
@@ -18,11 +18,8 @@ script:
   - go fmt $(go list ./... | grep -v vendor) | wc -l | grep 0
   - make install
   - make vet
-  - make lint
   - make docker-test
   - make docs
-  - make docker-coverage
-  - goveralls -coverprofile=/mnt/coverage.out -service=travis-ci -repotoken "${COVERALLS_TOKEN}"
   - if [ "${TRAVIS_BRANCH}" == "master" ] && [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
       make docker-build-osd;
       docker login -u "${DOCKER_USER}" -p "${DOCKER_PASS}";


### PR DESCRIPTION
make lint does not did not provide any benefits since it was not run
against any package, but if it failed to download, it would fail travis.

Closes #398
