### PR TITLE
Add helper API to wait for completion of cloudbackup operations

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -323,13 +323,25 @@ const (
 	CloudRestoreOp = CloudBackupOpType("Restore")
 )
 
+type CloudBackupStatusType string
+
+const (
+	CloudBackupStatusNotStarted = CloudBackupStatusType("NotStarted")
+	CloudBackupStatusDone       = CloudBackupStatusType("Done")
+	CloudBackupStatusAborted    = CloudBackupStatusType("Aborted")
+	CloudBackupStatusPaused     = CloudBackupStatusType("Paused")
+	CloudBackupStatusStopped    = CloudBackupStatusType("Stopped")
+	CloudBackupStatusActive     = CloudBackupStatusType("Active")
+	CloudBackupStatusFailed     = CloudBackupStatusType("Failed")
+)
+
 type CloudBackupStatus struct {
 	// ID is the ID for the operation
 	ID string
 	// OpType indicates if this is a backup or restore
 	OpType CloudBackupOpType
 	// State indicates if the op is currently active/done/failed
-	Status string
+	Status CloudBackupStatusType
 	// BytesDone indicates total Bytes uploaded/downloaded
 	BytesDone uint64
 	// StartTime indicates Op's start time

--- a/pkg/sanity/backup_restore.go
+++ b/pkg/sanity/backup_restore.go
@@ -17,7 +17,6 @@ limitations under the License.
 package sanity
 
 import (
-	"strings"
 	"time"
 
 	"github.com/libopenstorage/openstorage/api"
@@ -173,18 +172,18 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 					Expect(err).To(BeNil())
 
 					bkpStatus = bkpStatusResp.Statuses[volumeID]
-					if strings.Contains(bkpStatus.Status, "Done") {
+					if bkpStatus.Status == api.CloudBackupStatusDone {
 						break
 					}
-					if strings.Contains(bkpStatus.Status, "Active") {
+					if bkpStatus.Status == api.CloudBackupStatusActive {
 						time.Sleep(time.Second * 10)
 						timeout += 10
 					}
-					if strings.Contains(bkpStatus.Status, "Failed") {
+					if bkpStatus.Status == api.CloudBackupStatusFailed {
 						break
 					}
 				}
-				Expect(bkpStatus.Status).To(BeEquivalentTo("Done"))
+				Expect(bkpStatus.Status).To(BeEquivalentTo(api.CloudBackupStatusDone))
 			}
 		})
 	})
@@ -278,18 +277,18 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 					Expect(err).To(BeNil())
 
 					bkpStatus = bkpStatusResp.Statuses[volumeID]
-					if strings.Contains(bkpStatus.Status, "Done") {
+					if bkpStatus.Status == api.CloudBackupStatusDone {
 						break
 					}
-					if strings.Contains(bkpStatus.Status, "Active") {
+					if bkpStatus.Status == api.CloudBackupStatusActive {
 						time.Sleep(time.Second * 10)
 						timeout += 10
 					}
-					if strings.Contains(bkpStatus.Status, "Failed") {
+					if bkpStatus.Status == api.CloudBackupStatusFailed {
 						break
 					}
 				}
-				Expect(bkpStatus.Status).To(BeEquivalentTo("Done"))
+				Expect(bkpStatus.Status).To(BeEquivalentTo(api.CloudBackupStatusDone))
 
 				By("Backup enumerate")
 
@@ -405,18 +404,18 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 					Expect(err).To(BeNil())
 
 					bkpStatus = bkpStatusResp.Statuses[volumeID]
-					if strings.Contains(bkpStatus.Status, "Done") {
+					if bkpStatus.Status == api.CloudBackupStatusDone {
 						break
 					}
-					if strings.Contains(bkpStatus.Status, "Active") {
+					if bkpStatus.Status == api.CloudBackupStatusActive {
 						time.Sleep(time.Second * 10)
 						timeout += 10
 					}
-					if strings.Contains(bkpStatus.Status, "Failed") {
+					if bkpStatus.Status == api.CloudBackupStatusFailed {
 						break
 					}
 				}
-				Expect(bkpStatus.Status).To(BeEquivalentTo("Done"))
+				Expect(bkpStatus.Status).To(BeEquivalentTo(api.CloudBackupStatusDone))
 
 				By("Backup enumerate")
 				bkpEnumReq := &api.CloudBackupEnumerateRequest{
@@ -799,18 +798,18 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 					Expect(err).To(BeNil())
 
 					bkpStatus = bkpStatusResp.Statuses[volumeID]
-					if strings.Contains(bkpStatus.Status, "Done") {
+					if bkpStatus.Status == api.CloudBackupStatusDone {
 						break
 					}
-					if strings.Contains(bkpStatus.Status, "Active") {
+					if bkpStatus.Status == api.CloudBackupStatusActive {
 						time.Sleep(time.Second * 10)
 						timeout += 10
 					}
-					if strings.Contains(bkpStatus.Status, "Failed") {
+					if bkpStatus.Status == api.CloudBackupStatusFailed {
 						break
 					}
 				}
-				Expect(bkpStatus.Status).To(BeEquivalentTo("Done"))
+				Expect(bkpStatus.Status).To(BeEquivalentTo(api.CloudBackupStatusDone))
 
 				By("Backup enumerate")
 				bkpEnumReq := &api.CloudBackupEnumerateRequest{

--- a/vendor/github.com/cenkalti/backoff/LICENSE
+++ b/vendor/github.com/cenkalti/backoff/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Cenk Altı
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/cenkalti/backoff/README.md
+++ b/vendor/github.com/cenkalti/backoff/README.md
@@ -1,0 +1,30 @@
+# Exponential Backoff [![GoDoc][godoc image]][godoc] [![Build Status][travis image]][travis] [![Coverage Status][coveralls image]][coveralls]
+
+This is a Go port of the exponential backoff algorithm from [Google's HTTP Client Library for Java][google-http-java-client].
+
+[Exponential backoff][exponential backoff wiki]
+is an algorithm that uses feedback to multiplicatively decrease the rate of some process,
+in order to gradually find an acceptable rate.
+The retries exponentially increase and stop increasing when a certain threshold is met.
+
+## Usage
+
+See https://godoc.org/github.com/cenkalti/backoff#pkg-examples
+
+## Contributing
+
+* I would like to keep this library as small as possible.
+* Please don't send a PR without opening an issue and discussing it first.
+* If proposed change is not a common use case, I will probably not accept it.
+
+[godoc]: https://godoc.org/github.com/cenkalti/backoff
+[godoc image]: https://godoc.org/github.com/cenkalti/backoff?status.png
+[travis]: https://travis-ci.org/cenkalti/backoff
+[travis image]: https://travis-ci.org/cenkalti/backoff.png?branch=master
+[coveralls]: https://coveralls.io/github/cenkalti/backoff?branch=master
+[coveralls image]: https://coveralls.io/repos/github/cenkalti/backoff/badge.svg?branch=master
+
+[google-http-java-client]: https://github.com/google/google-http-java-client
+[exponential backoff wiki]: http://en.wikipedia.org/wiki/Exponential_backoff
+
+[advanced example]: https://godoc.org/github.com/cenkalti/backoff#example_

--- a/vendor/github.com/cenkalti/backoff/backoff.go
+++ b/vendor/github.com/cenkalti/backoff/backoff.go
@@ -1,0 +1,66 @@
+// Package backoff implements backoff algorithms for retrying operations.
+//
+// Use Retry function for retrying operations that may fail.
+// If Retry does not meet your needs,
+// copy/paste the function into your project and modify as you wish.
+//
+// There is also Ticker type similar to time.Ticker.
+// You can use it if you need to work with channels.
+//
+// See Examples section below for usage examples.
+package backoff
+
+import "time"
+
+// BackOff is a backoff policy for retrying an operation.
+type BackOff interface {
+	// NextBackOff returns the duration to wait before retrying the operation,
+	// or backoff.Stop to indicate that no more retries should be made.
+	//
+	// Example usage:
+	//
+	// 	duration := backoff.NextBackOff();
+	// 	if (duration == backoff.Stop) {
+	// 		// Do not retry operation.
+	// 	} else {
+	// 		// Sleep for duration and retry operation.
+	// 	}
+	//
+	NextBackOff() time.Duration
+
+	// Reset to initial state.
+	Reset()
+}
+
+// Stop indicates that no more retries should be made for use in NextBackOff().
+const Stop time.Duration = -1
+
+// ZeroBackOff is a fixed backoff policy whose backoff time is always zero,
+// meaning that the operation is retried immediately without waiting, indefinitely.
+type ZeroBackOff struct{}
+
+func (b *ZeroBackOff) Reset() {}
+
+func (b *ZeroBackOff) NextBackOff() time.Duration { return 0 }
+
+// StopBackOff is a fixed backoff policy that always returns backoff.Stop for
+// NextBackOff(), meaning that the operation should never be retried.
+type StopBackOff struct{}
+
+func (b *StopBackOff) Reset() {}
+
+func (b *StopBackOff) NextBackOff() time.Duration { return Stop }
+
+// ConstantBackOff is a backoff policy that always returns the same backoff delay.
+// This is in contrast to an exponential backoff policy,
+// which returns a delay that grows longer as you call NextBackOff() over and over again.
+type ConstantBackOff struct {
+	Interval time.Duration
+}
+
+func (b *ConstantBackOff) Reset()                     {}
+func (b *ConstantBackOff) NextBackOff() time.Duration { return b.Interval }
+
+func NewConstantBackOff(d time.Duration) *ConstantBackOff {
+	return &ConstantBackOff{Interval: d}
+}

--- a/vendor/github.com/cenkalti/backoff/context.go
+++ b/vendor/github.com/cenkalti/backoff/context.go
@@ -1,0 +1,60 @@
+package backoff
+
+import (
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+// BackOffContext is a backoff policy that stops retrying after the context
+// is canceled.
+type BackOffContext interface {
+	BackOff
+	Context() context.Context
+}
+
+type backOffContext struct {
+	BackOff
+	ctx context.Context
+}
+
+// WithContext returns a BackOffContext with context ctx
+//
+// ctx must not be nil
+func WithContext(b BackOff, ctx context.Context) BackOffContext {
+	if ctx == nil {
+		panic("nil context")
+	}
+
+	if b, ok := b.(*backOffContext); ok {
+		return &backOffContext{
+			BackOff: b.BackOff,
+			ctx:     ctx,
+		}
+	}
+
+	return &backOffContext{
+		BackOff: b,
+		ctx:     ctx,
+	}
+}
+
+func ensureContext(b BackOff) BackOffContext {
+	if cb, ok := b.(BackOffContext); ok {
+		return cb
+	}
+	return WithContext(b, context.Background())
+}
+
+func (b *backOffContext) Context() context.Context {
+	return b.ctx
+}
+
+func (b *backOffContext) NextBackOff() time.Duration {
+	select {
+	case <-b.Context().Done():
+		return Stop
+	default:
+		return b.BackOff.NextBackOff()
+	}
+}

--- a/vendor/github.com/cenkalti/backoff/exponential.go
+++ b/vendor/github.com/cenkalti/backoff/exponential.go
@@ -1,0 +1,151 @@
+package backoff
+
+import (
+	"math/rand"
+	"time"
+)
+
+/*
+ExponentialBackOff is a backoff implementation that increases the backoff
+period for each retry attempt using a randomization function that grows exponentially.
+
+NextBackOff() is calculated using the following formula:
+
+ randomized interval =
+     RetryInterval * (random value in range [1 - RandomizationFactor, 1 + RandomizationFactor])
+
+In other words NextBackOff() will range between the randomization factor
+percentage below and above the retry interval.
+
+For example, given the following parameters:
+
+ RetryInterval = 2
+ RandomizationFactor = 0.5
+ Multiplier = 2
+
+the actual backoff period used in the next retry attempt will range between 1 and 3 seconds,
+multiplied by the exponential, that is, between 2 and 6 seconds.
+
+Note: MaxInterval caps the RetryInterval and not the randomized interval.
+
+If the time elapsed since an ExponentialBackOff instance is created goes past the
+MaxElapsedTime, then the method NextBackOff() starts returning backoff.Stop.
+
+The elapsed time can be reset by calling Reset().
+
+Example: Given the following default arguments, for 10 tries the sequence will be,
+and assuming we go over the MaxElapsedTime on the 10th try:
+
+ Request #  RetryInterval (seconds)  Randomized Interval (seconds)
+
+  1          0.5                     [0.25,   0.75]
+  2          0.75                    [0.375,  1.125]
+  3          1.125                   [0.562,  1.687]
+  4          1.687                   [0.8435, 2.53]
+  5          2.53                    [1.265,  3.795]
+  6          3.795                   [1.897,  5.692]
+  7          5.692                   [2.846,  8.538]
+  8          8.538                   [4.269, 12.807]
+  9         12.807                   [6.403, 19.210]
+ 10         19.210                   backoff.Stop
+
+Note: Implementation is not thread-safe.
+*/
+type ExponentialBackOff struct {
+	InitialInterval     time.Duration
+	RandomizationFactor float64
+	Multiplier          float64
+	MaxInterval         time.Duration
+	// After MaxElapsedTime the ExponentialBackOff stops.
+	// It never stops if MaxElapsedTime == 0.
+	MaxElapsedTime time.Duration
+	Clock          Clock
+
+	currentInterval time.Duration
+	startTime       time.Time
+}
+
+// Clock is an interface that returns current time for BackOff.
+type Clock interface {
+	Now() time.Time
+}
+
+// Default values for ExponentialBackOff.
+const (
+	DefaultInitialInterval     = 500 * time.Millisecond
+	DefaultRandomizationFactor = 0.5
+	DefaultMultiplier          = 1.5
+	DefaultMaxInterval         = 60 * time.Second
+	DefaultMaxElapsedTime      = 15 * time.Minute
+)
+
+// NewExponentialBackOff creates an instance of ExponentialBackOff using default values.
+func NewExponentialBackOff() *ExponentialBackOff {
+	b := &ExponentialBackOff{
+		InitialInterval:     DefaultInitialInterval,
+		RandomizationFactor: DefaultRandomizationFactor,
+		Multiplier:          DefaultMultiplier,
+		MaxInterval:         DefaultMaxInterval,
+		MaxElapsedTime:      DefaultMaxElapsedTime,
+		Clock:               SystemClock,
+	}
+	b.Reset()
+	return b
+}
+
+type systemClock struct{}
+
+func (t systemClock) Now() time.Time {
+	return time.Now()
+}
+
+// SystemClock implements Clock interface that uses time.Now().
+var SystemClock = systemClock{}
+
+// Reset the interval back to the initial retry interval and restarts the timer.
+func (b *ExponentialBackOff) Reset() {
+	b.currentInterval = b.InitialInterval
+	b.startTime = b.Clock.Now()
+}
+
+// NextBackOff calculates the next backoff interval using the formula:
+// 	Randomized interval = RetryInterval +/- (RandomizationFactor * RetryInterval)
+func (b *ExponentialBackOff) NextBackOff() time.Duration {
+	// Make sure we have not gone over the maximum elapsed time.
+	if b.MaxElapsedTime != 0 && b.GetElapsedTime() > b.MaxElapsedTime {
+		return Stop
+	}
+	defer b.incrementCurrentInterval()
+	return getRandomValueFromInterval(b.RandomizationFactor, rand.Float64(), b.currentInterval)
+}
+
+// GetElapsedTime returns the elapsed time since an ExponentialBackOff instance
+// is created and is reset when Reset() is called.
+//
+// The elapsed time is computed using time.Now().UnixNano().
+func (b *ExponentialBackOff) GetElapsedTime() time.Duration {
+	return b.Clock.Now().Sub(b.startTime)
+}
+
+// Increments the current interval by multiplying it with the multiplier.
+func (b *ExponentialBackOff) incrementCurrentInterval() {
+	// Check for overflow, if overflow is detected set the current interval to the max interval.
+	if float64(b.currentInterval) >= float64(b.MaxInterval)/b.Multiplier {
+		b.currentInterval = b.MaxInterval
+	} else {
+		b.currentInterval = time.Duration(float64(b.currentInterval) * b.Multiplier)
+	}
+}
+
+// Returns a random value from the following interval:
+// 	[randomizationFactor * currentInterval, randomizationFactor * currentInterval].
+func getRandomValueFromInterval(randomizationFactor, random float64, currentInterval time.Duration) time.Duration {
+	var delta = randomizationFactor * float64(currentInterval)
+	var minInterval = float64(currentInterval) - delta
+	var maxInterval = float64(currentInterval) + delta
+
+	// Get a random value from the range [minInterval, maxInterval].
+	// The formula used below has a +1 because if the minInterval is 1 and the maxInterval is 3 then
+	// we want a 33% chance for selecting either 1, 2 or 3.
+	return time.Duration(minInterval + (random * (maxInterval - minInterval + 1)))
+}

--- a/vendor/github.com/cenkalti/backoff/retry.go
+++ b/vendor/github.com/cenkalti/backoff/retry.go
@@ -1,0 +1,78 @@
+package backoff
+
+import "time"
+
+// An Operation is executing by Retry() or RetryNotify().
+// The operation will be retried using a backoff policy if it returns an error.
+type Operation func() error
+
+// Notify is a notify-on-error function. It receives an operation error and
+// backoff delay if the operation failed (with an error).
+//
+// NOTE that if the backoff policy stated to stop retrying,
+// the notify function isn't called.
+type Notify func(error, time.Duration)
+
+// Retry the operation o until it does not return error or BackOff stops.
+// o is guaranteed to be run at least once.
+// It is the caller's responsibility to reset b after Retry returns.
+//
+// If o returns a *PermanentError, the operation is not retried, and the
+// wrapped error is returned.
+//
+// Retry sleeps the goroutine for the duration returned by BackOff after a
+// failed operation returns.
+func Retry(o Operation, b BackOff) error { return RetryNotify(o, b, nil) }
+
+// RetryNotify calls notify function with the error and wait duration
+// for each failed attempt before sleep.
+func RetryNotify(operation Operation, b BackOff, notify Notify) error {
+	var err error
+	var next time.Duration
+
+	cb := ensureContext(b)
+
+	b.Reset()
+	for {
+		if err = operation(); err == nil {
+			return nil
+		}
+
+		if permanent, ok := err.(*PermanentError); ok {
+			return permanent.Err
+		}
+
+		if next = b.NextBackOff(); next == Stop {
+			return err
+		}
+
+		if notify != nil {
+			notify(err, next)
+		}
+
+		t := time.NewTimer(next)
+
+		select {
+		case <-cb.Context().Done():
+			t.Stop()
+			return err
+		case <-t.C:
+		}
+	}
+}
+
+// PermanentError signals that the operation should not be retried.
+type PermanentError struct {
+	Err error
+}
+
+func (e *PermanentError) Error() string {
+	return e.Err.Error()
+}
+
+// Permanent wraps the given err in a *PermanentError.
+func Permanent(err error) *PermanentError {
+	return &PermanentError{
+		Err: err,
+	}
+}

--- a/vendor/github.com/cenkalti/backoff/ticker.go
+++ b/vendor/github.com/cenkalti/backoff/ticker.go
@@ -1,0 +1,81 @@
+package backoff
+
+import (
+	"runtime"
+	"sync"
+	"time"
+)
+
+// Ticker holds a channel that delivers `ticks' of a clock at times reported by a BackOff.
+//
+// Ticks will continue to arrive when the previous operation is still running,
+// so operations that take a while to fail could run in quick succession.
+type Ticker struct {
+	C        <-chan time.Time
+	c        chan time.Time
+	b        BackOffContext
+	stop     chan struct{}
+	stopOnce sync.Once
+}
+
+// NewTicker returns a new Ticker containing a channel that will send the time at times
+// specified by the BackOff argument. Ticker is guaranteed to tick at least once.
+// The channel is closed when Stop method is called or BackOff stops.
+func NewTicker(b BackOff) *Ticker {
+	c := make(chan time.Time)
+	t := &Ticker{
+		C:    c,
+		c:    c,
+		b:    ensureContext(b),
+		stop: make(chan struct{}),
+	}
+	go t.run()
+	runtime.SetFinalizer(t, (*Ticker).Stop)
+	return t
+}
+
+// Stop turns off a ticker. After Stop, no more ticks will be sent.
+func (t *Ticker) Stop() {
+	t.stopOnce.Do(func() { close(t.stop) })
+}
+
+func (t *Ticker) run() {
+	c := t.c
+	defer close(c)
+	t.b.Reset()
+
+	// Ticker is guaranteed to tick at least once.
+	afterC := t.send(time.Now())
+
+	for {
+		if afterC == nil {
+			return
+		}
+
+		select {
+		case tick := <-afterC:
+			afterC = t.send(tick)
+		case <-t.stop:
+			t.c = nil // Prevent future ticks from being sent to the channel.
+			return
+		case <-t.b.Context().Done():
+			return
+		}
+	}
+}
+
+func (t *Ticker) send(tick time.Time) <-chan time.Time {
+	select {
+	case t.c <- tick:
+	case <-t.stop:
+		return nil
+	}
+
+	next := t.b.NextBackOff()
+	if next == Stop {
+		t.Stop()
+		return nil
+	}
+
+	return time.After(next)
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -189,6 +189,12 @@
 			"revisionTime": "2017-09-07T20:20:52Z"
 		},
 		{
+			"checksumSHA1": "NfQBkfSVHEmnR2OaORxdOXmhLcs=",
+			"path": "github.com/cenkalti/backoff",
+			"revision": "5d150e7eec023ce7a124856b37c68e54b4050ac7",
+			"revisionTime": "2017-03-29T03:22:34Z"
+		},
+		{
 			"checksumSHA1": "rXq5zXSW6ZfBBSV2xc6Dz1Wor2w=",
 			"path": "github.com/cloudfoundry/gosigar",
 			"revision": "3ed7c74352dae6dc00bdc8c74045375352e3ec05",

--- a/volume/cloudbackup.go
+++ b/volume/cloudbackup.go
@@ -1,0 +1,64 @@
+package volume
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cenkalti/backoff"
+	"github.com/libopenstorage/openstorage/api"
+)
+
+var (
+	cloudsnapBackoffInitialInterval   = 5 * time.Second
+	cloudsnapBackoffDefaultMultiplier = float64(1)
+	cloudsnapBackoffMaxInterval       = 2 * time.Minute
+	// Wait indefinitely
+	cloudsnapBackoffMaxElapsedTime = 0 * time.Second
+)
+
+func CloudBackupWaitForCompletion(
+	cl CloudBackupDriver,
+	id string,
+	opType api.CloudBackupOpType,
+) error {
+	cloudsnapBackoff := backoff.NewExponentialBackOff()
+	cloudsnapBackoff.InitialInterval = cloudsnapBackoffInitialInterval
+	cloudsnapBackoff.Multiplier = cloudsnapBackoffDefaultMultiplier
+	cloudsnapBackoff.MaxInterval = cloudsnapBackoffMaxInterval
+	cloudsnapBackoff.MaxElapsedTime = cloudsnapBackoffMaxElapsedTime
+
+	var opError error
+	err := backoff.Retry(func() error {
+		response, err := cl.CloudBackupStatus(&api.CloudBackupStatusRequest{
+			SrcVolumeID: id,
+		})
+		if err != nil {
+			return err
+		}
+		csStatus, present := response.Statuses[id]
+		if !present {
+			opError = fmt.Errorf("failed to get cloudsnap status for volume: %s", id)
+			return nil
+		}
+
+		err = fmt.Errorf("CloudBackup operation %v for %v in state %v", opType, id, csStatus.Status)
+		switch csStatus.Status {
+		case api.CloudBackupStatusFailed, api.CloudBackupStatusAborted, api.CloudBackupStatusStopped:
+			opError = err
+			return nil
+		case api.CloudBackupStatusDone:
+			opError = nil
+			return nil
+		case api.CloudBackupStatusNotStarted, api.CloudBackupStatusActive, api.CloudBackupStatusPaused:
+			return err
+		default:
+			opError = err
+			return nil
+		}
+	}, cloudsnapBackoff)
+	if err != nil {
+		return err
+	}
+
+	return opError
+}


### PR DESCRIPTION
Cloudbackup is being used in multiple plugins which can use
this API to wait for operations to complete

Signed-off-by: Dinesh Israni <disrani@portworx.com>

