### PR TITLE
sdk: Prefix all Sdk Request and response messages with Sdk

### DIFF
--- a/api/api.pb.go
+++ b/api/api.pb.go
@@ -85,7 +85,7 @@ func (x Status) String() string {
 	return proto.EnumName(Status_name, int32(x))
 }
 func (Status) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{0}
+	return fileDescriptor_api_ac37319a59d075f7, []int{0}
 }
 
 type DriverType int32
@@ -120,7 +120,7 @@ func (x DriverType) String() string {
 	return proto.EnumName(DriverType_name, int32(x))
 }
 func (DriverType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{1}
+	return fileDescriptor_api_ac37319a59d075f7, []int{1}
 }
 
 type FSType int32
@@ -161,7 +161,7 @@ func (x FSType) String() string {
 	return proto.EnumName(FSType_name, int32(x))
 }
 func (FSType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{2}
+	return fileDescriptor_api_ac37319a59d075f7, []int{2}
 }
 
 type GraphDriverChangeType int32
@@ -190,7 +190,7 @@ func (x GraphDriverChangeType) String() string {
 	return proto.EnumName(GraphDriverChangeType_name, int32(x))
 }
 func (GraphDriverChangeType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{3}
+	return fileDescriptor_api_ac37319a59d075f7, []int{3}
 }
 
 type SeverityType int32
@@ -219,7 +219,7 @@ func (x SeverityType) String() string {
 	return proto.EnumName(SeverityType_name, int32(x))
 }
 func (SeverityType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{4}
+	return fileDescriptor_api_ac37319a59d075f7, []int{4}
 }
 
 type ResourceType int32
@@ -251,7 +251,7 @@ func (x ResourceType) String() string {
 	return proto.EnumName(ResourceType_name, int32(x))
 }
 func (ResourceType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{5}
+	return fileDescriptor_api_ac37319a59d075f7, []int{5}
 }
 
 type AlertActionType int32
@@ -280,7 +280,7 @@ func (x AlertActionType) String() string {
 	return proto.EnumName(AlertActionType_name, int32(x))
 }
 func (AlertActionType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{6}
+	return fileDescriptor_api_ac37319a59d075f7, []int{6}
 }
 
 type VolumeActionParam int32
@@ -308,7 +308,7 @@ func (x VolumeActionParam) String() string {
 	return proto.EnumName(VolumeActionParam_name, int32(x))
 }
 func (VolumeActionParam) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{7}
+	return fileDescriptor_api_ac37319a59d075f7, []int{7}
 }
 
 type CosType int32
@@ -337,7 +337,7 @@ func (x CosType) String() string {
 	return proto.EnumName(CosType_name, int32(x))
 }
 func (CosType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{8}
+	return fileDescriptor_api_ac37319a59d075f7, []int{8}
 }
 
 type IoProfile int32
@@ -369,7 +369,7 @@ func (x IoProfile) String() string {
 	return proto.EnumName(IoProfile_name, int32(x))
 }
 func (IoProfile) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{9}
+	return fileDescriptor_api_ac37319a59d075f7, []int{9}
 }
 
 // VolumeState represents the state of a volume.
@@ -427,7 +427,7 @@ func (x VolumeState) String() string {
 	return proto.EnumName(VolumeState_name, int32(x))
 }
 func (VolumeState) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{10}
+	return fileDescriptor_api_ac37319a59d075f7, []int{10}
 }
 
 // VolumeStatus represents a health status for a volume.
@@ -465,7 +465,7 @@ func (x VolumeStatus) String() string {
 	return proto.EnumName(VolumeStatus_name, int32(x))
 }
 func (VolumeStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{11}
+	return fileDescriptor_api_ac37319a59d075f7, []int{11}
 }
 
 type StorageMedium int32
@@ -494,7 +494,7 @@ func (x StorageMedium) String() string {
 	return proto.EnumName(StorageMedium_name, int32(x))
 }
 func (StorageMedium) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{12}
+	return fileDescriptor_api_ac37319a59d075f7, []int{12}
 }
 
 type ClusterNotify int32
@@ -515,7 +515,7 @@ func (x ClusterNotify) String() string {
 	return proto.EnumName(ClusterNotify_name, int32(x))
 }
 func (ClusterNotify) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{13}
+	return fileDescriptor_api_ac37319a59d075f7, []int{13}
 }
 
 type AttachState int32
@@ -544,7 +544,7 @@ func (x AttachState) String() string {
 	return proto.EnumName(AttachState_name, int32(x))
 }
 func (AttachState) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{14}
+	return fileDescriptor_api_ac37319a59d075f7, []int{14}
 }
 
 type OperationFlags int32
@@ -571,7 +571,7 @@ func (x OperationFlags) String() string {
 	return proto.EnumName(OperationFlags_name, int32(x))
 }
 func (OperationFlags) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{15}
+	return fileDescriptor_api_ac37319a59d075f7, []int{15}
 }
 
 // StorageResource groups properties of a storage device.
@@ -612,7 +612,7 @@ func (m *StorageResource) Reset()         { *m = StorageResource{} }
 func (m *StorageResource) String() string { return proto.CompactTextString(m) }
 func (*StorageResource) ProtoMessage()    {}
 func (*StorageResource) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{0}
+	return fileDescriptor_api_ac37319a59d075f7, []int{0}
 }
 func (m *StorageResource) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StorageResource.Unmarshal(m, b)
@@ -748,7 +748,7 @@ func (m *StoragePool) Reset()         { *m = StoragePool{} }
 func (m *StoragePool) String() string { return proto.CompactTextString(m) }
 func (*StoragePool) ProtoMessage()    {}
 func (*StoragePool) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{1}
+	return fileDescriptor_api_ac37319a59d075f7, []int{1}
 }
 func (m *StoragePool) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StoragePool.Unmarshal(m, b)
@@ -834,7 +834,7 @@ func (m *VolumeLocator) Reset()         { *m = VolumeLocator{} }
 func (m *VolumeLocator) String() string { return proto.CompactTextString(m) }
 func (*VolumeLocator) ProtoMessage()    {}
 func (*VolumeLocator) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{2}
+	return fileDescriptor_api_ac37319a59d075f7, []int{2}
 }
 func (m *VolumeLocator) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeLocator.Unmarshal(m, b)
@@ -886,7 +886,7 @@ func (m *Source) Reset()         { *m = Source{} }
 func (m *Source) String() string { return proto.CompactTextString(m) }
 func (*Source) ProtoMessage()    {}
 func (*Source) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{3}
+	return fileDescriptor_api_ac37319a59d075f7, []int{3}
 }
 func (m *Source) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Source.Unmarshal(m, b)
@@ -935,7 +935,7 @@ func (m *Group) Reset()         { *m = Group{} }
 func (m *Group) String() string { return proto.CompactTextString(m) }
 func (*Group) ProtoMessage()    {}
 func (*Group) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{4}
+	return fileDescriptor_api_ac37319a59d075f7, []int{4}
 }
 func (m *Group) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Group.Unmarshal(m, b)
@@ -1022,7 +1022,7 @@ func (m *VolumeSpec) Reset()         { *m = VolumeSpec{} }
 func (m *VolumeSpec) String() string { return proto.CompactTextString(m) }
 func (*VolumeSpec) ProtoMessage()    {}
 func (*VolumeSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{5}
+	return fileDescriptor_api_ac37319a59d075f7, []int{5}
 }
 func (m *VolumeSpec) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeSpec.Unmarshal(m, b)
@@ -1224,7 +1224,7 @@ func (m *ReplicaSet) Reset()         { *m = ReplicaSet{} }
 func (m *ReplicaSet) String() string { return proto.CompactTextString(m) }
 func (*ReplicaSet) ProtoMessage()    {}
 func (*ReplicaSet) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{6}
+	return fileDescriptor_api_ac37319a59d075f7, []int{6}
 }
 func (m *ReplicaSet) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ReplicaSet.Unmarshal(m, b)
@@ -1265,7 +1265,7 @@ func (m *RuntimeStateMap) Reset()         { *m = RuntimeStateMap{} }
 func (m *RuntimeStateMap) String() string { return proto.CompactTextString(m) }
 func (*RuntimeStateMap) ProtoMessage()    {}
 func (*RuntimeStateMap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{7}
+	return fileDescriptor_api_ac37319a59d075f7, []int{7}
 }
 func (m *RuntimeStateMap) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RuntimeStateMap.Unmarshal(m, b)
@@ -1350,7 +1350,7 @@ func (m *Volume) Reset()         { *m = Volume{} }
 func (m *Volume) String() string { return proto.CompactTextString(m) }
 func (*Volume) ProtoMessage()    {}
 func (*Volume) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{8}
+	return fileDescriptor_api_ac37319a59d075f7, []int{8}
 }
 func (m *Volume) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Volume.Unmarshal(m, b)
@@ -1554,7 +1554,7 @@ func (m *Stats) Reset()         { *m = Stats{} }
 func (m *Stats) String() string { return proto.CompactTextString(m) }
 func (*Stats) ProtoMessage()    {}
 func (*Stats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{9}
+	return fileDescriptor_api_ac37319a59d075f7, []int{9}
 }
 func (m *Stats) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Stats.Unmarshal(m, b)
@@ -1676,7 +1676,7 @@ func (m *Alert) Reset()         { *m = Alert{} }
 func (m *Alert) String() string { return proto.CompactTextString(m) }
 func (*Alert) ProtoMessage()    {}
 func (*Alert) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{10}
+	return fileDescriptor_api_ac37319a59d075f7, []int{10}
 }
 func (m *Alert) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Alert.Unmarshal(m, b)
@@ -1779,7 +1779,7 @@ func (m *Alerts) Reset()         { *m = Alerts{} }
 func (m *Alerts) String() string { return proto.CompactTextString(m) }
 func (*Alerts) ProtoMessage()    {}
 func (*Alerts) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{11}
+	return fileDescriptor_api_ac37319a59d075f7, []int{11}
 }
 func (m *Alerts) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Alerts.Unmarshal(m, b)
@@ -1840,7 +1840,7 @@ func (m *ObjectstoreInfo) Reset()         { *m = ObjectstoreInfo{} }
 func (m *ObjectstoreInfo) String() string { return proto.CompactTextString(m) }
 func (*ObjectstoreInfo) ProtoMessage()    {}
 func (*ObjectstoreInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{12}
+	return fileDescriptor_api_ac37319a59d075f7, []int{12}
 }
 func (m *ObjectstoreInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ObjectstoreInfo.Unmarshal(m, b)
@@ -1956,7 +1956,7 @@ func (m *VolumeCreateRequest) Reset()         { *m = VolumeCreateRequest{} }
 func (m *VolumeCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*VolumeCreateRequest) ProtoMessage()    {}
 func (*VolumeCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{13}
+	return fileDescriptor_api_ac37319a59d075f7, []int{13}
 }
 func (m *VolumeCreateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeCreateRequest.Unmarshal(m, b)
@@ -2014,7 +2014,7 @@ func (m *VolumeResponse) Reset()         { *m = VolumeResponse{} }
 func (m *VolumeResponse) String() string { return proto.CompactTextString(m) }
 func (*VolumeResponse) ProtoMessage()    {}
 func (*VolumeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{14}
+	return fileDescriptor_api_ac37319a59d075f7, []int{14}
 }
 func (m *VolumeResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeResponse.Unmarshal(m, b)
@@ -2063,7 +2063,7 @@ func (m *VolumeCreateResponse) Reset()         { *m = VolumeCreateResponse{} }
 func (m *VolumeCreateResponse) String() string { return proto.CompactTextString(m) }
 func (*VolumeCreateResponse) ProtoMessage()    {}
 func (*VolumeCreateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{15}
+	return fileDescriptor_api_ac37319a59d075f7, []int{15}
 }
 func (m *VolumeCreateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeCreateResponse.Unmarshal(m, b)
@@ -2117,7 +2117,7 @@ func (m *VolumeStateAction) Reset()         { *m = VolumeStateAction{} }
 func (m *VolumeStateAction) String() string { return proto.CompactTextString(m) }
 func (*VolumeStateAction) ProtoMessage()    {}
 func (*VolumeStateAction) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{16}
+	return fileDescriptor_api_ac37319a59d075f7, []int{16}
 }
 func (m *VolumeStateAction) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeStateAction.Unmarshal(m, b)
@@ -2186,7 +2186,7 @@ func (m *VolumeSetRequest) Reset()         { *m = VolumeSetRequest{} }
 func (m *VolumeSetRequest) String() string { return proto.CompactTextString(m) }
 func (*VolumeSetRequest) ProtoMessage()    {}
 func (*VolumeSetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{17}
+	return fileDescriptor_api_ac37319a59d075f7, []int{17}
 }
 func (m *VolumeSetRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeSetRequest.Unmarshal(m, b)
@@ -2256,7 +2256,7 @@ func (m *VolumeSetResponse) Reset()         { *m = VolumeSetResponse{} }
 func (m *VolumeSetResponse) String() string { return proto.CompactTextString(m) }
 func (*VolumeSetResponse) ProtoMessage()    {}
 func (*VolumeSetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{18}
+	return fileDescriptor_api_ac37319a59d075f7, []int{18}
 }
 func (m *VolumeSetResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeSetResponse.Unmarshal(m, b)
@@ -2306,7 +2306,7 @@ func (m *SnapCreateRequest) Reset()         { *m = SnapCreateRequest{} }
 func (m *SnapCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*SnapCreateRequest) ProtoMessage()    {}
 func (*SnapCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{19}
+	return fileDescriptor_api_ac37319a59d075f7, []int{19}
 }
 func (m *SnapCreateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SnapCreateRequest.Unmarshal(m, b)
@@ -2364,7 +2364,7 @@ func (m *SnapCreateResponse) Reset()         { *m = SnapCreateResponse{} }
 func (m *SnapCreateResponse) String() string { return proto.CompactTextString(m) }
 func (*SnapCreateResponse) ProtoMessage()    {}
 func (*SnapCreateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{20}
+	return fileDescriptor_api_ac37319a59d075f7, []int{20}
 }
 func (m *SnapCreateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SnapCreateResponse.Unmarshal(m, b)
@@ -2406,7 +2406,7 @@ func (m *VolumeInfo) Reset()         { *m = VolumeInfo{} }
 func (m *VolumeInfo) String() string { return proto.CompactTextString(m) }
 func (*VolumeInfo) ProtoMessage()    {}
 func (*VolumeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{21}
+	return fileDescriptor_api_ac37319a59d075f7, []int{21}
 }
 func (m *VolumeInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeInfo.Unmarshal(m, b)
@@ -2478,7 +2478,7 @@ func (m *VolumeConsumer) Reset()         { *m = VolumeConsumer{} }
 func (m *VolumeConsumer) String() string { return proto.CompactTextString(m) }
 func (*VolumeConsumer) ProtoMessage()    {}
 func (*VolumeConsumer) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{22}
+	return fileDescriptor_api_ac37319a59d075f7, []int{22}
 }
 func (m *VolumeConsumer) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeConsumer.Unmarshal(m, b)
@@ -2557,7 +2557,7 @@ func (m *GraphDriverChanges) Reset()         { *m = GraphDriverChanges{} }
 func (m *GraphDriverChanges) String() string { return proto.CompactTextString(m) }
 func (*GraphDriverChanges) ProtoMessage()    {}
 func (*GraphDriverChanges) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{23}
+	return fileDescriptor_api_ac37319a59d075f7, []int{23}
 }
 func (m *GraphDriverChanges) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GraphDriverChanges.Unmarshal(m, b)
@@ -2607,7 +2607,7 @@ func (m *ClusterResponse) Reset()         { *m = ClusterResponse{} }
 func (m *ClusterResponse) String() string { return proto.CompactTextString(m) }
 func (*ClusterResponse) ProtoMessage()    {}
 func (*ClusterResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{24}
+	return fileDescriptor_api_ac37319a59d075f7, []int{24}
 }
 func (m *ClusterResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ClusterResponse.Unmarshal(m, b)
@@ -2647,7 +2647,7 @@ func (m *ActiveRequest) Reset()         { *m = ActiveRequest{} }
 func (m *ActiveRequest) String() string { return proto.CompactTextString(m) }
 func (*ActiveRequest) ProtoMessage()    {}
 func (*ActiveRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{25}
+	return fileDescriptor_api_ac37319a59d075f7, []int{25}
 }
 func (m *ActiveRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ActiveRequest.Unmarshal(m, b)
@@ -2688,7 +2688,7 @@ func (m *ActiveRequests) Reset()         { *m = ActiveRequests{} }
 func (m *ActiveRequests) String() string { return proto.CompactTextString(m) }
 func (*ActiveRequests) ProtoMessage()    {}
 func (*ActiveRequests) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{26}
+	return fileDescriptor_api_ac37319a59d075f7, []int{26}
 }
 func (m *ActiveRequests) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ActiveRequests.Unmarshal(m, b)
@@ -2736,7 +2736,7 @@ func (m *GroupSnapCreateRequest) Reset()         { *m = GroupSnapCreateRequest{}
 func (m *GroupSnapCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*GroupSnapCreateRequest) ProtoMessage()    {}
 func (*GroupSnapCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{27}
+	return fileDescriptor_api_ac37319a59d075f7, []int{27}
 }
 func (m *GroupSnapCreateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GroupSnapCreateRequest.Unmarshal(m, b)
@@ -2792,7 +2792,7 @@ func (m *GroupSnapCreateResponse) Reset()         { *m = GroupSnapCreateResponse
 func (m *GroupSnapCreateResponse) String() string { return proto.CompactTextString(m) }
 func (*GroupSnapCreateResponse) ProtoMessage()    {}
 func (*GroupSnapCreateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{28}
+	return fileDescriptor_api_ac37319a59d075f7, []int{28}
 }
 func (m *GroupSnapCreateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GroupSnapCreateResponse.Unmarshal(m, b)
@@ -2863,7 +2863,7 @@ func (m *StorageNode) Reset()         { *m = StorageNode{} }
 func (m *StorageNode) String() string { return proto.CompactTextString(m) }
 func (*StorageNode) ProtoMessage()    {}
 func (*StorageNode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{29}
+	return fileDescriptor_api_ac37319a59d075f7, []int{29}
 }
 func (m *StorageNode) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StorageNode.Unmarshal(m, b)
@@ -2993,7 +2993,7 @@ func (m *StorageCluster) Reset()         { *m = StorageCluster{} }
 func (m *StorageCluster) String() string { return proto.CompactTextString(m) }
 func (*StorageCluster) ProtoMessage()    {}
 func (*StorageCluster) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{30}
+	return fileDescriptor_api_ac37319a59d075f7, []int{30}
 }
 func (m *StorageCluster) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StorageCluster.Unmarshal(m, b)
@@ -3041,7 +3041,7 @@ func (m *StorageCluster) GetNodes() []*StorageNode {
 	return nil
 }
 
-type CredentialCreateAzureRequest struct {
+type SdkCredentialCreateAzureRequest struct {
 	// Azure Credential
 	Credential           *AzureCredential `protobuf:"bytes,1,opt,name=credential" json:"credential,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
@@ -3049,38 +3049,38 @@ type CredentialCreateAzureRequest struct {
 	XXX_sizecache        int32            `json:"-"`
 }
 
-func (m *CredentialCreateAzureRequest) Reset()         { *m = CredentialCreateAzureRequest{} }
-func (m *CredentialCreateAzureRequest) String() string { return proto.CompactTextString(m) }
-func (*CredentialCreateAzureRequest) ProtoMessage()    {}
-func (*CredentialCreateAzureRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{31}
+func (m *SdkCredentialCreateAzureRequest) Reset()         { *m = SdkCredentialCreateAzureRequest{} }
+func (m *SdkCredentialCreateAzureRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkCredentialCreateAzureRequest) ProtoMessage()    {}
+func (*SdkCredentialCreateAzureRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{31}
 }
-func (m *CredentialCreateAzureRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CredentialCreateAzureRequest.Unmarshal(m, b)
+func (m *SdkCredentialCreateAzureRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkCredentialCreateAzureRequest.Unmarshal(m, b)
 }
-func (m *CredentialCreateAzureRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CredentialCreateAzureRequest.Marshal(b, m, deterministic)
+func (m *SdkCredentialCreateAzureRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkCredentialCreateAzureRequest.Marshal(b, m, deterministic)
 }
-func (dst *CredentialCreateAzureRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CredentialCreateAzureRequest.Merge(dst, src)
+func (dst *SdkCredentialCreateAzureRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkCredentialCreateAzureRequest.Merge(dst, src)
 }
-func (m *CredentialCreateAzureRequest) XXX_Size() int {
-	return xxx_messageInfo_CredentialCreateAzureRequest.Size(m)
+func (m *SdkCredentialCreateAzureRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkCredentialCreateAzureRequest.Size(m)
 }
-func (m *CredentialCreateAzureRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_CredentialCreateAzureRequest.DiscardUnknown(m)
+func (m *SdkCredentialCreateAzureRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkCredentialCreateAzureRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CredentialCreateAzureRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkCredentialCreateAzureRequest proto.InternalMessageInfo
 
-func (m *CredentialCreateAzureRequest) GetCredential() *AzureCredential {
+func (m *SdkCredentialCreateAzureRequest) GetCredential() *AzureCredential {
 	if m != nil {
 		return m.Credential
 	}
 	return nil
 }
 
-type CredentialCreateAzureResponse struct {
+type SdkCredentialCreateAzureResponse struct {
 	// Id of the credentials
 	CredentialId         string   `protobuf:"bytes,1,opt,name=credential_id,json=credentialId" json:"credential_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -3088,38 +3088,38 @@ type CredentialCreateAzureResponse struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *CredentialCreateAzureResponse) Reset()         { *m = CredentialCreateAzureResponse{} }
-func (m *CredentialCreateAzureResponse) String() string { return proto.CompactTextString(m) }
-func (*CredentialCreateAzureResponse) ProtoMessage()    {}
-func (*CredentialCreateAzureResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{32}
+func (m *SdkCredentialCreateAzureResponse) Reset()         { *m = SdkCredentialCreateAzureResponse{} }
+func (m *SdkCredentialCreateAzureResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkCredentialCreateAzureResponse) ProtoMessage()    {}
+func (*SdkCredentialCreateAzureResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{32}
 }
-func (m *CredentialCreateAzureResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CredentialCreateAzureResponse.Unmarshal(m, b)
+func (m *SdkCredentialCreateAzureResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkCredentialCreateAzureResponse.Unmarshal(m, b)
 }
-func (m *CredentialCreateAzureResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CredentialCreateAzureResponse.Marshal(b, m, deterministic)
+func (m *SdkCredentialCreateAzureResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkCredentialCreateAzureResponse.Marshal(b, m, deterministic)
 }
-func (dst *CredentialCreateAzureResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CredentialCreateAzureResponse.Merge(dst, src)
+func (dst *SdkCredentialCreateAzureResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkCredentialCreateAzureResponse.Merge(dst, src)
 }
-func (m *CredentialCreateAzureResponse) XXX_Size() int {
-	return xxx_messageInfo_CredentialCreateAzureResponse.Size(m)
+func (m *SdkCredentialCreateAzureResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkCredentialCreateAzureResponse.Size(m)
 }
-func (m *CredentialCreateAzureResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_CredentialCreateAzureResponse.DiscardUnknown(m)
+func (m *SdkCredentialCreateAzureResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkCredentialCreateAzureResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CredentialCreateAzureResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkCredentialCreateAzureResponse proto.InternalMessageInfo
 
-func (m *CredentialCreateAzureResponse) GetCredentialId() string {
+func (m *SdkCredentialCreateAzureResponse) GetCredentialId() string {
 	if m != nil {
 		return m.CredentialId
 	}
 	return ""
 }
 
-type CredentialCreateGoogleRequest struct {
+type SdkCredentialCreateGoogleRequest struct {
 	// Google Credential
 	Credential           *GoogleCredential `protobuf:"bytes,1,opt,name=credential" json:"credential,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
@@ -3127,38 +3127,38 @@ type CredentialCreateGoogleRequest struct {
 	XXX_sizecache        int32             `json:"-"`
 }
 
-func (m *CredentialCreateGoogleRequest) Reset()         { *m = CredentialCreateGoogleRequest{} }
-func (m *CredentialCreateGoogleRequest) String() string { return proto.CompactTextString(m) }
-func (*CredentialCreateGoogleRequest) ProtoMessage()    {}
-func (*CredentialCreateGoogleRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{33}
+func (m *SdkCredentialCreateGoogleRequest) Reset()         { *m = SdkCredentialCreateGoogleRequest{} }
+func (m *SdkCredentialCreateGoogleRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkCredentialCreateGoogleRequest) ProtoMessage()    {}
+func (*SdkCredentialCreateGoogleRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{33}
 }
-func (m *CredentialCreateGoogleRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CredentialCreateGoogleRequest.Unmarshal(m, b)
+func (m *SdkCredentialCreateGoogleRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkCredentialCreateGoogleRequest.Unmarshal(m, b)
 }
-func (m *CredentialCreateGoogleRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CredentialCreateGoogleRequest.Marshal(b, m, deterministic)
+func (m *SdkCredentialCreateGoogleRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkCredentialCreateGoogleRequest.Marshal(b, m, deterministic)
 }
-func (dst *CredentialCreateGoogleRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CredentialCreateGoogleRequest.Merge(dst, src)
+func (dst *SdkCredentialCreateGoogleRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkCredentialCreateGoogleRequest.Merge(dst, src)
 }
-func (m *CredentialCreateGoogleRequest) XXX_Size() int {
-	return xxx_messageInfo_CredentialCreateGoogleRequest.Size(m)
+func (m *SdkCredentialCreateGoogleRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkCredentialCreateGoogleRequest.Size(m)
 }
-func (m *CredentialCreateGoogleRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_CredentialCreateGoogleRequest.DiscardUnknown(m)
+func (m *SdkCredentialCreateGoogleRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkCredentialCreateGoogleRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CredentialCreateGoogleRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkCredentialCreateGoogleRequest proto.InternalMessageInfo
 
-func (m *CredentialCreateGoogleRequest) GetCredential() *GoogleCredential {
+func (m *SdkCredentialCreateGoogleRequest) GetCredential() *GoogleCredential {
 	if m != nil {
 		return m.Credential
 	}
 	return nil
 }
 
-type CredentialCreateGoogleResponse struct {
+type SdkCredentialCreateGoogleResponse struct {
 	// Id of the credentials
 	CredentialId         string   `protobuf:"bytes,1,opt,name=credential_id,json=credentialId" json:"credential_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -3166,38 +3166,38 @@ type CredentialCreateGoogleResponse struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *CredentialCreateGoogleResponse) Reset()         { *m = CredentialCreateGoogleResponse{} }
-func (m *CredentialCreateGoogleResponse) String() string { return proto.CompactTextString(m) }
-func (*CredentialCreateGoogleResponse) ProtoMessage()    {}
-func (*CredentialCreateGoogleResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{34}
+func (m *SdkCredentialCreateGoogleResponse) Reset()         { *m = SdkCredentialCreateGoogleResponse{} }
+func (m *SdkCredentialCreateGoogleResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkCredentialCreateGoogleResponse) ProtoMessage()    {}
+func (*SdkCredentialCreateGoogleResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{34}
 }
-func (m *CredentialCreateGoogleResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CredentialCreateGoogleResponse.Unmarshal(m, b)
+func (m *SdkCredentialCreateGoogleResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkCredentialCreateGoogleResponse.Unmarshal(m, b)
 }
-func (m *CredentialCreateGoogleResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CredentialCreateGoogleResponse.Marshal(b, m, deterministic)
+func (m *SdkCredentialCreateGoogleResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkCredentialCreateGoogleResponse.Marshal(b, m, deterministic)
 }
-func (dst *CredentialCreateGoogleResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CredentialCreateGoogleResponse.Merge(dst, src)
+func (dst *SdkCredentialCreateGoogleResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkCredentialCreateGoogleResponse.Merge(dst, src)
 }
-func (m *CredentialCreateGoogleResponse) XXX_Size() int {
-	return xxx_messageInfo_CredentialCreateGoogleResponse.Size(m)
+func (m *SdkCredentialCreateGoogleResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkCredentialCreateGoogleResponse.Size(m)
 }
-func (m *CredentialCreateGoogleResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_CredentialCreateGoogleResponse.DiscardUnknown(m)
+func (m *SdkCredentialCreateGoogleResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkCredentialCreateGoogleResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CredentialCreateGoogleResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkCredentialCreateGoogleResponse proto.InternalMessageInfo
 
-func (m *CredentialCreateGoogleResponse) GetCredentialId() string {
+func (m *SdkCredentialCreateGoogleResponse) GetCredentialId() string {
 	if m != nil {
 		return m.CredentialId
 	}
 	return ""
 }
 
-type CredentialCreateAWSRequest struct {
+type SdkCredentialCreateAWSRequest struct {
 	// AWS S3 Credential
 	Credential           *S3Credential `protobuf:"bytes,1,opt,name=credential" json:"credential,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
@@ -3205,38 +3205,38 @@ type CredentialCreateAWSRequest struct {
 	XXX_sizecache        int32         `json:"-"`
 }
 
-func (m *CredentialCreateAWSRequest) Reset()         { *m = CredentialCreateAWSRequest{} }
-func (m *CredentialCreateAWSRequest) String() string { return proto.CompactTextString(m) }
-func (*CredentialCreateAWSRequest) ProtoMessage()    {}
-func (*CredentialCreateAWSRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{35}
+func (m *SdkCredentialCreateAWSRequest) Reset()         { *m = SdkCredentialCreateAWSRequest{} }
+func (m *SdkCredentialCreateAWSRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkCredentialCreateAWSRequest) ProtoMessage()    {}
+func (*SdkCredentialCreateAWSRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{35}
 }
-func (m *CredentialCreateAWSRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CredentialCreateAWSRequest.Unmarshal(m, b)
+func (m *SdkCredentialCreateAWSRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkCredentialCreateAWSRequest.Unmarshal(m, b)
 }
-func (m *CredentialCreateAWSRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CredentialCreateAWSRequest.Marshal(b, m, deterministic)
+func (m *SdkCredentialCreateAWSRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkCredentialCreateAWSRequest.Marshal(b, m, deterministic)
 }
-func (dst *CredentialCreateAWSRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CredentialCreateAWSRequest.Merge(dst, src)
+func (dst *SdkCredentialCreateAWSRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkCredentialCreateAWSRequest.Merge(dst, src)
 }
-func (m *CredentialCreateAWSRequest) XXX_Size() int {
-	return xxx_messageInfo_CredentialCreateAWSRequest.Size(m)
+func (m *SdkCredentialCreateAWSRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkCredentialCreateAWSRequest.Size(m)
 }
-func (m *CredentialCreateAWSRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_CredentialCreateAWSRequest.DiscardUnknown(m)
+func (m *SdkCredentialCreateAWSRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkCredentialCreateAWSRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CredentialCreateAWSRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkCredentialCreateAWSRequest proto.InternalMessageInfo
 
-func (m *CredentialCreateAWSRequest) GetCredential() *S3Credential {
+func (m *SdkCredentialCreateAWSRequest) GetCredential() *S3Credential {
 	if m != nil {
 		return m.Credential
 	}
 	return nil
 }
 
-type CredentialCreateAWSResponse struct {
+type SdkCredentialCreateAWSResponse struct {
 	// Id of the credentials
 	CredentialId         string   `protobuf:"bytes,1,opt,name=credential_id,json=credentialId" json:"credential_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -3244,31 +3244,31 @@ type CredentialCreateAWSResponse struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *CredentialCreateAWSResponse) Reset()         { *m = CredentialCreateAWSResponse{} }
-func (m *CredentialCreateAWSResponse) String() string { return proto.CompactTextString(m) }
-func (*CredentialCreateAWSResponse) ProtoMessage()    {}
-func (*CredentialCreateAWSResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{36}
+func (m *SdkCredentialCreateAWSResponse) Reset()         { *m = SdkCredentialCreateAWSResponse{} }
+func (m *SdkCredentialCreateAWSResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkCredentialCreateAWSResponse) ProtoMessage()    {}
+func (*SdkCredentialCreateAWSResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{36}
 }
-func (m *CredentialCreateAWSResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CredentialCreateAWSResponse.Unmarshal(m, b)
+func (m *SdkCredentialCreateAWSResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkCredentialCreateAWSResponse.Unmarshal(m, b)
 }
-func (m *CredentialCreateAWSResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CredentialCreateAWSResponse.Marshal(b, m, deterministic)
+func (m *SdkCredentialCreateAWSResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkCredentialCreateAWSResponse.Marshal(b, m, deterministic)
 }
-func (dst *CredentialCreateAWSResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CredentialCreateAWSResponse.Merge(dst, src)
+func (dst *SdkCredentialCreateAWSResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkCredentialCreateAWSResponse.Merge(dst, src)
 }
-func (m *CredentialCreateAWSResponse) XXX_Size() int {
-	return xxx_messageInfo_CredentialCreateAWSResponse.Size(m)
+func (m *SdkCredentialCreateAWSResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkCredentialCreateAWSResponse.Size(m)
 }
-func (m *CredentialCreateAWSResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_CredentialCreateAWSResponse.DiscardUnknown(m)
+func (m *SdkCredentialCreateAWSResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkCredentialCreateAWSResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CredentialCreateAWSResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkCredentialCreateAWSResponse proto.InternalMessageInfo
 
-func (m *CredentialCreateAWSResponse) GetCredentialId() string {
+func (m *SdkCredentialCreateAWSResponse) GetCredentialId() string {
 	if m != nil {
 		return m.CredentialId
 	}
@@ -3295,7 +3295,7 @@ func (m *S3Credential) Reset()         { *m = S3Credential{} }
 func (m *S3Credential) String() string { return proto.CompactTextString(m) }
 func (*S3Credential) ProtoMessage()    {}
 func (*S3Credential) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{37}
+	return fileDescriptor_api_ac37319a59d075f7, []int{37}
 }
 func (m *S3Credential) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_S3Credential.Unmarshal(m, b)
@@ -3366,7 +3366,7 @@ func (m *AzureCredential) Reset()         { *m = AzureCredential{} }
 func (m *AzureCredential) String() string { return proto.CompactTextString(m) }
 func (*AzureCredential) ProtoMessage()    {}
 func (*AzureCredential) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{38}
+	return fileDescriptor_api_ac37319a59d075f7, []int{38}
 }
 func (m *AzureCredential) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_AzureCredential.Unmarshal(m, b)
@@ -3422,7 +3422,7 @@ func (m *GoogleCredential) Reset()         { *m = GoogleCredential{} }
 func (m *GoogleCredential) String() string { return proto.CompactTextString(m) }
 func (*GoogleCredential) ProtoMessage()    {}
 func (*GoogleCredential) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{39}
+	return fileDescriptor_api_ac37319a59d075f7, []int{39}
 }
 func (m *GoogleCredential) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GoogleCredential.Unmarshal(m, b)
@@ -3464,7 +3464,7 @@ func (m *GoogleCredential) GetJsonKey() string {
 }
 
 // should enumerate accept anything?
-type CredentialEnumerateAWSRequest struct {
+type SdkCredentialEnumerateAWSRequest struct {
 	// Id of the credentials
 	CredentialId         string   `protobuf:"bytes,1,opt,name=credential_id,json=credentialId" json:"credential_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -3472,38 +3472,38 @@ type CredentialEnumerateAWSRequest struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *CredentialEnumerateAWSRequest) Reset()         { *m = CredentialEnumerateAWSRequest{} }
-func (m *CredentialEnumerateAWSRequest) String() string { return proto.CompactTextString(m) }
-func (*CredentialEnumerateAWSRequest) ProtoMessage()    {}
-func (*CredentialEnumerateAWSRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{40}
+func (m *SdkCredentialEnumerateAWSRequest) Reset()         { *m = SdkCredentialEnumerateAWSRequest{} }
+func (m *SdkCredentialEnumerateAWSRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkCredentialEnumerateAWSRequest) ProtoMessage()    {}
+func (*SdkCredentialEnumerateAWSRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{40}
 }
-func (m *CredentialEnumerateAWSRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CredentialEnumerateAWSRequest.Unmarshal(m, b)
+func (m *SdkCredentialEnumerateAWSRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkCredentialEnumerateAWSRequest.Unmarshal(m, b)
 }
-func (m *CredentialEnumerateAWSRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CredentialEnumerateAWSRequest.Marshal(b, m, deterministic)
+func (m *SdkCredentialEnumerateAWSRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkCredentialEnumerateAWSRequest.Marshal(b, m, deterministic)
 }
-func (dst *CredentialEnumerateAWSRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CredentialEnumerateAWSRequest.Merge(dst, src)
+func (dst *SdkCredentialEnumerateAWSRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkCredentialEnumerateAWSRequest.Merge(dst, src)
 }
-func (m *CredentialEnumerateAWSRequest) XXX_Size() int {
-	return xxx_messageInfo_CredentialEnumerateAWSRequest.Size(m)
+func (m *SdkCredentialEnumerateAWSRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkCredentialEnumerateAWSRequest.Size(m)
 }
-func (m *CredentialEnumerateAWSRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_CredentialEnumerateAWSRequest.DiscardUnknown(m)
+func (m *SdkCredentialEnumerateAWSRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkCredentialEnumerateAWSRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CredentialEnumerateAWSRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkCredentialEnumerateAWSRequest proto.InternalMessageInfo
 
-func (m *CredentialEnumerateAWSRequest) GetCredentialId() string {
+func (m *SdkCredentialEnumerateAWSRequest) GetCredentialId() string {
 	if m != nil {
 		return m.CredentialId
 	}
 	return ""
 }
 
-type CredentialEnumerateAWSResponse struct {
+type SdkCredentialEnumerateAWSResponse struct {
 	// Array of Credentials for AWS
 	Credential           []*S3Credential `protobuf:"bytes,1,rep,name=credential" json:"credential,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
@@ -3511,76 +3511,76 @@ type CredentialEnumerateAWSResponse struct {
 	XXX_sizecache        int32           `json:"-"`
 }
 
-func (m *CredentialEnumerateAWSResponse) Reset()         { *m = CredentialEnumerateAWSResponse{} }
-func (m *CredentialEnumerateAWSResponse) String() string { return proto.CompactTextString(m) }
-func (*CredentialEnumerateAWSResponse) ProtoMessage()    {}
-func (*CredentialEnumerateAWSResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{41}
+func (m *SdkCredentialEnumerateAWSResponse) Reset()         { *m = SdkCredentialEnumerateAWSResponse{} }
+func (m *SdkCredentialEnumerateAWSResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkCredentialEnumerateAWSResponse) ProtoMessage()    {}
+func (*SdkCredentialEnumerateAWSResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{41}
 }
-func (m *CredentialEnumerateAWSResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CredentialEnumerateAWSResponse.Unmarshal(m, b)
+func (m *SdkCredentialEnumerateAWSResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkCredentialEnumerateAWSResponse.Unmarshal(m, b)
 }
-func (m *CredentialEnumerateAWSResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CredentialEnumerateAWSResponse.Marshal(b, m, deterministic)
+func (m *SdkCredentialEnumerateAWSResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkCredentialEnumerateAWSResponse.Marshal(b, m, deterministic)
 }
-func (dst *CredentialEnumerateAWSResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CredentialEnumerateAWSResponse.Merge(dst, src)
+func (dst *SdkCredentialEnumerateAWSResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkCredentialEnumerateAWSResponse.Merge(dst, src)
 }
-func (m *CredentialEnumerateAWSResponse) XXX_Size() int {
-	return xxx_messageInfo_CredentialEnumerateAWSResponse.Size(m)
+func (m *SdkCredentialEnumerateAWSResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkCredentialEnumerateAWSResponse.Size(m)
 }
-func (m *CredentialEnumerateAWSResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_CredentialEnumerateAWSResponse.DiscardUnknown(m)
+func (m *SdkCredentialEnumerateAWSResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkCredentialEnumerateAWSResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CredentialEnumerateAWSResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkCredentialEnumerateAWSResponse proto.InternalMessageInfo
 
-func (m *CredentialEnumerateAWSResponse) GetCredential() []*S3Credential {
+func (m *SdkCredentialEnumerateAWSResponse) GetCredential() []*S3Credential {
 	if m != nil {
 		return m.Credential
 	}
 	return nil
 }
 
-type CredentialEnumerateAzureRequest struct {
+type SdkCredentialEnumerateAzureRequest struct {
 	CredentialId         string   `protobuf:"bytes,1,opt,name=credential_id,json=credentialId" json:"credential_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *CredentialEnumerateAzureRequest) Reset()         { *m = CredentialEnumerateAzureRequest{} }
-func (m *CredentialEnumerateAzureRequest) String() string { return proto.CompactTextString(m) }
-func (*CredentialEnumerateAzureRequest) ProtoMessage()    {}
-func (*CredentialEnumerateAzureRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{42}
+func (m *SdkCredentialEnumerateAzureRequest) Reset()         { *m = SdkCredentialEnumerateAzureRequest{} }
+func (m *SdkCredentialEnumerateAzureRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkCredentialEnumerateAzureRequest) ProtoMessage()    {}
+func (*SdkCredentialEnumerateAzureRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{42}
 }
-func (m *CredentialEnumerateAzureRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CredentialEnumerateAzureRequest.Unmarshal(m, b)
+func (m *SdkCredentialEnumerateAzureRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkCredentialEnumerateAzureRequest.Unmarshal(m, b)
 }
-func (m *CredentialEnumerateAzureRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CredentialEnumerateAzureRequest.Marshal(b, m, deterministic)
+func (m *SdkCredentialEnumerateAzureRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkCredentialEnumerateAzureRequest.Marshal(b, m, deterministic)
 }
-func (dst *CredentialEnumerateAzureRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CredentialEnumerateAzureRequest.Merge(dst, src)
+func (dst *SdkCredentialEnumerateAzureRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkCredentialEnumerateAzureRequest.Merge(dst, src)
 }
-func (m *CredentialEnumerateAzureRequest) XXX_Size() int {
-	return xxx_messageInfo_CredentialEnumerateAzureRequest.Size(m)
+func (m *SdkCredentialEnumerateAzureRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkCredentialEnumerateAzureRequest.Size(m)
 }
-func (m *CredentialEnumerateAzureRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_CredentialEnumerateAzureRequest.DiscardUnknown(m)
+func (m *SdkCredentialEnumerateAzureRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkCredentialEnumerateAzureRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CredentialEnumerateAzureRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkCredentialEnumerateAzureRequest proto.InternalMessageInfo
 
-func (m *CredentialEnumerateAzureRequest) GetCredentialId() string {
+func (m *SdkCredentialEnumerateAzureRequest) GetCredentialId() string {
 	if m != nil {
 		return m.CredentialId
 	}
 	return ""
 }
 
-type CredentialEnumerateAzureResponse struct {
+type SdkCredentialEnumerateAzureResponse struct {
 	// List of Credentials for Azure
 	Credential           []*AzureCredential `protobuf:"bytes,1,rep,name=credential" json:"credential,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}           `json:"-"`
@@ -3588,76 +3588,76 @@ type CredentialEnumerateAzureResponse struct {
 	XXX_sizecache        int32              `json:"-"`
 }
 
-func (m *CredentialEnumerateAzureResponse) Reset()         { *m = CredentialEnumerateAzureResponse{} }
-func (m *CredentialEnumerateAzureResponse) String() string { return proto.CompactTextString(m) }
-func (*CredentialEnumerateAzureResponse) ProtoMessage()    {}
-func (*CredentialEnumerateAzureResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{43}
+func (m *SdkCredentialEnumerateAzureResponse) Reset()         { *m = SdkCredentialEnumerateAzureResponse{} }
+func (m *SdkCredentialEnumerateAzureResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkCredentialEnumerateAzureResponse) ProtoMessage()    {}
+func (*SdkCredentialEnumerateAzureResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{43}
 }
-func (m *CredentialEnumerateAzureResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CredentialEnumerateAzureResponse.Unmarshal(m, b)
+func (m *SdkCredentialEnumerateAzureResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkCredentialEnumerateAzureResponse.Unmarshal(m, b)
 }
-func (m *CredentialEnumerateAzureResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CredentialEnumerateAzureResponse.Marshal(b, m, deterministic)
+func (m *SdkCredentialEnumerateAzureResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkCredentialEnumerateAzureResponse.Marshal(b, m, deterministic)
 }
-func (dst *CredentialEnumerateAzureResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CredentialEnumerateAzureResponse.Merge(dst, src)
+func (dst *SdkCredentialEnumerateAzureResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkCredentialEnumerateAzureResponse.Merge(dst, src)
 }
-func (m *CredentialEnumerateAzureResponse) XXX_Size() int {
-	return xxx_messageInfo_CredentialEnumerateAzureResponse.Size(m)
+func (m *SdkCredentialEnumerateAzureResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkCredentialEnumerateAzureResponse.Size(m)
 }
-func (m *CredentialEnumerateAzureResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_CredentialEnumerateAzureResponse.DiscardUnknown(m)
+func (m *SdkCredentialEnumerateAzureResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkCredentialEnumerateAzureResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CredentialEnumerateAzureResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkCredentialEnumerateAzureResponse proto.InternalMessageInfo
 
-func (m *CredentialEnumerateAzureResponse) GetCredential() []*AzureCredential {
+func (m *SdkCredentialEnumerateAzureResponse) GetCredential() []*AzureCredential {
 	if m != nil {
 		return m.Credential
 	}
 	return nil
 }
 
-type CredentialEnumerateGoogleRequest struct {
+type SdkCredentialEnumerateGoogleRequest struct {
 	CredentialId         string   `protobuf:"bytes,1,opt,name=credential_id,json=credentialId" json:"credential_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *CredentialEnumerateGoogleRequest) Reset()         { *m = CredentialEnumerateGoogleRequest{} }
-func (m *CredentialEnumerateGoogleRequest) String() string { return proto.CompactTextString(m) }
-func (*CredentialEnumerateGoogleRequest) ProtoMessage()    {}
-func (*CredentialEnumerateGoogleRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{44}
+func (m *SdkCredentialEnumerateGoogleRequest) Reset()         { *m = SdkCredentialEnumerateGoogleRequest{} }
+func (m *SdkCredentialEnumerateGoogleRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkCredentialEnumerateGoogleRequest) ProtoMessage()    {}
+func (*SdkCredentialEnumerateGoogleRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{44}
 }
-func (m *CredentialEnumerateGoogleRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CredentialEnumerateGoogleRequest.Unmarshal(m, b)
+func (m *SdkCredentialEnumerateGoogleRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkCredentialEnumerateGoogleRequest.Unmarshal(m, b)
 }
-func (m *CredentialEnumerateGoogleRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CredentialEnumerateGoogleRequest.Marshal(b, m, deterministic)
+func (m *SdkCredentialEnumerateGoogleRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkCredentialEnumerateGoogleRequest.Marshal(b, m, deterministic)
 }
-func (dst *CredentialEnumerateGoogleRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CredentialEnumerateGoogleRequest.Merge(dst, src)
+func (dst *SdkCredentialEnumerateGoogleRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkCredentialEnumerateGoogleRequest.Merge(dst, src)
 }
-func (m *CredentialEnumerateGoogleRequest) XXX_Size() int {
-	return xxx_messageInfo_CredentialEnumerateGoogleRequest.Size(m)
+func (m *SdkCredentialEnumerateGoogleRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkCredentialEnumerateGoogleRequest.Size(m)
 }
-func (m *CredentialEnumerateGoogleRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_CredentialEnumerateGoogleRequest.DiscardUnknown(m)
+func (m *SdkCredentialEnumerateGoogleRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkCredentialEnumerateGoogleRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CredentialEnumerateGoogleRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkCredentialEnumerateGoogleRequest proto.InternalMessageInfo
 
-func (m *CredentialEnumerateGoogleRequest) GetCredentialId() string {
+func (m *SdkCredentialEnumerateGoogleRequest) GetCredentialId() string {
 	if m != nil {
 		return m.CredentialId
 	}
 	return ""
 }
 
-type CredentialEnumerateGoogleResponse struct {
+type SdkCredentialEnumerateGoogleResponse struct {
 	// List of Credentials for Google
 	Credential           []*GoogleCredential `protobuf:"bytes,1,rep,name=credential" json:"credential,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}            `json:"-"`
@@ -3665,38 +3665,38 @@ type CredentialEnumerateGoogleResponse struct {
 	XXX_sizecache        int32               `json:"-"`
 }
 
-func (m *CredentialEnumerateGoogleResponse) Reset()         { *m = CredentialEnumerateGoogleResponse{} }
-func (m *CredentialEnumerateGoogleResponse) String() string { return proto.CompactTextString(m) }
-func (*CredentialEnumerateGoogleResponse) ProtoMessage()    {}
-func (*CredentialEnumerateGoogleResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{45}
+func (m *SdkCredentialEnumerateGoogleResponse) Reset()         { *m = SdkCredentialEnumerateGoogleResponse{} }
+func (m *SdkCredentialEnumerateGoogleResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkCredentialEnumerateGoogleResponse) ProtoMessage()    {}
+func (*SdkCredentialEnumerateGoogleResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{45}
 }
-func (m *CredentialEnumerateGoogleResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CredentialEnumerateGoogleResponse.Unmarshal(m, b)
+func (m *SdkCredentialEnumerateGoogleResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkCredentialEnumerateGoogleResponse.Unmarshal(m, b)
 }
-func (m *CredentialEnumerateGoogleResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CredentialEnumerateGoogleResponse.Marshal(b, m, deterministic)
+func (m *SdkCredentialEnumerateGoogleResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkCredentialEnumerateGoogleResponse.Marshal(b, m, deterministic)
 }
-func (dst *CredentialEnumerateGoogleResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CredentialEnumerateGoogleResponse.Merge(dst, src)
+func (dst *SdkCredentialEnumerateGoogleResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkCredentialEnumerateGoogleResponse.Merge(dst, src)
 }
-func (m *CredentialEnumerateGoogleResponse) XXX_Size() int {
-	return xxx_messageInfo_CredentialEnumerateGoogleResponse.Size(m)
+func (m *SdkCredentialEnumerateGoogleResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkCredentialEnumerateGoogleResponse.Size(m)
 }
-func (m *CredentialEnumerateGoogleResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_CredentialEnumerateGoogleResponse.DiscardUnknown(m)
+func (m *SdkCredentialEnumerateGoogleResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkCredentialEnumerateGoogleResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CredentialEnumerateGoogleResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkCredentialEnumerateGoogleResponse proto.InternalMessageInfo
 
-func (m *CredentialEnumerateGoogleResponse) GetCredential() []*GoogleCredential {
+func (m *SdkCredentialEnumerateGoogleResponse) GetCredential() []*GoogleCredential {
 	if m != nil {
 		return m.Credential
 	}
 	return nil
 }
 
-type CredentialDeleteRequest struct {
+type SdkCredentialDeleteRequest struct {
 	// ID for credentials
 	CredentialId         string   `protobuf:"bytes,1,opt,name=credential_id,json=credentialId" json:"credential_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -3704,68 +3704,68 @@ type CredentialDeleteRequest struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *CredentialDeleteRequest) Reset()         { *m = CredentialDeleteRequest{} }
-func (m *CredentialDeleteRequest) String() string { return proto.CompactTextString(m) }
-func (*CredentialDeleteRequest) ProtoMessage()    {}
-func (*CredentialDeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{46}
+func (m *SdkCredentialDeleteRequest) Reset()         { *m = SdkCredentialDeleteRequest{} }
+func (m *SdkCredentialDeleteRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkCredentialDeleteRequest) ProtoMessage()    {}
+func (*SdkCredentialDeleteRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{46}
 }
-func (m *CredentialDeleteRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CredentialDeleteRequest.Unmarshal(m, b)
+func (m *SdkCredentialDeleteRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkCredentialDeleteRequest.Unmarshal(m, b)
 }
-func (m *CredentialDeleteRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CredentialDeleteRequest.Marshal(b, m, deterministic)
+func (m *SdkCredentialDeleteRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkCredentialDeleteRequest.Marshal(b, m, deterministic)
 }
-func (dst *CredentialDeleteRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CredentialDeleteRequest.Merge(dst, src)
+func (dst *SdkCredentialDeleteRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkCredentialDeleteRequest.Merge(dst, src)
 }
-func (m *CredentialDeleteRequest) XXX_Size() int {
-	return xxx_messageInfo_CredentialDeleteRequest.Size(m)
+func (m *SdkCredentialDeleteRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkCredentialDeleteRequest.Size(m)
 }
-func (m *CredentialDeleteRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_CredentialDeleteRequest.DiscardUnknown(m)
+func (m *SdkCredentialDeleteRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkCredentialDeleteRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CredentialDeleteRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkCredentialDeleteRequest proto.InternalMessageInfo
 
-func (m *CredentialDeleteRequest) GetCredentialId() string {
+func (m *SdkCredentialDeleteRequest) GetCredentialId() string {
 	if m != nil {
 		return m.CredentialId
 	}
 	return ""
 }
 
-type CredentialDeleteResponse struct {
+type SdkCredentialDeleteResponse struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *CredentialDeleteResponse) Reset()         { *m = CredentialDeleteResponse{} }
-func (m *CredentialDeleteResponse) String() string { return proto.CompactTextString(m) }
-func (*CredentialDeleteResponse) ProtoMessage()    {}
-func (*CredentialDeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{47}
+func (m *SdkCredentialDeleteResponse) Reset()         { *m = SdkCredentialDeleteResponse{} }
+func (m *SdkCredentialDeleteResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkCredentialDeleteResponse) ProtoMessage()    {}
+func (*SdkCredentialDeleteResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{47}
 }
-func (m *CredentialDeleteResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CredentialDeleteResponse.Unmarshal(m, b)
+func (m *SdkCredentialDeleteResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkCredentialDeleteResponse.Unmarshal(m, b)
 }
-func (m *CredentialDeleteResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CredentialDeleteResponse.Marshal(b, m, deterministic)
+func (m *SdkCredentialDeleteResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkCredentialDeleteResponse.Marshal(b, m, deterministic)
 }
-func (dst *CredentialDeleteResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CredentialDeleteResponse.Merge(dst, src)
+func (dst *SdkCredentialDeleteResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkCredentialDeleteResponse.Merge(dst, src)
 }
-func (m *CredentialDeleteResponse) XXX_Size() int {
-	return xxx_messageInfo_CredentialDeleteResponse.Size(m)
+func (m *SdkCredentialDeleteResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkCredentialDeleteResponse.Size(m)
 }
-func (m *CredentialDeleteResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_CredentialDeleteResponse.DiscardUnknown(m)
+func (m *SdkCredentialDeleteResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkCredentialDeleteResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CredentialDeleteResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkCredentialDeleteResponse proto.InternalMessageInfo
 
-type CredentialValidateRequest struct {
+type SdkCredentialValidateRequest struct {
 	// Id of the credentials
 	CredentialId         string   `protobuf:"bytes,1,opt,name=credential_id,json=credentialId" json:"credential_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -3773,68 +3773,68 @@ type CredentialValidateRequest struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *CredentialValidateRequest) Reset()         { *m = CredentialValidateRequest{} }
-func (m *CredentialValidateRequest) String() string { return proto.CompactTextString(m) }
-func (*CredentialValidateRequest) ProtoMessage()    {}
-func (*CredentialValidateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{48}
+func (m *SdkCredentialValidateRequest) Reset()         { *m = SdkCredentialValidateRequest{} }
+func (m *SdkCredentialValidateRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkCredentialValidateRequest) ProtoMessage()    {}
+func (*SdkCredentialValidateRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{48}
 }
-func (m *CredentialValidateRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CredentialValidateRequest.Unmarshal(m, b)
+func (m *SdkCredentialValidateRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkCredentialValidateRequest.Unmarshal(m, b)
 }
-func (m *CredentialValidateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CredentialValidateRequest.Marshal(b, m, deterministic)
+func (m *SdkCredentialValidateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkCredentialValidateRequest.Marshal(b, m, deterministic)
 }
-func (dst *CredentialValidateRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CredentialValidateRequest.Merge(dst, src)
+func (dst *SdkCredentialValidateRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkCredentialValidateRequest.Merge(dst, src)
 }
-func (m *CredentialValidateRequest) XXX_Size() int {
-	return xxx_messageInfo_CredentialValidateRequest.Size(m)
+func (m *SdkCredentialValidateRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkCredentialValidateRequest.Size(m)
 }
-func (m *CredentialValidateRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_CredentialValidateRequest.DiscardUnknown(m)
+func (m *SdkCredentialValidateRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkCredentialValidateRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CredentialValidateRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkCredentialValidateRequest proto.InternalMessageInfo
 
-func (m *CredentialValidateRequest) GetCredentialId() string {
+func (m *SdkCredentialValidateRequest) GetCredentialId() string {
 	if m != nil {
 		return m.CredentialId
 	}
 	return ""
 }
 
-type CredentialValidateResponse struct {
+type SdkCredentialValidateResponse struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *CredentialValidateResponse) Reset()         { *m = CredentialValidateResponse{} }
-func (m *CredentialValidateResponse) String() string { return proto.CompactTextString(m) }
-func (*CredentialValidateResponse) ProtoMessage()    {}
-func (*CredentialValidateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{49}
+func (m *SdkCredentialValidateResponse) Reset()         { *m = SdkCredentialValidateResponse{} }
+func (m *SdkCredentialValidateResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkCredentialValidateResponse) ProtoMessage()    {}
+func (*SdkCredentialValidateResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{49}
 }
-func (m *CredentialValidateResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_CredentialValidateResponse.Unmarshal(m, b)
+func (m *SdkCredentialValidateResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkCredentialValidateResponse.Unmarshal(m, b)
 }
-func (m *CredentialValidateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_CredentialValidateResponse.Marshal(b, m, deterministic)
+func (m *SdkCredentialValidateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkCredentialValidateResponse.Marshal(b, m, deterministic)
 }
-func (dst *CredentialValidateResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_CredentialValidateResponse.Merge(dst, src)
+func (dst *SdkCredentialValidateResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkCredentialValidateResponse.Merge(dst, src)
 }
-func (m *CredentialValidateResponse) XXX_Size() int {
-	return xxx_messageInfo_CredentialValidateResponse.Size(m)
+func (m *SdkCredentialValidateResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkCredentialValidateResponse.Size(m)
 }
-func (m *CredentialValidateResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_CredentialValidateResponse.DiscardUnknown(m)
+func (m *SdkCredentialValidateResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkCredentialValidateResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_CredentialValidateResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkCredentialValidateResponse proto.InternalMessageInfo
 
-type VolumeMountRequest struct {
+type SdkVolumeMountRequest struct {
 	// Id of the volume
 	VolumeId string `protobuf:"bytes,1,opt,name=volume_id,json=volumeId" json:"volume_id,omitempty"`
 	// Mount path for mounting the volume.
@@ -3846,82 +3846,82 @@ type VolumeMountRequest struct {
 	XXX_sizecache        int32             `json:"-"`
 }
 
-func (m *VolumeMountRequest) Reset()         { *m = VolumeMountRequest{} }
-func (m *VolumeMountRequest) String() string { return proto.CompactTextString(m) }
-func (*VolumeMountRequest) ProtoMessage()    {}
-func (*VolumeMountRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{50}
+func (m *SdkVolumeMountRequest) Reset()         { *m = SdkVolumeMountRequest{} }
+func (m *SdkVolumeMountRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeMountRequest) ProtoMessage()    {}
+func (*SdkVolumeMountRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{50}
 }
-func (m *VolumeMountRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeMountRequest.Unmarshal(m, b)
+func (m *SdkVolumeMountRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeMountRequest.Unmarshal(m, b)
 }
-func (m *VolumeMountRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeMountRequest.Marshal(b, m, deterministic)
+func (m *SdkVolumeMountRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeMountRequest.Marshal(b, m, deterministic)
 }
-func (dst *VolumeMountRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeMountRequest.Merge(dst, src)
+func (dst *SdkVolumeMountRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeMountRequest.Merge(dst, src)
 }
-func (m *VolumeMountRequest) XXX_Size() int {
-	return xxx_messageInfo_VolumeMountRequest.Size(m)
+func (m *SdkVolumeMountRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeMountRequest.Size(m)
 }
-func (m *VolumeMountRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeMountRequest.DiscardUnknown(m)
+func (m *SdkVolumeMountRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeMountRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeMountRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeMountRequest proto.InternalMessageInfo
 
-func (m *VolumeMountRequest) GetVolumeId() string {
+func (m *SdkVolumeMountRequest) GetVolumeId() string {
 	if m != nil {
 		return m.VolumeId
 	}
 	return ""
 }
 
-func (m *VolumeMountRequest) GetMountPath() string {
+func (m *SdkVolumeMountRequest) GetMountPath() string {
 	if m != nil {
 		return m.MountPath
 	}
 	return ""
 }
 
-func (m *VolumeMountRequest) GetOptions() map[string]string {
+func (m *SdkVolumeMountRequest) GetOptions() map[string]string {
 	if m != nil {
 		return m.Options
 	}
 	return nil
 }
 
-type VolumeMountResponse struct {
+type SdkVolumeMountResponse struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *VolumeMountResponse) Reset()         { *m = VolumeMountResponse{} }
-func (m *VolumeMountResponse) String() string { return proto.CompactTextString(m) }
-func (*VolumeMountResponse) ProtoMessage()    {}
-func (*VolumeMountResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{51}
+func (m *SdkVolumeMountResponse) Reset()         { *m = SdkVolumeMountResponse{} }
+func (m *SdkVolumeMountResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeMountResponse) ProtoMessage()    {}
+func (*SdkVolumeMountResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{51}
 }
-func (m *VolumeMountResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeMountResponse.Unmarshal(m, b)
+func (m *SdkVolumeMountResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeMountResponse.Unmarshal(m, b)
 }
-func (m *VolumeMountResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeMountResponse.Marshal(b, m, deterministic)
+func (m *SdkVolumeMountResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeMountResponse.Marshal(b, m, deterministic)
 }
-func (dst *VolumeMountResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeMountResponse.Merge(dst, src)
+func (dst *SdkVolumeMountResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeMountResponse.Merge(dst, src)
 }
-func (m *VolumeMountResponse) XXX_Size() int {
-	return xxx_messageInfo_VolumeMountResponse.Size(m)
+func (m *SdkVolumeMountResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeMountResponse.Size(m)
 }
-func (m *VolumeMountResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeMountResponse.DiscardUnknown(m)
+func (m *SdkVolumeMountResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeMountResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeMountResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeMountResponse proto.InternalMessageInfo
 
-type VolumeUnmountRequest struct {
+type SdkVolumeUnmountRequest struct {
 	// Id of volume
 	VolumeId string `protobuf:"bytes,1,opt,name=volume_id,json=volumeId" json:"volume_id,omitempty"`
 	// MountPath for device
@@ -3933,82 +3933,82 @@ type VolumeUnmountRequest struct {
 	XXX_sizecache        int32             `json:"-"`
 }
 
-func (m *VolumeUnmountRequest) Reset()         { *m = VolumeUnmountRequest{} }
-func (m *VolumeUnmountRequest) String() string { return proto.CompactTextString(m) }
-func (*VolumeUnmountRequest) ProtoMessage()    {}
-func (*VolumeUnmountRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{52}
+func (m *SdkVolumeUnmountRequest) Reset()         { *m = SdkVolumeUnmountRequest{} }
+func (m *SdkVolumeUnmountRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeUnmountRequest) ProtoMessage()    {}
+func (*SdkVolumeUnmountRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{52}
 }
-func (m *VolumeUnmountRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeUnmountRequest.Unmarshal(m, b)
+func (m *SdkVolumeUnmountRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeUnmountRequest.Unmarshal(m, b)
 }
-func (m *VolumeUnmountRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeUnmountRequest.Marshal(b, m, deterministic)
+func (m *SdkVolumeUnmountRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeUnmountRequest.Marshal(b, m, deterministic)
 }
-func (dst *VolumeUnmountRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeUnmountRequest.Merge(dst, src)
+func (dst *SdkVolumeUnmountRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeUnmountRequest.Merge(dst, src)
 }
-func (m *VolumeUnmountRequest) XXX_Size() int {
-	return xxx_messageInfo_VolumeUnmountRequest.Size(m)
+func (m *SdkVolumeUnmountRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeUnmountRequest.Size(m)
 }
-func (m *VolumeUnmountRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeUnmountRequest.DiscardUnknown(m)
+func (m *SdkVolumeUnmountRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeUnmountRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeUnmountRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeUnmountRequest proto.InternalMessageInfo
 
-func (m *VolumeUnmountRequest) GetVolumeId() string {
+func (m *SdkVolumeUnmountRequest) GetVolumeId() string {
 	if m != nil {
 		return m.VolumeId
 	}
 	return ""
 }
 
-func (m *VolumeUnmountRequest) GetMountPath() string {
+func (m *SdkVolumeUnmountRequest) GetMountPath() string {
 	if m != nil {
 		return m.MountPath
 	}
 	return ""
 }
 
-func (m *VolumeUnmountRequest) GetOptions() map[string]string {
+func (m *SdkVolumeUnmountRequest) GetOptions() map[string]string {
 	if m != nil {
 		return m.Options
 	}
 	return nil
 }
 
-type VolumeUnmountResponse struct {
+type SdkVolumeUnmountResponse struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *VolumeUnmountResponse) Reset()         { *m = VolumeUnmountResponse{} }
-func (m *VolumeUnmountResponse) String() string { return proto.CompactTextString(m) }
-func (*VolumeUnmountResponse) ProtoMessage()    {}
-func (*VolumeUnmountResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{53}
+func (m *SdkVolumeUnmountResponse) Reset()         { *m = SdkVolumeUnmountResponse{} }
+func (m *SdkVolumeUnmountResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeUnmountResponse) ProtoMessage()    {}
+func (*SdkVolumeUnmountResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{53}
 }
-func (m *VolumeUnmountResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeUnmountResponse.Unmarshal(m, b)
+func (m *SdkVolumeUnmountResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeUnmountResponse.Unmarshal(m, b)
 }
-func (m *VolumeUnmountResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeUnmountResponse.Marshal(b, m, deterministic)
+func (m *SdkVolumeUnmountResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeUnmountResponse.Marshal(b, m, deterministic)
 }
-func (dst *VolumeUnmountResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeUnmountResponse.Merge(dst, src)
+func (dst *SdkVolumeUnmountResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeUnmountResponse.Merge(dst, src)
 }
-func (m *VolumeUnmountResponse) XXX_Size() int {
-	return xxx_messageInfo_VolumeUnmountResponse.Size(m)
+func (m *SdkVolumeUnmountResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeUnmountResponse.Size(m)
 }
-func (m *VolumeUnmountResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeUnmountResponse.DiscardUnknown(m)
+func (m *SdkVolumeUnmountResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeUnmountResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeUnmountResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeUnmountResponse proto.InternalMessageInfo
 
-type VolumeAttachRequest struct {
+type SdkVolumeAttachRequest struct {
 	// Id of volume
 	VolumeId string `protobuf:"bytes,1,opt,name=volume_id,json=volumeId" json:"volume_id,omitempty"`
 	// Options for attaching volume, right now only passphrase options is supported
@@ -4018,45 +4018,45 @@ type VolumeAttachRequest struct {
 	XXX_sizecache        int32             `json:"-"`
 }
 
-func (m *VolumeAttachRequest) Reset()         { *m = VolumeAttachRequest{} }
-func (m *VolumeAttachRequest) String() string { return proto.CompactTextString(m) }
-func (*VolumeAttachRequest) ProtoMessage()    {}
-func (*VolumeAttachRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{54}
+func (m *SdkVolumeAttachRequest) Reset()         { *m = SdkVolumeAttachRequest{} }
+func (m *SdkVolumeAttachRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeAttachRequest) ProtoMessage()    {}
+func (*SdkVolumeAttachRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{54}
 }
-func (m *VolumeAttachRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeAttachRequest.Unmarshal(m, b)
+func (m *SdkVolumeAttachRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeAttachRequest.Unmarshal(m, b)
 }
-func (m *VolumeAttachRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeAttachRequest.Marshal(b, m, deterministic)
+func (m *SdkVolumeAttachRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeAttachRequest.Marshal(b, m, deterministic)
 }
-func (dst *VolumeAttachRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeAttachRequest.Merge(dst, src)
+func (dst *SdkVolumeAttachRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeAttachRequest.Merge(dst, src)
 }
-func (m *VolumeAttachRequest) XXX_Size() int {
-	return xxx_messageInfo_VolumeAttachRequest.Size(m)
+func (m *SdkVolumeAttachRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeAttachRequest.Size(m)
 }
-func (m *VolumeAttachRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeAttachRequest.DiscardUnknown(m)
+func (m *SdkVolumeAttachRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeAttachRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeAttachRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeAttachRequest proto.InternalMessageInfo
 
-func (m *VolumeAttachRequest) GetVolumeId() string {
+func (m *SdkVolumeAttachRequest) GetVolumeId() string {
 	if m != nil {
 		return m.VolumeId
 	}
 	return ""
 }
 
-func (m *VolumeAttachRequest) GetOptions() map[string]string {
+func (m *SdkVolumeAttachRequest) GetOptions() map[string]string {
 	if m != nil {
 		return m.Options
 	}
 	return nil
 }
 
-type VolumeAttachResponse struct {
+type SdkVolumeAttachResponse struct {
 	// Device path where device is exported
 	DevicePath           string   `protobuf:"bytes,1,opt,name=device_path,json=devicePath" json:"device_path,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -4064,38 +4064,38 @@ type VolumeAttachResponse struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *VolumeAttachResponse) Reset()         { *m = VolumeAttachResponse{} }
-func (m *VolumeAttachResponse) String() string { return proto.CompactTextString(m) }
-func (*VolumeAttachResponse) ProtoMessage()    {}
-func (*VolumeAttachResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{55}
+func (m *SdkVolumeAttachResponse) Reset()         { *m = SdkVolumeAttachResponse{} }
+func (m *SdkVolumeAttachResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeAttachResponse) ProtoMessage()    {}
+func (*SdkVolumeAttachResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{55}
 }
-func (m *VolumeAttachResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeAttachResponse.Unmarshal(m, b)
+func (m *SdkVolumeAttachResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeAttachResponse.Unmarshal(m, b)
 }
-func (m *VolumeAttachResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeAttachResponse.Marshal(b, m, deterministic)
+func (m *SdkVolumeAttachResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeAttachResponse.Marshal(b, m, deterministic)
 }
-func (dst *VolumeAttachResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeAttachResponse.Merge(dst, src)
+func (dst *SdkVolumeAttachResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeAttachResponse.Merge(dst, src)
 }
-func (m *VolumeAttachResponse) XXX_Size() int {
-	return xxx_messageInfo_VolumeAttachResponse.Size(m)
+func (m *SdkVolumeAttachResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeAttachResponse.Size(m)
 }
-func (m *VolumeAttachResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeAttachResponse.DiscardUnknown(m)
+func (m *SdkVolumeAttachResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeAttachResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeAttachResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeAttachResponse proto.InternalMessageInfo
 
-func (m *VolumeAttachResponse) GetDevicePath() string {
+func (m *SdkVolumeAttachResponse) GetDevicePath() string {
 	if m != nil {
 		return m.DevicePath
 	}
 	return ""
 }
 
-type VolumeDetachRequest struct {
+type SdkVolumeDetachRequest struct {
 	// Id of the volume
 	VolumeId             string   `protobuf:"bytes,1,opt,name=volume_id,json=volumeId" json:"volume_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -4103,68 +4103,68 @@ type VolumeDetachRequest struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *VolumeDetachRequest) Reset()         { *m = VolumeDetachRequest{} }
-func (m *VolumeDetachRequest) String() string { return proto.CompactTextString(m) }
-func (*VolumeDetachRequest) ProtoMessage()    {}
-func (*VolumeDetachRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{56}
+func (m *SdkVolumeDetachRequest) Reset()         { *m = SdkVolumeDetachRequest{} }
+func (m *SdkVolumeDetachRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeDetachRequest) ProtoMessage()    {}
+func (*SdkVolumeDetachRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{56}
 }
-func (m *VolumeDetachRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeDetachRequest.Unmarshal(m, b)
+func (m *SdkVolumeDetachRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeDetachRequest.Unmarshal(m, b)
 }
-func (m *VolumeDetachRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeDetachRequest.Marshal(b, m, deterministic)
+func (m *SdkVolumeDetachRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeDetachRequest.Marshal(b, m, deterministic)
 }
-func (dst *VolumeDetachRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeDetachRequest.Merge(dst, src)
+func (dst *SdkVolumeDetachRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeDetachRequest.Merge(dst, src)
 }
-func (m *VolumeDetachRequest) XXX_Size() int {
-	return xxx_messageInfo_VolumeDetachRequest.Size(m)
+func (m *SdkVolumeDetachRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeDetachRequest.Size(m)
 }
-func (m *VolumeDetachRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeDetachRequest.DiscardUnknown(m)
+func (m *SdkVolumeDetachRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeDetachRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeDetachRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeDetachRequest proto.InternalMessageInfo
 
-func (m *VolumeDetachRequest) GetVolumeId() string {
+func (m *SdkVolumeDetachRequest) GetVolumeId() string {
 	if m != nil {
 		return m.VolumeId
 	}
 	return ""
 }
 
-type VolumeDetachResponse struct {
+type SdkVolumeDetachResponse struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *VolumeDetachResponse) Reset()         { *m = VolumeDetachResponse{} }
-func (m *VolumeDetachResponse) String() string { return proto.CompactTextString(m) }
-func (*VolumeDetachResponse) ProtoMessage()    {}
-func (*VolumeDetachResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{57}
+func (m *SdkVolumeDetachResponse) Reset()         { *m = SdkVolumeDetachResponse{} }
+func (m *SdkVolumeDetachResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeDetachResponse) ProtoMessage()    {}
+func (*SdkVolumeDetachResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{57}
 }
-func (m *VolumeDetachResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeDetachResponse.Unmarshal(m, b)
+func (m *SdkVolumeDetachResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeDetachResponse.Unmarshal(m, b)
 }
-func (m *VolumeDetachResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeDetachResponse.Marshal(b, m, deterministic)
+func (m *SdkVolumeDetachResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeDetachResponse.Marshal(b, m, deterministic)
 }
-func (dst *VolumeDetachResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeDetachResponse.Merge(dst, src)
+func (dst *SdkVolumeDetachResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeDetachResponse.Merge(dst, src)
 }
-func (m *VolumeDetachResponse) XXX_Size() int {
-	return xxx_messageInfo_VolumeDetachResponse.Size(m)
+func (m *SdkVolumeDetachResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeDetachResponse.Size(m)
 }
-func (m *VolumeDetachResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeDetachResponse.DiscardUnknown(m)
+func (m *SdkVolumeDetachResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeDetachResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeDetachResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeDetachResponse proto.InternalMessageInfo
 
-type OpenStorageVolumeCreateRequest struct {
+type SdkVolumeCreateRequest struct {
 	// Unique name of the volume. This will be used for idempotency.
 	Name string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
 	// Volume specification
@@ -4174,45 +4174,45 @@ type OpenStorageVolumeCreateRequest struct {
 	XXX_sizecache        int32       `json:"-"`
 }
 
-func (m *OpenStorageVolumeCreateRequest) Reset()         { *m = OpenStorageVolumeCreateRequest{} }
-func (m *OpenStorageVolumeCreateRequest) String() string { return proto.CompactTextString(m) }
-func (*OpenStorageVolumeCreateRequest) ProtoMessage()    {}
-func (*OpenStorageVolumeCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{58}
+func (m *SdkVolumeCreateRequest) Reset()         { *m = SdkVolumeCreateRequest{} }
+func (m *SdkVolumeCreateRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeCreateRequest) ProtoMessage()    {}
+func (*SdkVolumeCreateRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{58}
 }
-func (m *OpenStorageVolumeCreateRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_OpenStorageVolumeCreateRequest.Unmarshal(m, b)
+func (m *SdkVolumeCreateRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeCreateRequest.Unmarshal(m, b)
 }
-func (m *OpenStorageVolumeCreateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_OpenStorageVolumeCreateRequest.Marshal(b, m, deterministic)
+func (m *SdkVolumeCreateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeCreateRequest.Marshal(b, m, deterministic)
 }
-func (dst *OpenStorageVolumeCreateRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_OpenStorageVolumeCreateRequest.Merge(dst, src)
+func (dst *SdkVolumeCreateRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeCreateRequest.Merge(dst, src)
 }
-func (m *OpenStorageVolumeCreateRequest) XXX_Size() int {
-	return xxx_messageInfo_OpenStorageVolumeCreateRequest.Size(m)
+func (m *SdkVolumeCreateRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeCreateRequest.Size(m)
 }
-func (m *OpenStorageVolumeCreateRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_OpenStorageVolumeCreateRequest.DiscardUnknown(m)
+func (m *SdkVolumeCreateRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeCreateRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_OpenStorageVolumeCreateRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeCreateRequest proto.InternalMessageInfo
 
-func (m *OpenStorageVolumeCreateRequest) GetName() string {
+func (m *SdkVolumeCreateRequest) GetName() string {
 	if m != nil {
 		return m.Name
 	}
 	return ""
 }
 
-func (m *OpenStorageVolumeCreateRequest) GetSpec() *VolumeSpec {
+func (m *SdkVolumeCreateRequest) GetSpec() *VolumeSpec {
 	if m != nil {
 		return m.Spec
 	}
 	return nil
 }
 
-type OpenStorageVolumeCreateResponse struct {
+type SdkVolumeCreateResponse struct {
 	// Id of new volume
 	VolumeId             string   `protobuf:"bytes,1,opt,name=volume_id,json=volumeId" json:"volume_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -4220,38 +4220,38 @@ type OpenStorageVolumeCreateResponse struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *OpenStorageVolumeCreateResponse) Reset()         { *m = OpenStorageVolumeCreateResponse{} }
-func (m *OpenStorageVolumeCreateResponse) String() string { return proto.CompactTextString(m) }
-func (*OpenStorageVolumeCreateResponse) ProtoMessage()    {}
-func (*OpenStorageVolumeCreateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{59}
+func (m *SdkVolumeCreateResponse) Reset()         { *m = SdkVolumeCreateResponse{} }
+func (m *SdkVolumeCreateResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeCreateResponse) ProtoMessage()    {}
+func (*SdkVolumeCreateResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{59}
 }
-func (m *OpenStorageVolumeCreateResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_OpenStorageVolumeCreateResponse.Unmarshal(m, b)
+func (m *SdkVolumeCreateResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeCreateResponse.Unmarshal(m, b)
 }
-func (m *OpenStorageVolumeCreateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_OpenStorageVolumeCreateResponse.Marshal(b, m, deterministic)
+func (m *SdkVolumeCreateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeCreateResponse.Marshal(b, m, deterministic)
 }
-func (dst *OpenStorageVolumeCreateResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_OpenStorageVolumeCreateResponse.Merge(dst, src)
+func (dst *SdkVolumeCreateResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeCreateResponse.Merge(dst, src)
 }
-func (m *OpenStorageVolumeCreateResponse) XXX_Size() int {
-	return xxx_messageInfo_OpenStorageVolumeCreateResponse.Size(m)
+func (m *SdkVolumeCreateResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeCreateResponse.Size(m)
 }
-func (m *OpenStorageVolumeCreateResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_OpenStorageVolumeCreateResponse.DiscardUnknown(m)
+func (m *SdkVolumeCreateResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeCreateResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_OpenStorageVolumeCreateResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeCreateResponse proto.InternalMessageInfo
 
-func (m *OpenStorageVolumeCreateResponse) GetVolumeId() string {
+func (m *SdkVolumeCreateResponse) GetVolumeId() string {
 	if m != nil {
 		return m.VolumeId
 	}
 	return ""
 }
 
-type VolumeCreateFromVolumeIDRequest struct {
+type SdkVolumeCreateFromVolumeIdRequest struct {
 	// Unique name of the volume. This will be used for idempotency.
 	Name string `protobuf:"bytes,1,opt,name=name" json:"name,omitempty"`
 	// Parent volume id, if specified will create a new volume as a clone of the parent.
@@ -4263,52 +4263,52 @@ type VolumeCreateFromVolumeIDRequest struct {
 	XXX_sizecache        int32       `json:"-"`
 }
 
-func (m *VolumeCreateFromVolumeIDRequest) Reset()         { *m = VolumeCreateFromVolumeIDRequest{} }
-func (m *VolumeCreateFromVolumeIDRequest) String() string { return proto.CompactTextString(m) }
-func (*VolumeCreateFromVolumeIDRequest) ProtoMessage()    {}
-func (*VolumeCreateFromVolumeIDRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{60}
+func (m *SdkVolumeCreateFromVolumeIdRequest) Reset()         { *m = SdkVolumeCreateFromVolumeIdRequest{} }
+func (m *SdkVolumeCreateFromVolumeIdRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeCreateFromVolumeIdRequest) ProtoMessage()    {}
+func (*SdkVolumeCreateFromVolumeIdRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{60}
 }
-func (m *VolumeCreateFromVolumeIDRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeCreateFromVolumeIDRequest.Unmarshal(m, b)
+func (m *SdkVolumeCreateFromVolumeIdRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeCreateFromVolumeIdRequest.Unmarshal(m, b)
 }
-func (m *VolumeCreateFromVolumeIDRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeCreateFromVolumeIDRequest.Marshal(b, m, deterministic)
+func (m *SdkVolumeCreateFromVolumeIdRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeCreateFromVolumeIdRequest.Marshal(b, m, deterministic)
 }
-func (dst *VolumeCreateFromVolumeIDRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeCreateFromVolumeIDRequest.Merge(dst, src)
+func (dst *SdkVolumeCreateFromVolumeIdRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeCreateFromVolumeIdRequest.Merge(dst, src)
 }
-func (m *VolumeCreateFromVolumeIDRequest) XXX_Size() int {
-	return xxx_messageInfo_VolumeCreateFromVolumeIDRequest.Size(m)
+func (m *SdkVolumeCreateFromVolumeIdRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeCreateFromVolumeIdRequest.Size(m)
 }
-func (m *VolumeCreateFromVolumeIDRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeCreateFromVolumeIDRequest.DiscardUnknown(m)
+func (m *SdkVolumeCreateFromVolumeIdRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeCreateFromVolumeIdRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeCreateFromVolumeIDRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeCreateFromVolumeIdRequest proto.InternalMessageInfo
 
-func (m *VolumeCreateFromVolumeIDRequest) GetName() string {
+func (m *SdkVolumeCreateFromVolumeIdRequest) GetName() string {
 	if m != nil {
 		return m.Name
 	}
 	return ""
 }
 
-func (m *VolumeCreateFromVolumeIDRequest) GetParentId() string {
+func (m *SdkVolumeCreateFromVolumeIdRequest) GetParentId() string {
 	if m != nil {
 		return m.ParentId
 	}
 	return ""
 }
 
-func (m *VolumeCreateFromVolumeIDRequest) GetSpec() *VolumeSpec {
+func (m *SdkVolumeCreateFromVolumeIdRequest) GetSpec() *VolumeSpec {
 	if m != nil {
 		return m.Spec
 	}
 	return nil
 }
 
-type VolumeCreateFromVolumeIDResponse struct {
+type SdkVolumeCreateFromVolumeIdResponse struct {
 	// Id of new volume
 	VolumeId             string   `protobuf:"bytes,1,opt,name=volume_id,json=volumeId" json:"volume_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -4316,38 +4316,38 @@ type VolumeCreateFromVolumeIDResponse struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *VolumeCreateFromVolumeIDResponse) Reset()         { *m = VolumeCreateFromVolumeIDResponse{} }
-func (m *VolumeCreateFromVolumeIDResponse) String() string { return proto.CompactTextString(m) }
-func (*VolumeCreateFromVolumeIDResponse) ProtoMessage()    {}
-func (*VolumeCreateFromVolumeIDResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{61}
+func (m *SdkVolumeCreateFromVolumeIdResponse) Reset()         { *m = SdkVolumeCreateFromVolumeIdResponse{} }
+func (m *SdkVolumeCreateFromVolumeIdResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeCreateFromVolumeIdResponse) ProtoMessage()    {}
+func (*SdkVolumeCreateFromVolumeIdResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{61}
 }
-func (m *VolumeCreateFromVolumeIDResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeCreateFromVolumeIDResponse.Unmarshal(m, b)
+func (m *SdkVolumeCreateFromVolumeIdResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeCreateFromVolumeIdResponse.Unmarshal(m, b)
 }
-func (m *VolumeCreateFromVolumeIDResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeCreateFromVolumeIDResponse.Marshal(b, m, deterministic)
+func (m *SdkVolumeCreateFromVolumeIdResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeCreateFromVolumeIdResponse.Marshal(b, m, deterministic)
 }
-func (dst *VolumeCreateFromVolumeIDResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeCreateFromVolumeIDResponse.Merge(dst, src)
+func (dst *SdkVolumeCreateFromVolumeIdResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeCreateFromVolumeIdResponse.Merge(dst, src)
 }
-func (m *VolumeCreateFromVolumeIDResponse) XXX_Size() int {
-	return xxx_messageInfo_VolumeCreateFromVolumeIDResponse.Size(m)
+func (m *SdkVolumeCreateFromVolumeIdResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeCreateFromVolumeIdResponse.Size(m)
 }
-func (m *VolumeCreateFromVolumeIDResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeCreateFromVolumeIDResponse.DiscardUnknown(m)
+func (m *SdkVolumeCreateFromVolumeIdResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeCreateFromVolumeIdResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeCreateFromVolumeIDResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeCreateFromVolumeIdResponse proto.InternalMessageInfo
 
-func (m *VolumeCreateFromVolumeIDResponse) GetVolumeId() string {
+func (m *SdkVolumeCreateFromVolumeIdResponse) GetVolumeId() string {
 	if m != nil {
 		return m.VolumeId
 	}
 	return ""
 }
 
-type VolumeDeleteRequest struct {
+type SdkVolumeDeleteRequest struct {
 	// Id of volume to delete
 	VolumeId             string   `protobuf:"bytes,1,opt,name=volume_id,json=volumeId" json:"volume_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -4355,68 +4355,68 @@ type VolumeDeleteRequest struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *VolumeDeleteRequest) Reset()         { *m = VolumeDeleteRequest{} }
-func (m *VolumeDeleteRequest) String() string { return proto.CompactTextString(m) }
-func (*VolumeDeleteRequest) ProtoMessage()    {}
-func (*VolumeDeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{62}
+func (m *SdkVolumeDeleteRequest) Reset()         { *m = SdkVolumeDeleteRequest{} }
+func (m *SdkVolumeDeleteRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeDeleteRequest) ProtoMessage()    {}
+func (*SdkVolumeDeleteRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{62}
 }
-func (m *VolumeDeleteRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeDeleteRequest.Unmarshal(m, b)
+func (m *SdkVolumeDeleteRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeDeleteRequest.Unmarshal(m, b)
 }
-func (m *VolumeDeleteRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeDeleteRequest.Marshal(b, m, deterministic)
+func (m *SdkVolumeDeleteRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeDeleteRequest.Marshal(b, m, deterministic)
 }
-func (dst *VolumeDeleteRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeDeleteRequest.Merge(dst, src)
+func (dst *SdkVolumeDeleteRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeDeleteRequest.Merge(dst, src)
 }
-func (m *VolumeDeleteRequest) XXX_Size() int {
-	return xxx_messageInfo_VolumeDeleteRequest.Size(m)
+func (m *SdkVolumeDeleteRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeDeleteRequest.Size(m)
 }
-func (m *VolumeDeleteRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeDeleteRequest.DiscardUnknown(m)
+func (m *SdkVolumeDeleteRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeDeleteRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeDeleteRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeDeleteRequest proto.InternalMessageInfo
 
-func (m *VolumeDeleteRequest) GetVolumeId() string {
+func (m *SdkVolumeDeleteRequest) GetVolumeId() string {
 	if m != nil {
 		return m.VolumeId
 	}
 	return ""
 }
 
-type VolumeDeleteResponse struct {
+type SdkVolumeDeleteResponse struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *VolumeDeleteResponse) Reset()         { *m = VolumeDeleteResponse{} }
-func (m *VolumeDeleteResponse) String() string { return proto.CompactTextString(m) }
-func (*VolumeDeleteResponse) ProtoMessage()    {}
-func (*VolumeDeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{63}
+func (m *SdkVolumeDeleteResponse) Reset()         { *m = SdkVolumeDeleteResponse{} }
+func (m *SdkVolumeDeleteResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeDeleteResponse) ProtoMessage()    {}
+func (*SdkVolumeDeleteResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{63}
 }
-func (m *VolumeDeleteResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeDeleteResponse.Unmarshal(m, b)
+func (m *SdkVolumeDeleteResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeDeleteResponse.Unmarshal(m, b)
 }
-func (m *VolumeDeleteResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeDeleteResponse.Marshal(b, m, deterministic)
+func (m *SdkVolumeDeleteResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeDeleteResponse.Marshal(b, m, deterministic)
 }
-func (dst *VolumeDeleteResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeDeleteResponse.Merge(dst, src)
+func (dst *SdkVolumeDeleteResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeDeleteResponse.Merge(dst, src)
 }
-func (m *VolumeDeleteResponse) XXX_Size() int {
-	return xxx_messageInfo_VolumeDeleteResponse.Size(m)
+func (m *SdkVolumeDeleteResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeDeleteResponse.Size(m)
 }
-func (m *VolumeDeleteResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeDeleteResponse.DiscardUnknown(m)
+func (m *SdkVolumeDeleteResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeDeleteResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeDeleteResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeDeleteResponse proto.InternalMessageInfo
 
-type VolumeInspectRequest struct {
+type SdkVolumeInspectRequest struct {
 	// Id of volume to inspect
 	VolumeId             string   `protobuf:"bytes,1,opt,name=volume_id,json=volumeId" json:"volume_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -4424,38 +4424,38 @@ type VolumeInspectRequest struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *VolumeInspectRequest) Reset()         { *m = VolumeInspectRequest{} }
-func (m *VolumeInspectRequest) String() string { return proto.CompactTextString(m) }
-func (*VolumeInspectRequest) ProtoMessage()    {}
-func (*VolumeInspectRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{64}
+func (m *SdkVolumeInspectRequest) Reset()         { *m = SdkVolumeInspectRequest{} }
+func (m *SdkVolumeInspectRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeInspectRequest) ProtoMessage()    {}
+func (*SdkVolumeInspectRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{64}
 }
-func (m *VolumeInspectRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeInspectRequest.Unmarshal(m, b)
+func (m *SdkVolumeInspectRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeInspectRequest.Unmarshal(m, b)
 }
-func (m *VolumeInspectRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeInspectRequest.Marshal(b, m, deterministic)
+func (m *SdkVolumeInspectRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeInspectRequest.Marshal(b, m, deterministic)
 }
-func (dst *VolumeInspectRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeInspectRequest.Merge(dst, src)
+func (dst *SdkVolumeInspectRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeInspectRequest.Merge(dst, src)
 }
-func (m *VolumeInspectRequest) XXX_Size() int {
-	return xxx_messageInfo_VolumeInspectRequest.Size(m)
+func (m *SdkVolumeInspectRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeInspectRequest.Size(m)
 }
-func (m *VolumeInspectRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeInspectRequest.DiscardUnknown(m)
+func (m *SdkVolumeInspectRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeInspectRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeInspectRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeInspectRequest proto.InternalMessageInfo
 
-func (m *VolumeInspectRequest) GetVolumeId() string {
+func (m *SdkVolumeInspectRequest) GetVolumeId() string {
 	if m != nil {
 		return m.VolumeId
 	}
 	return ""
 }
 
-type VolumeInspectResponse struct {
+type SdkVolumeInspectResponse struct {
 	// Information about the volume
 	Volume               *Volume  `protobuf:"bytes,1,opt,name=volume" json:"volume,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -4463,38 +4463,38 @@ type VolumeInspectResponse struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *VolumeInspectResponse) Reset()         { *m = VolumeInspectResponse{} }
-func (m *VolumeInspectResponse) String() string { return proto.CompactTextString(m) }
-func (*VolumeInspectResponse) ProtoMessage()    {}
-func (*VolumeInspectResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{65}
+func (m *SdkVolumeInspectResponse) Reset()         { *m = SdkVolumeInspectResponse{} }
+func (m *SdkVolumeInspectResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeInspectResponse) ProtoMessage()    {}
+func (*SdkVolumeInspectResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{65}
 }
-func (m *VolumeInspectResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeInspectResponse.Unmarshal(m, b)
+func (m *SdkVolumeInspectResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeInspectResponse.Unmarshal(m, b)
 }
-func (m *VolumeInspectResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeInspectResponse.Marshal(b, m, deterministic)
+func (m *SdkVolumeInspectResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeInspectResponse.Marshal(b, m, deterministic)
 }
-func (dst *VolumeInspectResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeInspectResponse.Merge(dst, src)
+func (dst *SdkVolumeInspectResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeInspectResponse.Merge(dst, src)
 }
-func (m *VolumeInspectResponse) XXX_Size() int {
-	return xxx_messageInfo_VolumeInspectResponse.Size(m)
+func (m *SdkVolumeInspectResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeInspectResponse.Size(m)
 }
-func (m *VolumeInspectResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeInspectResponse.DiscardUnknown(m)
+func (m *SdkVolumeInspectResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeInspectResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeInspectResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeInspectResponse proto.InternalMessageInfo
 
-func (m *VolumeInspectResponse) GetVolume() *Volume {
+func (m *SdkVolumeInspectResponse) GetVolume() *Volume {
 	if m != nil {
 		return m.Volume
 	}
 	return nil
 }
 
-type VolumeEnumerateRequest struct {
+type SdkVolumeEnumerateRequest struct {
 	// Volumes to match to this locator.
 	// If not provided, all volumes will be returned.
 	Locator              *VolumeLocator `protobuf:"bytes,1,opt,name=locator" json:"locator,omitempty"`
@@ -4503,38 +4503,38 @@ type VolumeEnumerateRequest struct {
 	XXX_sizecache        int32          `json:"-"`
 }
 
-func (m *VolumeEnumerateRequest) Reset()         { *m = VolumeEnumerateRequest{} }
-func (m *VolumeEnumerateRequest) String() string { return proto.CompactTextString(m) }
-func (*VolumeEnumerateRequest) ProtoMessage()    {}
-func (*VolumeEnumerateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{66}
+func (m *SdkVolumeEnumerateRequest) Reset()         { *m = SdkVolumeEnumerateRequest{} }
+func (m *SdkVolumeEnumerateRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeEnumerateRequest) ProtoMessage()    {}
+func (*SdkVolumeEnumerateRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{66}
 }
-func (m *VolumeEnumerateRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeEnumerateRequest.Unmarshal(m, b)
+func (m *SdkVolumeEnumerateRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeEnumerateRequest.Unmarshal(m, b)
 }
-func (m *VolumeEnumerateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeEnumerateRequest.Marshal(b, m, deterministic)
+func (m *SdkVolumeEnumerateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeEnumerateRequest.Marshal(b, m, deterministic)
 }
-func (dst *VolumeEnumerateRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeEnumerateRequest.Merge(dst, src)
+func (dst *SdkVolumeEnumerateRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeEnumerateRequest.Merge(dst, src)
 }
-func (m *VolumeEnumerateRequest) XXX_Size() int {
-	return xxx_messageInfo_VolumeEnumerateRequest.Size(m)
+func (m *SdkVolumeEnumerateRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeEnumerateRequest.Size(m)
 }
-func (m *VolumeEnumerateRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeEnumerateRequest.DiscardUnknown(m)
+func (m *SdkVolumeEnumerateRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeEnumerateRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeEnumerateRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeEnumerateRequest proto.InternalMessageInfo
 
-func (m *VolumeEnumerateRequest) GetLocator() *VolumeLocator {
+func (m *SdkVolumeEnumerateRequest) GetLocator() *VolumeLocator {
 	if m != nil {
 		return m.Locator
 	}
 	return nil
 }
 
-type VolumeEnumerateResponse struct {
+type SdkVolumeEnumerateResponse struct {
 	// List of volumes matching label
 	Volumes              []*Volume `protobuf:"bytes,1,rep,name=volumes" json:"volumes,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
@@ -4542,38 +4542,38 @@ type VolumeEnumerateResponse struct {
 	XXX_sizecache        int32     `json:"-"`
 }
 
-func (m *VolumeEnumerateResponse) Reset()         { *m = VolumeEnumerateResponse{} }
-func (m *VolumeEnumerateResponse) String() string { return proto.CompactTextString(m) }
-func (*VolumeEnumerateResponse) ProtoMessage()    {}
-func (*VolumeEnumerateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{67}
+func (m *SdkVolumeEnumerateResponse) Reset()         { *m = SdkVolumeEnumerateResponse{} }
+func (m *SdkVolumeEnumerateResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeEnumerateResponse) ProtoMessage()    {}
+func (*SdkVolumeEnumerateResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{67}
 }
-func (m *VolumeEnumerateResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeEnumerateResponse.Unmarshal(m, b)
+func (m *SdkVolumeEnumerateResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeEnumerateResponse.Unmarshal(m, b)
 }
-func (m *VolumeEnumerateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeEnumerateResponse.Marshal(b, m, deterministic)
+func (m *SdkVolumeEnumerateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeEnumerateResponse.Marshal(b, m, deterministic)
 }
-func (dst *VolumeEnumerateResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeEnumerateResponse.Merge(dst, src)
+func (dst *SdkVolumeEnumerateResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeEnumerateResponse.Merge(dst, src)
 }
-func (m *VolumeEnumerateResponse) XXX_Size() int {
-	return xxx_messageInfo_VolumeEnumerateResponse.Size(m)
+func (m *SdkVolumeEnumerateResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeEnumerateResponse.Size(m)
 }
-func (m *VolumeEnumerateResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeEnumerateResponse.DiscardUnknown(m)
+func (m *SdkVolumeEnumerateResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeEnumerateResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeEnumerateResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeEnumerateResponse proto.InternalMessageInfo
 
-func (m *VolumeEnumerateResponse) GetVolumes() []*Volume {
+func (m *SdkVolumeEnumerateResponse) GetVolumes() []*Volume {
 	if m != nil {
 		return m.Volumes
 	}
 	return nil
 }
 
-type VolumeSnapshotCreateRequest struct {
+type SdkVolumeSnapshotCreateRequest struct {
 	// Id of volume to take the snapshot from
 	VolumeId string `protobuf:"bytes,1,opt,name=volume_id,json=volumeId" json:"volume_id,omitempty"`
 	// Labels to apply to snapshot
@@ -4583,45 +4583,45 @@ type VolumeSnapshotCreateRequest struct {
 	XXX_sizecache        int32             `json:"-"`
 }
 
-func (m *VolumeSnapshotCreateRequest) Reset()         { *m = VolumeSnapshotCreateRequest{} }
-func (m *VolumeSnapshotCreateRequest) String() string { return proto.CompactTextString(m) }
-func (*VolumeSnapshotCreateRequest) ProtoMessage()    {}
-func (*VolumeSnapshotCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{68}
+func (m *SdkVolumeSnapshotCreateRequest) Reset()         { *m = SdkVolumeSnapshotCreateRequest{} }
+func (m *SdkVolumeSnapshotCreateRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeSnapshotCreateRequest) ProtoMessage()    {}
+func (*SdkVolumeSnapshotCreateRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{68}
 }
-func (m *VolumeSnapshotCreateRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeSnapshotCreateRequest.Unmarshal(m, b)
+func (m *SdkVolumeSnapshotCreateRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeSnapshotCreateRequest.Unmarshal(m, b)
 }
-func (m *VolumeSnapshotCreateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeSnapshotCreateRequest.Marshal(b, m, deterministic)
+func (m *SdkVolumeSnapshotCreateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeSnapshotCreateRequest.Marshal(b, m, deterministic)
 }
-func (dst *VolumeSnapshotCreateRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeSnapshotCreateRequest.Merge(dst, src)
+func (dst *SdkVolumeSnapshotCreateRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeSnapshotCreateRequest.Merge(dst, src)
 }
-func (m *VolumeSnapshotCreateRequest) XXX_Size() int {
-	return xxx_messageInfo_VolumeSnapshotCreateRequest.Size(m)
+func (m *SdkVolumeSnapshotCreateRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeSnapshotCreateRequest.Size(m)
 }
-func (m *VolumeSnapshotCreateRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeSnapshotCreateRequest.DiscardUnknown(m)
+func (m *SdkVolumeSnapshotCreateRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeSnapshotCreateRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeSnapshotCreateRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeSnapshotCreateRequest proto.InternalMessageInfo
 
-func (m *VolumeSnapshotCreateRequest) GetVolumeId() string {
+func (m *SdkVolumeSnapshotCreateRequest) GetVolumeId() string {
 	if m != nil {
 		return m.VolumeId
 	}
 	return ""
 }
 
-func (m *VolumeSnapshotCreateRequest) GetLabels() map[string]string {
+func (m *SdkVolumeSnapshotCreateRequest) GetLabels() map[string]string {
 	if m != nil {
 		return m.Labels
 	}
 	return nil
 }
 
-type VolumeSnapshotCreateResponse struct {
+type SdkVolumeSnapshotCreateResponse struct {
 	// Id of immutable snapshot
 	SnapshotId           string   `protobuf:"bytes,1,opt,name=snapshot_id,json=snapshotId" json:"snapshot_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -4629,38 +4629,38 @@ type VolumeSnapshotCreateResponse struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *VolumeSnapshotCreateResponse) Reset()         { *m = VolumeSnapshotCreateResponse{} }
-func (m *VolumeSnapshotCreateResponse) String() string { return proto.CompactTextString(m) }
-func (*VolumeSnapshotCreateResponse) ProtoMessage()    {}
-func (*VolumeSnapshotCreateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{69}
+func (m *SdkVolumeSnapshotCreateResponse) Reset()         { *m = SdkVolumeSnapshotCreateResponse{} }
+func (m *SdkVolumeSnapshotCreateResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeSnapshotCreateResponse) ProtoMessage()    {}
+func (*SdkVolumeSnapshotCreateResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{69}
 }
-func (m *VolumeSnapshotCreateResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeSnapshotCreateResponse.Unmarshal(m, b)
+func (m *SdkVolumeSnapshotCreateResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeSnapshotCreateResponse.Unmarshal(m, b)
 }
-func (m *VolumeSnapshotCreateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeSnapshotCreateResponse.Marshal(b, m, deterministic)
+func (m *SdkVolumeSnapshotCreateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeSnapshotCreateResponse.Marshal(b, m, deterministic)
 }
-func (dst *VolumeSnapshotCreateResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeSnapshotCreateResponse.Merge(dst, src)
+func (dst *SdkVolumeSnapshotCreateResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeSnapshotCreateResponse.Merge(dst, src)
 }
-func (m *VolumeSnapshotCreateResponse) XXX_Size() int {
-	return xxx_messageInfo_VolumeSnapshotCreateResponse.Size(m)
+func (m *SdkVolumeSnapshotCreateResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeSnapshotCreateResponse.Size(m)
 }
-func (m *VolumeSnapshotCreateResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeSnapshotCreateResponse.DiscardUnknown(m)
+func (m *SdkVolumeSnapshotCreateResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeSnapshotCreateResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeSnapshotCreateResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeSnapshotCreateResponse proto.InternalMessageInfo
 
-func (m *VolumeSnapshotCreateResponse) GetSnapshotId() string {
+func (m *SdkVolumeSnapshotCreateResponse) GetSnapshotId() string {
 	if m != nil {
 		return m.SnapshotId
 	}
 	return ""
 }
 
-type VolumeSnapshotRestoreRequest struct {
+type SdkVolumeSnapshotRestoreRequest struct {
 	// Id of volume
 	VolumeId string `protobuf:"bytes,1,opt,name=volume_id,json=volumeId" json:"volume_id,omitempty"`
 	// Snapshot id to apply to `volume_id`
@@ -4670,75 +4670,75 @@ type VolumeSnapshotRestoreRequest struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *VolumeSnapshotRestoreRequest) Reset()         { *m = VolumeSnapshotRestoreRequest{} }
-func (m *VolumeSnapshotRestoreRequest) String() string { return proto.CompactTextString(m) }
-func (*VolumeSnapshotRestoreRequest) ProtoMessage()    {}
-func (*VolumeSnapshotRestoreRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{70}
+func (m *SdkVolumeSnapshotRestoreRequest) Reset()         { *m = SdkVolumeSnapshotRestoreRequest{} }
+func (m *SdkVolumeSnapshotRestoreRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeSnapshotRestoreRequest) ProtoMessage()    {}
+func (*SdkVolumeSnapshotRestoreRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{70}
 }
-func (m *VolumeSnapshotRestoreRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeSnapshotRestoreRequest.Unmarshal(m, b)
+func (m *SdkVolumeSnapshotRestoreRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeSnapshotRestoreRequest.Unmarshal(m, b)
 }
-func (m *VolumeSnapshotRestoreRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeSnapshotRestoreRequest.Marshal(b, m, deterministic)
+func (m *SdkVolumeSnapshotRestoreRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeSnapshotRestoreRequest.Marshal(b, m, deterministic)
 }
-func (dst *VolumeSnapshotRestoreRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeSnapshotRestoreRequest.Merge(dst, src)
+func (dst *SdkVolumeSnapshotRestoreRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeSnapshotRestoreRequest.Merge(dst, src)
 }
-func (m *VolumeSnapshotRestoreRequest) XXX_Size() int {
-	return xxx_messageInfo_VolumeSnapshotRestoreRequest.Size(m)
+func (m *SdkVolumeSnapshotRestoreRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeSnapshotRestoreRequest.Size(m)
 }
-func (m *VolumeSnapshotRestoreRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeSnapshotRestoreRequest.DiscardUnknown(m)
+func (m *SdkVolumeSnapshotRestoreRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeSnapshotRestoreRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeSnapshotRestoreRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeSnapshotRestoreRequest proto.InternalMessageInfo
 
-func (m *VolumeSnapshotRestoreRequest) GetVolumeId() string {
+func (m *SdkVolumeSnapshotRestoreRequest) GetVolumeId() string {
 	if m != nil {
 		return m.VolumeId
 	}
 	return ""
 }
 
-func (m *VolumeSnapshotRestoreRequest) GetSnapshotId() string {
+func (m *SdkVolumeSnapshotRestoreRequest) GetSnapshotId() string {
 	if m != nil {
 		return m.SnapshotId
 	}
 	return ""
 }
 
-type VolumeSnapshotRestoreResponse struct {
+type SdkVolumeSnapshotRestoreResponse struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *VolumeSnapshotRestoreResponse) Reset()         { *m = VolumeSnapshotRestoreResponse{} }
-func (m *VolumeSnapshotRestoreResponse) String() string { return proto.CompactTextString(m) }
-func (*VolumeSnapshotRestoreResponse) ProtoMessage()    {}
-func (*VolumeSnapshotRestoreResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{71}
+func (m *SdkVolumeSnapshotRestoreResponse) Reset()         { *m = SdkVolumeSnapshotRestoreResponse{} }
+func (m *SdkVolumeSnapshotRestoreResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeSnapshotRestoreResponse) ProtoMessage()    {}
+func (*SdkVolumeSnapshotRestoreResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{71}
 }
-func (m *VolumeSnapshotRestoreResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeSnapshotRestoreResponse.Unmarshal(m, b)
+func (m *SdkVolumeSnapshotRestoreResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeSnapshotRestoreResponse.Unmarshal(m, b)
 }
-func (m *VolumeSnapshotRestoreResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeSnapshotRestoreResponse.Marshal(b, m, deterministic)
+func (m *SdkVolumeSnapshotRestoreResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeSnapshotRestoreResponse.Marshal(b, m, deterministic)
 }
-func (dst *VolumeSnapshotRestoreResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeSnapshotRestoreResponse.Merge(dst, src)
+func (dst *SdkVolumeSnapshotRestoreResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeSnapshotRestoreResponse.Merge(dst, src)
 }
-func (m *VolumeSnapshotRestoreResponse) XXX_Size() int {
-	return xxx_messageInfo_VolumeSnapshotRestoreResponse.Size(m)
+func (m *SdkVolumeSnapshotRestoreResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeSnapshotRestoreResponse.Size(m)
 }
-func (m *VolumeSnapshotRestoreResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeSnapshotRestoreResponse.DiscardUnknown(m)
+func (m *SdkVolumeSnapshotRestoreResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeSnapshotRestoreResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeSnapshotRestoreResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeSnapshotRestoreResponse proto.InternalMessageInfo
 
-type VolumeSnapshotEnumerateRequest struct {
+type SdkVolumeSnapshotEnumerateRequest struct {
 	// Id of volume
 	VolumeId string `protobuf:"bytes,1,opt,name=volume_id,json=volumeId" json:"volume_id,omitempty"`
 	// Labels from snapshot
@@ -4748,45 +4748,45 @@ type VolumeSnapshotEnumerateRequest struct {
 	XXX_sizecache        int32             `json:"-"`
 }
 
-func (m *VolumeSnapshotEnumerateRequest) Reset()         { *m = VolumeSnapshotEnumerateRequest{} }
-func (m *VolumeSnapshotEnumerateRequest) String() string { return proto.CompactTextString(m) }
-func (*VolumeSnapshotEnumerateRequest) ProtoMessage()    {}
-func (*VolumeSnapshotEnumerateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{72}
+func (m *SdkVolumeSnapshotEnumerateRequest) Reset()         { *m = SdkVolumeSnapshotEnumerateRequest{} }
+func (m *SdkVolumeSnapshotEnumerateRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeSnapshotEnumerateRequest) ProtoMessage()    {}
+func (*SdkVolumeSnapshotEnumerateRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{72}
 }
-func (m *VolumeSnapshotEnumerateRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeSnapshotEnumerateRequest.Unmarshal(m, b)
+func (m *SdkVolumeSnapshotEnumerateRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeSnapshotEnumerateRequest.Unmarshal(m, b)
 }
-func (m *VolumeSnapshotEnumerateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeSnapshotEnumerateRequest.Marshal(b, m, deterministic)
+func (m *SdkVolumeSnapshotEnumerateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeSnapshotEnumerateRequest.Marshal(b, m, deterministic)
 }
-func (dst *VolumeSnapshotEnumerateRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeSnapshotEnumerateRequest.Merge(dst, src)
+func (dst *SdkVolumeSnapshotEnumerateRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeSnapshotEnumerateRequest.Merge(dst, src)
 }
-func (m *VolumeSnapshotEnumerateRequest) XXX_Size() int {
-	return xxx_messageInfo_VolumeSnapshotEnumerateRequest.Size(m)
+func (m *SdkVolumeSnapshotEnumerateRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeSnapshotEnumerateRequest.Size(m)
 }
-func (m *VolumeSnapshotEnumerateRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeSnapshotEnumerateRequest.DiscardUnknown(m)
+func (m *SdkVolumeSnapshotEnumerateRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeSnapshotEnumerateRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeSnapshotEnumerateRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeSnapshotEnumerateRequest proto.InternalMessageInfo
 
-func (m *VolumeSnapshotEnumerateRequest) GetVolumeId() string {
+func (m *SdkVolumeSnapshotEnumerateRequest) GetVolumeId() string {
 	if m != nil {
 		return m.VolumeId
 	}
 	return ""
 }
 
-func (m *VolumeSnapshotEnumerateRequest) GetLabels() map[string]string {
+func (m *SdkVolumeSnapshotEnumerateRequest) GetLabels() map[string]string {
 	if m != nil {
 		return m.Labels
 	}
 	return nil
 }
 
-type VolumeSnapshotEnumerateResponse struct {
+type SdkVolumeSnapshotEnumerateResponse struct {
 	// List of immutable snapshots
 	Snapshots            []*Volume `protobuf:"bytes,1,rep,name=snapshots" json:"snapshots,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}  `json:"-"`
@@ -4794,68 +4794,68 @@ type VolumeSnapshotEnumerateResponse struct {
 	XXX_sizecache        int32     `json:"-"`
 }
 
-func (m *VolumeSnapshotEnumerateResponse) Reset()         { *m = VolumeSnapshotEnumerateResponse{} }
-func (m *VolumeSnapshotEnumerateResponse) String() string { return proto.CompactTextString(m) }
-func (*VolumeSnapshotEnumerateResponse) ProtoMessage()    {}
-func (*VolumeSnapshotEnumerateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{73}
+func (m *SdkVolumeSnapshotEnumerateResponse) Reset()         { *m = SdkVolumeSnapshotEnumerateResponse{} }
+func (m *SdkVolumeSnapshotEnumerateResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkVolumeSnapshotEnumerateResponse) ProtoMessage()    {}
+func (*SdkVolumeSnapshotEnumerateResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{73}
 }
-func (m *VolumeSnapshotEnumerateResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VolumeSnapshotEnumerateResponse.Unmarshal(m, b)
+func (m *SdkVolumeSnapshotEnumerateResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkVolumeSnapshotEnumerateResponse.Unmarshal(m, b)
 }
-func (m *VolumeSnapshotEnumerateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VolumeSnapshotEnumerateResponse.Marshal(b, m, deterministic)
+func (m *SdkVolumeSnapshotEnumerateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkVolumeSnapshotEnumerateResponse.Marshal(b, m, deterministic)
 }
-func (dst *VolumeSnapshotEnumerateResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VolumeSnapshotEnumerateResponse.Merge(dst, src)
+func (dst *SdkVolumeSnapshotEnumerateResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkVolumeSnapshotEnumerateResponse.Merge(dst, src)
 }
-func (m *VolumeSnapshotEnumerateResponse) XXX_Size() int {
-	return xxx_messageInfo_VolumeSnapshotEnumerateResponse.Size(m)
+func (m *SdkVolumeSnapshotEnumerateResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkVolumeSnapshotEnumerateResponse.Size(m)
 }
-func (m *VolumeSnapshotEnumerateResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_VolumeSnapshotEnumerateResponse.DiscardUnknown(m)
+func (m *SdkVolumeSnapshotEnumerateResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkVolumeSnapshotEnumerateResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_VolumeSnapshotEnumerateResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkVolumeSnapshotEnumerateResponse proto.InternalMessageInfo
 
-func (m *VolumeSnapshotEnumerateResponse) GetSnapshots() []*Volume {
+func (m *SdkVolumeSnapshotEnumerateResponse) GetSnapshots() []*Volume {
 	if m != nil {
 		return m.Snapshots
 	}
 	return nil
 }
 
-type ClusterEnumerateRequest struct {
+type SdkClusterEnumerateRequest struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *ClusterEnumerateRequest) Reset()         { *m = ClusterEnumerateRequest{} }
-func (m *ClusterEnumerateRequest) String() string { return proto.CompactTextString(m) }
-func (*ClusterEnumerateRequest) ProtoMessage()    {}
-func (*ClusterEnumerateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{74}
+func (m *SdkClusterEnumerateRequest) Reset()         { *m = SdkClusterEnumerateRequest{} }
+func (m *SdkClusterEnumerateRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkClusterEnumerateRequest) ProtoMessage()    {}
+func (*SdkClusterEnumerateRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{74}
 }
-func (m *ClusterEnumerateRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ClusterEnumerateRequest.Unmarshal(m, b)
+func (m *SdkClusterEnumerateRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkClusterEnumerateRequest.Unmarshal(m, b)
 }
-func (m *ClusterEnumerateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ClusterEnumerateRequest.Marshal(b, m, deterministic)
+func (m *SdkClusterEnumerateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkClusterEnumerateRequest.Marshal(b, m, deterministic)
 }
-func (dst *ClusterEnumerateRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ClusterEnumerateRequest.Merge(dst, src)
+func (dst *SdkClusterEnumerateRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkClusterEnumerateRequest.Merge(dst, src)
 }
-func (m *ClusterEnumerateRequest) XXX_Size() int {
-	return xxx_messageInfo_ClusterEnumerateRequest.Size(m)
+func (m *SdkClusterEnumerateRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkClusterEnumerateRequest.Size(m)
 }
-func (m *ClusterEnumerateRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_ClusterEnumerateRequest.DiscardUnknown(m)
+func (m *SdkClusterEnumerateRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkClusterEnumerateRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ClusterEnumerateRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkClusterEnumerateRequest proto.InternalMessageInfo
 
-type ClusterEnumerateResponse struct {
+type SdkClusterEnumerateResponse struct {
 	// Cluster information
 	Cluster              *StorageCluster `protobuf:"bytes,1,opt,name=cluster" json:"cluster,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
@@ -4863,38 +4863,38 @@ type ClusterEnumerateResponse struct {
 	XXX_sizecache        int32           `json:"-"`
 }
 
-func (m *ClusterEnumerateResponse) Reset()         { *m = ClusterEnumerateResponse{} }
-func (m *ClusterEnumerateResponse) String() string { return proto.CompactTextString(m) }
-func (*ClusterEnumerateResponse) ProtoMessage()    {}
-func (*ClusterEnumerateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{75}
+func (m *SdkClusterEnumerateResponse) Reset()         { *m = SdkClusterEnumerateResponse{} }
+func (m *SdkClusterEnumerateResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkClusterEnumerateResponse) ProtoMessage()    {}
+func (*SdkClusterEnumerateResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{75}
 }
-func (m *ClusterEnumerateResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ClusterEnumerateResponse.Unmarshal(m, b)
+func (m *SdkClusterEnumerateResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkClusterEnumerateResponse.Unmarshal(m, b)
 }
-func (m *ClusterEnumerateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ClusterEnumerateResponse.Marshal(b, m, deterministic)
+func (m *SdkClusterEnumerateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkClusterEnumerateResponse.Marshal(b, m, deterministic)
 }
-func (dst *ClusterEnumerateResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ClusterEnumerateResponse.Merge(dst, src)
+func (dst *SdkClusterEnumerateResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkClusterEnumerateResponse.Merge(dst, src)
 }
-func (m *ClusterEnumerateResponse) XXX_Size() int {
-	return xxx_messageInfo_ClusterEnumerateResponse.Size(m)
+func (m *SdkClusterEnumerateResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkClusterEnumerateResponse.Size(m)
 }
-func (m *ClusterEnumerateResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_ClusterEnumerateResponse.DiscardUnknown(m)
+func (m *SdkClusterEnumerateResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkClusterEnumerateResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ClusterEnumerateResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkClusterEnumerateResponse proto.InternalMessageInfo
 
-func (m *ClusterEnumerateResponse) GetCluster() *StorageCluster {
+func (m *SdkClusterEnumerateResponse) GetCluster() *StorageCluster {
 	if m != nil {
 		return m.Cluster
 	}
 	return nil
 }
 
-type ClusterInspectRequest struct {
+type SdkClusterInspectRequest struct {
 	// Id of node to inspect (required)
 	NodeId               string   `protobuf:"bytes,1,opt,name=node_id,json=nodeId" json:"node_id,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -4902,38 +4902,38 @@ type ClusterInspectRequest struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *ClusterInspectRequest) Reset()         { *m = ClusterInspectRequest{} }
-func (m *ClusterInspectRequest) String() string { return proto.CompactTextString(m) }
-func (*ClusterInspectRequest) ProtoMessage()    {}
-func (*ClusterInspectRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{76}
+func (m *SdkClusterInspectRequest) Reset()         { *m = SdkClusterInspectRequest{} }
+func (m *SdkClusterInspectRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkClusterInspectRequest) ProtoMessage()    {}
+func (*SdkClusterInspectRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{76}
 }
-func (m *ClusterInspectRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ClusterInspectRequest.Unmarshal(m, b)
+func (m *SdkClusterInspectRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkClusterInspectRequest.Unmarshal(m, b)
 }
-func (m *ClusterInspectRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ClusterInspectRequest.Marshal(b, m, deterministic)
+func (m *SdkClusterInspectRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkClusterInspectRequest.Marshal(b, m, deterministic)
 }
-func (dst *ClusterInspectRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ClusterInspectRequest.Merge(dst, src)
+func (dst *SdkClusterInspectRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkClusterInspectRequest.Merge(dst, src)
 }
-func (m *ClusterInspectRequest) XXX_Size() int {
-	return xxx_messageInfo_ClusterInspectRequest.Size(m)
+func (m *SdkClusterInspectRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkClusterInspectRequest.Size(m)
 }
-func (m *ClusterInspectRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_ClusterInspectRequest.DiscardUnknown(m)
+func (m *SdkClusterInspectRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkClusterInspectRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ClusterInspectRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkClusterInspectRequest proto.InternalMessageInfo
 
-func (m *ClusterInspectRequest) GetNodeId() string {
+func (m *SdkClusterInspectRequest) GetNodeId() string {
 	if m != nil {
 		return m.NodeId
 	}
 	return ""
 }
 
-type ClusterInspectResponse struct {
+type SdkClusterInspectResponse struct {
 	// Node information
 	Node                 *StorageNode `protobuf:"bytes,1,opt,name=node" json:"node,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}     `json:"-"`
@@ -4941,38 +4941,38 @@ type ClusterInspectResponse struct {
 	XXX_sizecache        int32        `json:"-"`
 }
 
-func (m *ClusterInspectResponse) Reset()         { *m = ClusterInspectResponse{} }
-func (m *ClusterInspectResponse) String() string { return proto.CompactTextString(m) }
-func (*ClusterInspectResponse) ProtoMessage()    {}
-func (*ClusterInspectResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{77}
+func (m *SdkClusterInspectResponse) Reset()         { *m = SdkClusterInspectResponse{} }
+func (m *SdkClusterInspectResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkClusterInspectResponse) ProtoMessage()    {}
+func (*SdkClusterInspectResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{77}
 }
-func (m *ClusterInspectResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ClusterInspectResponse.Unmarshal(m, b)
+func (m *SdkClusterInspectResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkClusterInspectResponse.Unmarshal(m, b)
 }
-func (m *ClusterInspectResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ClusterInspectResponse.Marshal(b, m, deterministic)
+func (m *SdkClusterInspectResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkClusterInspectResponse.Marshal(b, m, deterministic)
 }
-func (dst *ClusterInspectResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ClusterInspectResponse.Merge(dst, src)
+func (dst *SdkClusterInspectResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkClusterInspectResponse.Merge(dst, src)
 }
-func (m *ClusterInspectResponse) XXX_Size() int {
-	return xxx_messageInfo_ClusterInspectResponse.Size(m)
+func (m *SdkClusterInspectResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkClusterInspectResponse.Size(m)
 }
-func (m *ClusterInspectResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_ClusterInspectResponse.DiscardUnknown(m)
+func (m *SdkClusterInspectResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkClusterInspectResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ClusterInspectResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkClusterInspectResponse proto.InternalMessageInfo
 
-func (m *ClusterInspectResponse) GetNode() *StorageNode {
+func (m *SdkClusterInspectResponse) GetNode() *StorageNode {
 	if m != nil {
 		return m.Node
 	}
 	return nil
 }
 
-type ClusterAlertEnumerateRequest struct {
+type SdkClusterAlertEnumerateRequest struct {
 	// Start time of alerts (required)
 	TimeStart *timestamp.Timestamp `protobuf:"bytes,1,opt,name=time_start,json=timeStart" json:"time_start,omitempty"`
 	// End time of alerts (required)
@@ -4984,52 +4984,52 @@ type ClusterAlertEnumerateRequest struct {
 	XXX_sizecache        int32        `json:"-"`
 }
 
-func (m *ClusterAlertEnumerateRequest) Reset()         { *m = ClusterAlertEnumerateRequest{} }
-func (m *ClusterAlertEnumerateRequest) String() string { return proto.CompactTextString(m) }
-func (*ClusterAlertEnumerateRequest) ProtoMessage()    {}
-func (*ClusterAlertEnumerateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{78}
+func (m *SdkClusterAlertEnumerateRequest) Reset()         { *m = SdkClusterAlertEnumerateRequest{} }
+func (m *SdkClusterAlertEnumerateRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkClusterAlertEnumerateRequest) ProtoMessage()    {}
+func (*SdkClusterAlertEnumerateRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{78}
 }
-func (m *ClusterAlertEnumerateRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ClusterAlertEnumerateRequest.Unmarshal(m, b)
+func (m *SdkClusterAlertEnumerateRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkClusterAlertEnumerateRequest.Unmarshal(m, b)
 }
-func (m *ClusterAlertEnumerateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ClusterAlertEnumerateRequest.Marshal(b, m, deterministic)
+func (m *SdkClusterAlertEnumerateRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkClusterAlertEnumerateRequest.Marshal(b, m, deterministic)
 }
-func (dst *ClusterAlertEnumerateRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ClusterAlertEnumerateRequest.Merge(dst, src)
+func (dst *SdkClusterAlertEnumerateRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkClusterAlertEnumerateRequest.Merge(dst, src)
 }
-func (m *ClusterAlertEnumerateRequest) XXX_Size() int {
-	return xxx_messageInfo_ClusterAlertEnumerateRequest.Size(m)
+func (m *SdkClusterAlertEnumerateRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkClusterAlertEnumerateRequest.Size(m)
 }
-func (m *ClusterAlertEnumerateRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_ClusterAlertEnumerateRequest.DiscardUnknown(m)
+func (m *SdkClusterAlertEnumerateRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkClusterAlertEnumerateRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ClusterAlertEnumerateRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkClusterAlertEnumerateRequest proto.InternalMessageInfo
 
-func (m *ClusterAlertEnumerateRequest) GetTimeStart() *timestamp.Timestamp {
+func (m *SdkClusterAlertEnumerateRequest) GetTimeStart() *timestamp.Timestamp {
 	if m != nil {
 		return m.TimeStart
 	}
 	return nil
 }
 
-func (m *ClusterAlertEnumerateRequest) GetTimeEnd() *timestamp.Timestamp {
+func (m *SdkClusterAlertEnumerateRequest) GetTimeEnd() *timestamp.Timestamp {
 	if m != nil {
 		return m.TimeEnd
 	}
 	return nil
 }
 
-func (m *ClusterAlertEnumerateRequest) GetResource() ResourceType {
+func (m *SdkClusterAlertEnumerateRequest) GetResource() ResourceType {
 	if m != nil {
 		return m.Resource
 	}
 	return ResourceType_RESOURCE_TYPE_NONE
 }
 
-type ClusterAlertEnumerateResponse struct {
+type SdkClusterAlertEnumerateResponse struct {
 	// Information on the alerts requested
 	Alerts               *Alerts  `protobuf:"bytes,1,opt,name=alerts" json:"alerts,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
@@ -5037,38 +5037,38 @@ type ClusterAlertEnumerateResponse struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *ClusterAlertEnumerateResponse) Reset()         { *m = ClusterAlertEnumerateResponse{} }
-func (m *ClusterAlertEnumerateResponse) String() string { return proto.CompactTextString(m) }
-func (*ClusterAlertEnumerateResponse) ProtoMessage()    {}
-func (*ClusterAlertEnumerateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{79}
+func (m *SdkClusterAlertEnumerateResponse) Reset()         { *m = SdkClusterAlertEnumerateResponse{} }
+func (m *SdkClusterAlertEnumerateResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkClusterAlertEnumerateResponse) ProtoMessage()    {}
+func (*SdkClusterAlertEnumerateResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{79}
 }
-func (m *ClusterAlertEnumerateResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ClusterAlertEnumerateResponse.Unmarshal(m, b)
+func (m *SdkClusterAlertEnumerateResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkClusterAlertEnumerateResponse.Unmarshal(m, b)
 }
-func (m *ClusterAlertEnumerateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ClusterAlertEnumerateResponse.Marshal(b, m, deterministic)
+func (m *SdkClusterAlertEnumerateResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkClusterAlertEnumerateResponse.Marshal(b, m, deterministic)
 }
-func (dst *ClusterAlertEnumerateResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ClusterAlertEnumerateResponse.Merge(dst, src)
+func (dst *SdkClusterAlertEnumerateResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkClusterAlertEnumerateResponse.Merge(dst, src)
 }
-func (m *ClusterAlertEnumerateResponse) XXX_Size() int {
-	return xxx_messageInfo_ClusterAlertEnumerateResponse.Size(m)
+func (m *SdkClusterAlertEnumerateResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkClusterAlertEnumerateResponse.Size(m)
 }
-func (m *ClusterAlertEnumerateResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_ClusterAlertEnumerateResponse.DiscardUnknown(m)
+func (m *SdkClusterAlertEnumerateResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkClusterAlertEnumerateResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ClusterAlertEnumerateResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkClusterAlertEnumerateResponse proto.InternalMessageInfo
 
-func (m *ClusterAlertEnumerateResponse) GetAlerts() *Alerts {
+func (m *SdkClusterAlertEnumerateResponse) GetAlerts() *Alerts {
 	if m != nil {
 		return m.Alerts
 	}
 	return nil
 }
 
-type ClusterAlertClearRequest struct {
+type SdkClusterAlertClearRequest struct {
 	// Type of resource (required)
 	Resource ResourceType `protobuf:"varint,1,opt,name=resource,enum=openstorage.api.ResourceType" json:"resource,omitempty"`
 	// Id of alert as returned by ClusterEnumerateAlertResponse (required)
@@ -5078,75 +5078,75 @@ type ClusterAlertClearRequest struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *ClusterAlertClearRequest) Reset()         { *m = ClusterAlertClearRequest{} }
-func (m *ClusterAlertClearRequest) String() string { return proto.CompactTextString(m) }
-func (*ClusterAlertClearRequest) ProtoMessage()    {}
-func (*ClusterAlertClearRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{80}
+func (m *SdkClusterAlertClearRequest) Reset()         { *m = SdkClusterAlertClearRequest{} }
+func (m *SdkClusterAlertClearRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkClusterAlertClearRequest) ProtoMessage()    {}
+func (*SdkClusterAlertClearRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{80}
 }
-func (m *ClusterAlertClearRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ClusterAlertClearRequest.Unmarshal(m, b)
+func (m *SdkClusterAlertClearRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkClusterAlertClearRequest.Unmarshal(m, b)
 }
-func (m *ClusterAlertClearRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ClusterAlertClearRequest.Marshal(b, m, deterministic)
+func (m *SdkClusterAlertClearRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkClusterAlertClearRequest.Marshal(b, m, deterministic)
 }
-func (dst *ClusterAlertClearRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ClusterAlertClearRequest.Merge(dst, src)
+func (dst *SdkClusterAlertClearRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkClusterAlertClearRequest.Merge(dst, src)
 }
-func (m *ClusterAlertClearRequest) XXX_Size() int {
-	return xxx_messageInfo_ClusterAlertClearRequest.Size(m)
+func (m *SdkClusterAlertClearRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkClusterAlertClearRequest.Size(m)
 }
-func (m *ClusterAlertClearRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_ClusterAlertClearRequest.DiscardUnknown(m)
+func (m *SdkClusterAlertClearRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkClusterAlertClearRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ClusterAlertClearRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkClusterAlertClearRequest proto.InternalMessageInfo
 
-func (m *ClusterAlertClearRequest) GetResource() ResourceType {
+func (m *SdkClusterAlertClearRequest) GetResource() ResourceType {
 	if m != nil {
 		return m.Resource
 	}
 	return ResourceType_RESOURCE_TYPE_NONE
 }
 
-func (m *ClusterAlertClearRequest) GetAlertId() int64 {
+func (m *SdkClusterAlertClearRequest) GetAlertId() int64 {
 	if m != nil {
 		return m.AlertId
 	}
 	return 0
 }
 
-type ClusterAlertClearResponse struct {
+type SdkClusterAlertClearResponse struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *ClusterAlertClearResponse) Reset()         { *m = ClusterAlertClearResponse{} }
-func (m *ClusterAlertClearResponse) String() string { return proto.CompactTextString(m) }
-func (*ClusterAlertClearResponse) ProtoMessage()    {}
-func (*ClusterAlertClearResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{81}
+func (m *SdkClusterAlertClearResponse) Reset()         { *m = SdkClusterAlertClearResponse{} }
+func (m *SdkClusterAlertClearResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkClusterAlertClearResponse) ProtoMessage()    {}
+func (*SdkClusterAlertClearResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{81}
 }
-func (m *ClusterAlertClearResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ClusterAlertClearResponse.Unmarshal(m, b)
+func (m *SdkClusterAlertClearResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkClusterAlertClearResponse.Unmarshal(m, b)
 }
-func (m *ClusterAlertClearResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ClusterAlertClearResponse.Marshal(b, m, deterministic)
+func (m *SdkClusterAlertClearResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkClusterAlertClearResponse.Marshal(b, m, deterministic)
 }
-func (dst *ClusterAlertClearResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ClusterAlertClearResponse.Merge(dst, src)
+func (dst *SdkClusterAlertClearResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkClusterAlertClearResponse.Merge(dst, src)
 }
-func (m *ClusterAlertClearResponse) XXX_Size() int {
-	return xxx_messageInfo_ClusterAlertClearResponse.Size(m)
+func (m *SdkClusterAlertClearResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkClusterAlertClearResponse.Size(m)
 }
-func (m *ClusterAlertClearResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_ClusterAlertClearResponse.DiscardUnknown(m)
+func (m *SdkClusterAlertClearResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkClusterAlertClearResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ClusterAlertClearResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkClusterAlertClearResponse proto.InternalMessageInfo
 
-type ClusterAlertEraseRequest struct {
+type SdkClusterAlertEraseRequest struct {
 	// Type of resource (required)
 	Resource ResourceType `protobuf:"varint,1,opt,name=resource,enum=openstorage.api.ResourceType" json:"resource,omitempty"`
 	// Id of alert as returned by ClusterEnumerateAlertResponse (required)
@@ -5156,73 +5156,73 @@ type ClusterAlertEraseRequest struct {
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *ClusterAlertEraseRequest) Reset()         { *m = ClusterAlertEraseRequest{} }
-func (m *ClusterAlertEraseRequest) String() string { return proto.CompactTextString(m) }
-func (*ClusterAlertEraseRequest) ProtoMessage()    {}
-func (*ClusterAlertEraseRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{82}
+func (m *SdkClusterAlertEraseRequest) Reset()         { *m = SdkClusterAlertEraseRequest{} }
+func (m *SdkClusterAlertEraseRequest) String() string { return proto.CompactTextString(m) }
+func (*SdkClusterAlertEraseRequest) ProtoMessage()    {}
+func (*SdkClusterAlertEraseRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{82}
 }
-func (m *ClusterAlertEraseRequest) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ClusterAlertEraseRequest.Unmarshal(m, b)
+func (m *SdkClusterAlertEraseRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkClusterAlertEraseRequest.Unmarshal(m, b)
 }
-func (m *ClusterAlertEraseRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ClusterAlertEraseRequest.Marshal(b, m, deterministic)
+func (m *SdkClusterAlertEraseRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkClusterAlertEraseRequest.Marshal(b, m, deterministic)
 }
-func (dst *ClusterAlertEraseRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ClusterAlertEraseRequest.Merge(dst, src)
+func (dst *SdkClusterAlertEraseRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkClusterAlertEraseRequest.Merge(dst, src)
 }
-func (m *ClusterAlertEraseRequest) XXX_Size() int {
-	return xxx_messageInfo_ClusterAlertEraseRequest.Size(m)
+func (m *SdkClusterAlertEraseRequest) XXX_Size() int {
+	return xxx_messageInfo_SdkClusterAlertEraseRequest.Size(m)
 }
-func (m *ClusterAlertEraseRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_ClusterAlertEraseRequest.DiscardUnknown(m)
+func (m *SdkClusterAlertEraseRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkClusterAlertEraseRequest.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ClusterAlertEraseRequest proto.InternalMessageInfo
+var xxx_messageInfo_SdkClusterAlertEraseRequest proto.InternalMessageInfo
 
-func (m *ClusterAlertEraseRequest) GetResource() ResourceType {
+func (m *SdkClusterAlertEraseRequest) GetResource() ResourceType {
 	if m != nil {
 		return m.Resource
 	}
 	return ResourceType_RESOURCE_TYPE_NONE
 }
 
-func (m *ClusterAlertEraseRequest) GetAlertId() int64 {
+func (m *SdkClusterAlertEraseRequest) GetAlertId() int64 {
 	if m != nil {
 		return m.AlertId
 	}
 	return 0
 }
 
-type ClusterAlertEraseResponse struct {
+type SdkClusterAlertEraseResponse struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *ClusterAlertEraseResponse) Reset()         { *m = ClusterAlertEraseResponse{} }
-func (m *ClusterAlertEraseResponse) String() string { return proto.CompactTextString(m) }
-func (*ClusterAlertEraseResponse) ProtoMessage()    {}
-func (*ClusterAlertEraseResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_045a0b9d887bb59a, []int{83}
+func (m *SdkClusterAlertEraseResponse) Reset()         { *m = SdkClusterAlertEraseResponse{} }
+func (m *SdkClusterAlertEraseResponse) String() string { return proto.CompactTextString(m) }
+func (*SdkClusterAlertEraseResponse) ProtoMessage()    {}
+func (*SdkClusterAlertEraseResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_api_ac37319a59d075f7, []int{83}
 }
-func (m *ClusterAlertEraseResponse) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_ClusterAlertEraseResponse.Unmarshal(m, b)
+func (m *SdkClusterAlertEraseResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SdkClusterAlertEraseResponse.Unmarshal(m, b)
 }
-func (m *ClusterAlertEraseResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_ClusterAlertEraseResponse.Marshal(b, m, deterministic)
+func (m *SdkClusterAlertEraseResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SdkClusterAlertEraseResponse.Marshal(b, m, deterministic)
 }
-func (dst *ClusterAlertEraseResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_ClusterAlertEraseResponse.Merge(dst, src)
+func (dst *SdkClusterAlertEraseResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SdkClusterAlertEraseResponse.Merge(dst, src)
 }
-func (m *ClusterAlertEraseResponse) XXX_Size() int {
-	return xxx_messageInfo_ClusterAlertEraseResponse.Size(m)
+func (m *SdkClusterAlertEraseResponse) XXX_Size() int {
+	return xxx_messageInfo_SdkClusterAlertEraseResponse.Size(m)
 }
-func (m *ClusterAlertEraseResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_ClusterAlertEraseResponse.DiscardUnknown(m)
+func (m *SdkClusterAlertEraseResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SdkClusterAlertEraseResponse.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_ClusterAlertEraseResponse proto.InternalMessageInfo
+var xxx_messageInfo_SdkClusterAlertEraseResponse proto.InternalMessageInfo
 
 func init() {
 	proto.RegisterType((*StorageResource)(nil), "openstorage.api.StorageResource")
@@ -5267,64 +5267,64 @@ func init() {
 	proto.RegisterMapType((map[string]*StorageResource)(nil), "openstorage.api.StorageNode.DisksEntry")
 	proto.RegisterMapType((map[string]string)(nil), "openstorage.api.StorageNode.NodeLabelsEntry")
 	proto.RegisterType((*StorageCluster)(nil), "openstorage.api.StorageCluster")
-	proto.RegisterType((*CredentialCreateAzureRequest)(nil), "openstorage.api.CredentialCreateAzureRequest")
-	proto.RegisterType((*CredentialCreateAzureResponse)(nil), "openstorage.api.CredentialCreateAzureResponse")
-	proto.RegisterType((*CredentialCreateGoogleRequest)(nil), "openstorage.api.CredentialCreateGoogleRequest")
-	proto.RegisterType((*CredentialCreateGoogleResponse)(nil), "openstorage.api.CredentialCreateGoogleResponse")
-	proto.RegisterType((*CredentialCreateAWSRequest)(nil), "openstorage.api.CredentialCreateAWSRequest")
-	proto.RegisterType((*CredentialCreateAWSResponse)(nil), "openstorage.api.CredentialCreateAWSResponse")
+	proto.RegisterType((*SdkCredentialCreateAzureRequest)(nil), "openstorage.api.SdkCredentialCreateAzureRequest")
+	proto.RegisterType((*SdkCredentialCreateAzureResponse)(nil), "openstorage.api.SdkCredentialCreateAzureResponse")
+	proto.RegisterType((*SdkCredentialCreateGoogleRequest)(nil), "openstorage.api.SdkCredentialCreateGoogleRequest")
+	proto.RegisterType((*SdkCredentialCreateGoogleResponse)(nil), "openstorage.api.SdkCredentialCreateGoogleResponse")
+	proto.RegisterType((*SdkCredentialCreateAWSRequest)(nil), "openstorage.api.SdkCredentialCreateAWSRequest")
+	proto.RegisterType((*SdkCredentialCreateAWSResponse)(nil), "openstorage.api.SdkCredentialCreateAWSResponse")
 	proto.RegisterType((*S3Credential)(nil), "openstorage.api.S3Credential")
 	proto.RegisterType((*AzureCredential)(nil), "openstorage.api.AzureCredential")
 	proto.RegisterType((*GoogleCredential)(nil), "openstorage.api.GoogleCredential")
-	proto.RegisterType((*CredentialEnumerateAWSRequest)(nil), "openstorage.api.CredentialEnumerateAWSRequest")
-	proto.RegisterType((*CredentialEnumerateAWSResponse)(nil), "openstorage.api.CredentialEnumerateAWSResponse")
-	proto.RegisterType((*CredentialEnumerateAzureRequest)(nil), "openstorage.api.CredentialEnumerateAzureRequest")
-	proto.RegisterType((*CredentialEnumerateAzureResponse)(nil), "openstorage.api.CredentialEnumerateAzureResponse")
-	proto.RegisterType((*CredentialEnumerateGoogleRequest)(nil), "openstorage.api.CredentialEnumerateGoogleRequest")
-	proto.RegisterType((*CredentialEnumerateGoogleResponse)(nil), "openstorage.api.CredentialEnumerateGoogleResponse")
-	proto.RegisterType((*CredentialDeleteRequest)(nil), "openstorage.api.CredentialDeleteRequest")
-	proto.RegisterType((*CredentialDeleteResponse)(nil), "openstorage.api.CredentialDeleteResponse")
-	proto.RegisterType((*CredentialValidateRequest)(nil), "openstorage.api.CredentialValidateRequest")
-	proto.RegisterType((*CredentialValidateResponse)(nil), "openstorage.api.CredentialValidateResponse")
-	proto.RegisterType((*VolumeMountRequest)(nil), "openstorage.api.VolumeMountRequest")
-	proto.RegisterMapType((map[string]string)(nil), "openstorage.api.VolumeMountRequest.OptionsEntry")
-	proto.RegisterType((*VolumeMountResponse)(nil), "openstorage.api.VolumeMountResponse")
-	proto.RegisterType((*VolumeUnmountRequest)(nil), "openstorage.api.VolumeUnmountRequest")
-	proto.RegisterMapType((map[string]string)(nil), "openstorage.api.VolumeUnmountRequest.OptionsEntry")
-	proto.RegisterType((*VolumeUnmountResponse)(nil), "openstorage.api.VolumeUnmountResponse")
-	proto.RegisterType((*VolumeAttachRequest)(nil), "openstorage.api.VolumeAttachRequest")
-	proto.RegisterMapType((map[string]string)(nil), "openstorage.api.VolumeAttachRequest.OptionsEntry")
-	proto.RegisterType((*VolumeAttachResponse)(nil), "openstorage.api.VolumeAttachResponse")
-	proto.RegisterType((*VolumeDetachRequest)(nil), "openstorage.api.VolumeDetachRequest")
-	proto.RegisterType((*VolumeDetachResponse)(nil), "openstorage.api.VolumeDetachResponse")
-	proto.RegisterType((*OpenStorageVolumeCreateRequest)(nil), "openstorage.api.OpenStorageVolumeCreateRequest")
-	proto.RegisterType((*OpenStorageVolumeCreateResponse)(nil), "openstorage.api.OpenStorageVolumeCreateResponse")
-	proto.RegisterType((*VolumeCreateFromVolumeIDRequest)(nil), "openstorage.api.VolumeCreateFromVolumeIDRequest")
-	proto.RegisterType((*VolumeCreateFromVolumeIDResponse)(nil), "openstorage.api.VolumeCreateFromVolumeIDResponse")
-	proto.RegisterType((*VolumeDeleteRequest)(nil), "openstorage.api.VolumeDeleteRequest")
-	proto.RegisterType((*VolumeDeleteResponse)(nil), "openstorage.api.VolumeDeleteResponse")
-	proto.RegisterType((*VolumeInspectRequest)(nil), "openstorage.api.VolumeInspectRequest")
-	proto.RegisterType((*VolumeInspectResponse)(nil), "openstorage.api.VolumeInspectResponse")
-	proto.RegisterType((*VolumeEnumerateRequest)(nil), "openstorage.api.VolumeEnumerateRequest")
-	proto.RegisterType((*VolumeEnumerateResponse)(nil), "openstorage.api.VolumeEnumerateResponse")
-	proto.RegisterType((*VolumeSnapshotCreateRequest)(nil), "openstorage.api.VolumeSnapshotCreateRequest")
-	proto.RegisterMapType((map[string]string)(nil), "openstorage.api.VolumeSnapshotCreateRequest.LabelsEntry")
-	proto.RegisterType((*VolumeSnapshotCreateResponse)(nil), "openstorage.api.VolumeSnapshotCreateResponse")
-	proto.RegisterType((*VolumeSnapshotRestoreRequest)(nil), "openstorage.api.VolumeSnapshotRestoreRequest")
-	proto.RegisterType((*VolumeSnapshotRestoreResponse)(nil), "openstorage.api.VolumeSnapshotRestoreResponse")
-	proto.RegisterType((*VolumeSnapshotEnumerateRequest)(nil), "openstorage.api.VolumeSnapshotEnumerateRequest")
-	proto.RegisterMapType((map[string]string)(nil), "openstorage.api.VolumeSnapshotEnumerateRequest.LabelsEntry")
-	proto.RegisterType((*VolumeSnapshotEnumerateResponse)(nil), "openstorage.api.VolumeSnapshotEnumerateResponse")
-	proto.RegisterType((*ClusterEnumerateRequest)(nil), "openstorage.api.ClusterEnumerateRequest")
-	proto.RegisterType((*ClusterEnumerateResponse)(nil), "openstorage.api.ClusterEnumerateResponse")
-	proto.RegisterType((*ClusterInspectRequest)(nil), "openstorage.api.ClusterInspectRequest")
-	proto.RegisterType((*ClusterInspectResponse)(nil), "openstorage.api.ClusterInspectResponse")
-	proto.RegisterType((*ClusterAlertEnumerateRequest)(nil), "openstorage.api.ClusterAlertEnumerateRequest")
-	proto.RegisterType((*ClusterAlertEnumerateResponse)(nil), "openstorage.api.ClusterAlertEnumerateResponse")
-	proto.RegisterType((*ClusterAlertClearRequest)(nil), "openstorage.api.ClusterAlertClearRequest")
-	proto.RegisterType((*ClusterAlertClearResponse)(nil), "openstorage.api.ClusterAlertClearResponse")
-	proto.RegisterType((*ClusterAlertEraseRequest)(nil), "openstorage.api.ClusterAlertEraseRequest")
-	proto.RegisterType((*ClusterAlertEraseResponse)(nil), "openstorage.api.ClusterAlertEraseResponse")
+	proto.RegisterType((*SdkCredentialEnumerateAWSRequest)(nil), "openstorage.api.SdkCredentialEnumerateAWSRequest")
+	proto.RegisterType((*SdkCredentialEnumerateAWSResponse)(nil), "openstorage.api.SdkCredentialEnumerateAWSResponse")
+	proto.RegisterType((*SdkCredentialEnumerateAzureRequest)(nil), "openstorage.api.SdkCredentialEnumerateAzureRequest")
+	proto.RegisterType((*SdkCredentialEnumerateAzureResponse)(nil), "openstorage.api.SdkCredentialEnumerateAzureResponse")
+	proto.RegisterType((*SdkCredentialEnumerateGoogleRequest)(nil), "openstorage.api.SdkCredentialEnumerateGoogleRequest")
+	proto.RegisterType((*SdkCredentialEnumerateGoogleResponse)(nil), "openstorage.api.SdkCredentialEnumerateGoogleResponse")
+	proto.RegisterType((*SdkCredentialDeleteRequest)(nil), "openstorage.api.SdkCredentialDeleteRequest")
+	proto.RegisterType((*SdkCredentialDeleteResponse)(nil), "openstorage.api.SdkCredentialDeleteResponse")
+	proto.RegisterType((*SdkCredentialValidateRequest)(nil), "openstorage.api.SdkCredentialValidateRequest")
+	proto.RegisterType((*SdkCredentialValidateResponse)(nil), "openstorage.api.SdkCredentialValidateResponse")
+	proto.RegisterType((*SdkVolumeMountRequest)(nil), "openstorage.api.SdkVolumeMountRequest")
+	proto.RegisterMapType((map[string]string)(nil), "openstorage.api.SdkVolumeMountRequest.OptionsEntry")
+	proto.RegisterType((*SdkVolumeMountResponse)(nil), "openstorage.api.SdkVolumeMountResponse")
+	proto.RegisterType((*SdkVolumeUnmountRequest)(nil), "openstorage.api.SdkVolumeUnmountRequest")
+	proto.RegisterMapType((map[string]string)(nil), "openstorage.api.SdkVolumeUnmountRequest.OptionsEntry")
+	proto.RegisterType((*SdkVolumeUnmountResponse)(nil), "openstorage.api.SdkVolumeUnmountResponse")
+	proto.RegisterType((*SdkVolumeAttachRequest)(nil), "openstorage.api.SdkVolumeAttachRequest")
+	proto.RegisterMapType((map[string]string)(nil), "openstorage.api.SdkVolumeAttachRequest.OptionsEntry")
+	proto.RegisterType((*SdkVolumeAttachResponse)(nil), "openstorage.api.SdkVolumeAttachResponse")
+	proto.RegisterType((*SdkVolumeDetachRequest)(nil), "openstorage.api.SdkVolumeDetachRequest")
+	proto.RegisterType((*SdkVolumeDetachResponse)(nil), "openstorage.api.SdkVolumeDetachResponse")
+	proto.RegisterType((*SdkVolumeCreateRequest)(nil), "openstorage.api.SdkVolumeCreateRequest")
+	proto.RegisterType((*SdkVolumeCreateResponse)(nil), "openstorage.api.SdkVolumeCreateResponse")
+	proto.RegisterType((*SdkVolumeCreateFromVolumeIdRequest)(nil), "openstorage.api.SdkVolumeCreateFromVolumeIdRequest")
+	proto.RegisterType((*SdkVolumeCreateFromVolumeIdResponse)(nil), "openstorage.api.SdkVolumeCreateFromVolumeIdResponse")
+	proto.RegisterType((*SdkVolumeDeleteRequest)(nil), "openstorage.api.SdkVolumeDeleteRequest")
+	proto.RegisterType((*SdkVolumeDeleteResponse)(nil), "openstorage.api.SdkVolumeDeleteResponse")
+	proto.RegisterType((*SdkVolumeInspectRequest)(nil), "openstorage.api.SdkVolumeInspectRequest")
+	proto.RegisterType((*SdkVolumeInspectResponse)(nil), "openstorage.api.SdkVolumeInspectResponse")
+	proto.RegisterType((*SdkVolumeEnumerateRequest)(nil), "openstorage.api.SdkVolumeEnumerateRequest")
+	proto.RegisterType((*SdkVolumeEnumerateResponse)(nil), "openstorage.api.SdkVolumeEnumerateResponse")
+	proto.RegisterType((*SdkVolumeSnapshotCreateRequest)(nil), "openstorage.api.SdkVolumeSnapshotCreateRequest")
+	proto.RegisterMapType((map[string]string)(nil), "openstorage.api.SdkVolumeSnapshotCreateRequest.LabelsEntry")
+	proto.RegisterType((*SdkVolumeSnapshotCreateResponse)(nil), "openstorage.api.SdkVolumeSnapshotCreateResponse")
+	proto.RegisterType((*SdkVolumeSnapshotRestoreRequest)(nil), "openstorage.api.SdkVolumeSnapshotRestoreRequest")
+	proto.RegisterType((*SdkVolumeSnapshotRestoreResponse)(nil), "openstorage.api.SdkVolumeSnapshotRestoreResponse")
+	proto.RegisterType((*SdkVolumeSnapshotEnumerateRequest)(nil), "openstorage.api.SdkVolumeSnapshotEnumerateRequest")
+	proto.RegisterMapType((map[string]string)(nil), "openstorage.api.SdkVolumeSnapshotEnumerateRequest.LabelsEntry")
+	proto.RegisterType((*SdkVolumeSnapshotEnumerateResponse)(nil), "openstorage.api.SdkVolumeSnapshotEnumerateResponse")
+	proto.RegisterType((*SdkClusterEnumerateRequest)(nil), "openstorage.api.SdkClusterEnumerateRequest")
+	proto.RegisterType((*SdkClusterEnumerateResponse)(nil), "openstorage.api.SdkClusterEnumerateResponse")
+	proto.RegisterType((*SdkClusterInspectRequest)(nil), "openstorage.api.SdkClusterInspectRequest")
+	proto.RegisterType((*SdkClusterInspectResponse)(nil), "openstorage.api.SdkClusterInspectResponse")
+	proto.RegisterType((*SdkClusterAlertEnumerateRequest)(nil), "openstorage.api.SdkClusterAlertEnumerateRequest")
+	proto.RegisterType((*SdkClusterAlertEnumerateResponse)(nil), "openstorage.api.SdkClusterAlertEnumerateResponse")
+	proto.RegisterType((*SdkClusterAlertClearRequest)(nil), "openstorage.api.SdkClusterAlertClearRequest")
+	proto.RegisterType((*SdkClusterAlertClearResponse)(nil), "openstorage.api.SdkClusterAlertClearResponse")
+	proto.RegisterType((*SdkClusterAlertEraseRequest)(nil), "openstorage.api.SdkClusterAlertEraseRequest")
+	proto.RegisterType((*SdkClusterAlertEraseResponse)(nil), "openstorage.api.SdkClusterAlertEraseResponse")
 	proto.RegisterEnum("openstorage.api.Status", Status_name, Status_value)
 	proto.RegisterEnum("openstorage.api.DriverType", DriverType_name, DriverType_value)
 	proto.RegisterEnum("openstorage.api.FSType", FSType_name, FSType_value)
@@ -5351,20 +5351,19 @@ var _ grpc.ClientConn
 // is compatible with the grpc package it is being compiled against.
 const _ = grpc.SupportPackageIsVersion4
 
-// OpenStorageClusterClient is the client API for OpenStorageCluster service.
-//
-// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+// Client API for OpenStorageCluster service
+
 type OpenStorageClusterClient interface {
 	// Enumerate lists all the nodes in the cluster.
-	Enumerate(ctx context.Context, in *ClusterEnumerateRequest, opts ...grpc.CallOption) (*ClusterEnumerateResponse, error)
+	Enumerate(ctx context.Context, in *SdkClusterEnumerateRequest, opts ...grpc.CallOption) (*SdkClusterEnumerateResponse, error)
 	// Inspect the node given a UUID.
-	Inspect(ctx context.Context, in *ClusterInspectRequest, opts ...grpc.CallOption) (*ClusterInspectResponse, error)
+	Inspect(ctx context.Context, in *SdkClusterInspectRequest, opts ...grpc.CallOption) (*SdkClusterInspectResponse, error)
 	// Get a list of alerts from the storage cluster
-	AlertEnumerate(ctx context.Context, in *ClusterAlertEnumerateRequest, opts ...grpc.CallOption) (*ClusterAlertEnumerateResponse, error)
+	AlertEnumerate(ctx context.Context, in *SdkClusterAlertEnumerateRequest, opts ...grpc.CallOption) (*SdkClusterAlertEnumerateResponse, error)
 	// Clear the alert for a given resource
-	AlertClear(ctx context.Context, in *ClusterAlertClearRequest, opts ...grpc.CallOption) (*ClusterAlertClearResponse, error)
+	AlertClear(ctx context.Context, in *SdkClusterAlertClearRequest, opts ...grpc.CallOption) (*SdkClusterAlertClearResponse, error)
 	// Erases an alert for a given resource
-	AlertErase(ctx context.Context, in *ClusterAlertEraseRequest, opts ...grpc.CallOption) (*ClusterAlertEraseResponse, error)
+	AlertErase(ctx context.Context, in *SdkClusterAlertEraseRequest, opts ...grpc.CallOption) (*SdkClusterAlertEraseResponse, error)
 }
 
 type openStorageClusterClient struct {
@@ -5375,63 +5374,64 @@ func NewOpenStorageClusterClient(cc *grpc.ClientConn) OpenStorageClusterClient {
 	return &openStorageClusterClient{cc}
 }
 
-func (c *openStorageClusterClient) Enumerate(ctx context.Context, in *ClusterEnumerateRequest, opts ...grpc.CallOption) (*ClusterEnumerateResponse, error) {
-	out := new(ClusterEnumerateResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageCluster/Enumerate", in, out, opts...)
+func (c *openStorageClusterClient) Enumerate(ctx context.Context, in *SdkClusterEnumerateRequest, opts ...grpc.CallOption) (*SdkClusterEnumerateResponse, error) {
+	out := new(SdkClusterEnumerateResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageCluster/Enumerate", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageClusterClient) Inspect(ctx context.Context, in *ClusterInspectRequest, opts ...grpc.CallOption) (*ClusterInspectResponse, error) {
-	out := new(ClusterInspectResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageCluster/Inspect", in, out, opts...)
+func (c *openStorageClusterClient) Inspect(ctx context.Context, in *SdkClusterInspectRequest, opts ...grpc.CallOption) (*SdkClusterInspectResponse, error) {
+	out := new(SdkClusterInspectResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageCluster/Inspect", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageClusterClient) AlertEnumerate(ctx context.Context, in *ClusterAlertEnumerateRequest, opts ...grpc.CallOption) (*ClusterAlertEnumerateResponse, error) {
-	out := new(ClusterAlertEnumerateResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageCluster/AlertEnumerate", in, out, opts...)
+func (c *openStorageClusterClient) AlertEnumerate(ctx context.Context, in *SdkClusterAlertEnumerateRequest, opts ...grpc.CallOption) (*SdkClusterAlertEnumerateResponse, error) {
+	out := new(SdkClusterAlertEnumerateResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageCluster/AlertEnumerate", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageClusterClient) AlertClear(ctx context.Context, in *ClusterAlertClearRequest, opts ...grpc.CallOption) (*ClusterAlertClearResponse, error) {
-	out := new(ClusterAlertClearResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageCluster/AlertClear", in, out, opts...)
+func (c *openStorageClusterClient) AlertClear(ctx context.Context, in *SdkClusterAlertClearRequest, opts ...grpc.CallOption) (*SdkClusterAlertClearResponse, error) {
+	out := new(SdkClusterAlertClearResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageCluster/AlertClear", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageClusterClient) AlertErase(ctx context.Context, in *ClusterAlertEraseRequest, opts ...grpc.CallOption) (*ClusterAlertEraseResponse, error) {
-	out := new(ClusterAlertEraseResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageCluster/AlertErase", in, out, opts...)
+func (c *openStorageClusterClient) AlertErase(ctx context.Context, in *SdkClusterAlertEraseRequest, opts ...grpc.CallOption) (*SdkClusterAlertEraseResponse, error) {
+	out := new(SdkClusterAlertEraseResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageCluster/AlertErase", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-// OpenStorageClusterServer is the server API for OpenStorageCluster service.
+// Server API for OpenStorageCluster service
+
 type OpenStorageClusterServer interface {
 	// Enumerate lists all the nodes in the cluster.
-	Enumerate(context.Context, *ClusterEnumerateRequest) (*ClusterEnumerateResponse, error)
+	Enumerate(context.Context, *SdkClusterEnumerateRequest) (*SdkClusterEnumerateResponse, error)
 	// Inspect the node given a UUID.
-	Inspect(context.Context, *ClusterInspectRequest) (*ClusterInspectResponse, error)
+	Inspect(context.Context, *SdkClusterInspectRequest) (*SdkClusterInspectResponse, error)
 	// Get a list of alerts from the storage cluster
-	AlertEnumerate(context.Context, *ClusterAlertEnumerateRequest) (*ClusterAlertEnumerateResponse, error)
+	AlertEnumerate(context.Context, *SdkClusterAlertEnumerateRequest) (*SdkClusterAlertEnumerateResponse, error)
 	// Clear the alert for a given resource
-	AlertClear(context.Context, *ClusterAlertClearRequest) (*ClusterAlertClearResponse, error)
+	AlertClear(context.Context, *SdkClusterAlertClearRequest) (*SdkClusterAlertClearResponse, error)
 	// Erases an alert for a given resource
-	AlertErase(context.Context, *ClusterAlertEraseRequest) (*ClusterAlertEraseResponse, error)
+	AlertErase(context.Context, *SdkClusterAlertEraseRequest) (*SdkClusterAlertEraseResponse, error)
 }
 
 func RegisterOpenStorageClusterServer(s *grpc.Server, srv OpenStorageClusterServer) {
@@ -5439,7 +5439,7 @@ func RegisterOpenStorageClusterServer(s *grpc.Server, srv OpenStorageClusterServ
 }
 
 func _OpenStorageCluster_Enumerate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ClusterEnumerateRequest)
+	in := new(SdkClusterEnumerateRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -5451,13 +5451,13 @@ func _OpenStorageCluster_Enumerate_Handler(srv interface{}, ctx context.Context,
 		FullMethod: "/openstorage.api.OpenStorageCluster/Enumerate",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageClusterServer).Enumerate(ctx, req.(*ClusterEnumerateRequest))
+		return srv.(OpenStorageClusterServer).Enumerate(ctx, req.(*SdkClusterEnumerateRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageCluster_Inspect_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ClusterInspectRequest)
+	in := new(SdkClusterInspectRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -5469,13 +5469,13 @@ func _OpenStorageCluster_Inspect_Handler(srv interface{}, ctx context.Context, d
 		FullMethod: "/openstorage.api.OpenStorageCluster/Inspect",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageClusterServer).Inspect(ctx, req.(*ClusterInspectRequest))
+		return srv.(OpenStorageClusterServer).Inspect(ctx, req.(*SdkClusterInspectRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageCluster_AlertEnumerate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ClusterAlertEnumerateRequest)
+	in := new(SdkClusterAlertEnumerateRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -5487,13 +5487,13 @@ func _OpenStorageCluster_AlertEnumerate_Handler(srv interface{}, ctx context.Con
 		FullMethod: "/openstorage.api.OpenStorageCluster/AlertEnumerate",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageClusterServer).AlertEnumerate(ctx, req.(*ClusterAlertEnumerateRequest))
+		return srv.(OpenStorageClusterServer).AlertEnumerate(ctx, req.(*SdkClusterAlertEnumerateRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageCluster_AlertClear_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ClusterAlertClearRequest)
+	in := new(SdkClusterAlertClearRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -5505,13 +5505,13 @@ func _OpenStorageCluster_AlertClear_Handler(srv interface{}, ctx context.Context
 		FullMethod: "/openstorage.api.OpenStorageCluster/AlertClear",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageClusterServer).AlertClear(ctx, req.(*ClusterAlertClearRequest))
+		return srv.(OpenStorageClusterServer).AlertClear(ctx, req.(*SdkClusterAlertClearRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageCluster_AlertErase_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(ClusterAlertEraseRequest)
+	in := new(SdkClusterAlertEraseRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -5523,7 +5523,7 @@ func _OpenStorageCluster_AlertErase_Handler(srv interface{}, ctx context.Context
 		FullMethod: "/openstorage.api.OpenStorageCluster/AlertErase",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageClusterServer).AlertErase(ctx, req.(*ClusterAlertEraseRequest))
+		return srv.(OpenStorageClusterServer).AlertErase(ctx, req.(*SdkClusterAlertEraseRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -5557,35 +5557,34 @@ var _OpenStorageCluster_serviceDesc = grpc.ServiceDesc{
 	Metadata: "api/api.proto",
 }
 
-// OpenStorageVolumeClient is the client API for OpenStorageVolume service.
-//
-// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+// Client API for OpenStorageVolume service
+
 type OpenStorageVolumeClient interface {
 	// Creates a new volume
-	Create(ctx context.Context, in *OpenStorageVolumeCreateRequest, opts ...grpc.CallOption) (*OpenStorageVolumeCreateResponse, error)
-	// CreateFromVolumeID creates a new volume cloned from an existing volume
-	CreateFromVolumeID(ctx context.Context, in *VolumeCreateFromVolumeIDRequest, opts ...grpc.CallOption) (*VolumeCreateFromVolumeIDResponse, error)
+	Create(ctx context.Context, in *SdkVolumeCreateRequest, opts ...grpc.CallOption) (*SdkVolumeCreateResponse, error)
+	// CreateFromVolumeId creates a new volume cloned from an existing volume
+	CreateFromVolumeId(ctx context.Context, in *SdkVolumeCreateFromVolumeIdRequest, opts ...grpc.CallOption) (*SdkVolumeCreateFromVolumeIdResponse, error)
 	// Delete a volume
-	Delete(ctx context.Context, in *VolumeDeleteRequest, opts ...grpc.CallOption) (*VolumeDeleteResponse, error)
+	Delete(ctx context.Context, in *SdkVolumeDeleteRequest, opts ...grpc.CallOption) (*SdkVolumeDeleteResponse, error)
 	// Get information on a volume
-	Inspect(ctx context.Context, in *VolumeInspectRequest, opts ...grpc.CallOption) (*VolumeInspectResponse, error)
+	Inspect(ctx context.Context, in *SdkVolumeInspectRequest, opts ...grpc.CallOption) (*SdkVolumeInspectResponse, error)
 	// Get a list of volumes
-	Enumerate(ctx context.Context, in *VolumeEnumerateRequest, opts ...grpc.CallOption) (*VolumeEnumerateResponse, error)
+	Enumerate(ctx context.Context, in *SdkVolumeEnumerateRequest, opts ...grpc.CallOption) (*SdkVolumeEnumerateResponse, error)
 	// Create a snapshot of a volume. This creates an immutable (read-only),
 	// point-in-time snapshot of a volume.
-	SnapshotCreate(ctx context.Context, in *VolumeSnapshotCreateRequest, opts ...grpc.CallOption) (*VolumeSnapshotCreateResponse, error)
+	SnapshotCreate(ctx context.Context, in *SdkVolumeSnapshotCreateRequest, opts ...grpc.CallOption) (*SdkVolumeSnapshotCreateResponse, error)
 	// Restores a volume to a specified snapshot
-	SnapshotRestore(ctx context.Context, in *VolumeSnapshotRestoreRequest, opts ...grpc.CallOption) (*VolumeSnapshotRestoreResponse, error)
+	SnapshotRestore(ctx context.Context, in *SdkVolumeSnapshotRestoreRequest, opts ...grpc.CallOption) (*SdkVolumeSnapshotRestoreResponse, error)
 	// List the number of snapshots for a specific volume
-	SnapshotEnumerate(ctx context.Context, in *VolumeSnapshotEnumerateRequest, opts ...grpc.CallOption) (*VolumeSnapshotEnumerateResponse, error)
+	SnapshotEnumerate(ctx context.Context, in *SdkVolumeSnapshotEnumerateRequest, opts ...grpc.CallOption) (*SdkVolumeSnapshotEnumerateResponse, error)
 	// Attach device to host
-	Attach(ctx context.Context, in *VolumeAttachRequest, opts ...grpc.CallOption) (*VolumeAttachResponse, error)
+	Attach(ctx context.Context, in *SdkVolumeAttachRequest, opts ...grpc.CallOption) (*SdkVolumeAttachResponse, error)
 	// Detaches the volume from the node.
-	Detach(ctx context.Context, in *VolumeDetachRequest, opts ...grpc.CallOption) (*VolumeDetachResponse, error)
+	Detach(ctx context.Context, in *SdkVolumeDetachRequest, opts ...grpc.CallOption) (*SdkVolumeDetachResponse, error)
 	// Attaches the volume to a node.
-	Mount(ctx context.Context, in *VolumeMountRequest, opts ...grpc.CallOption) (*VolumeMountResponse, error)
+	Mount(ctx context.Context, in *SdkVolumeMountRequest, opts ...grpc.CallOption) (*SdkVolumeMountResponse, error)
 	// Unmount volume at specified path
-	Unmount(ctx context.Context, in *VolumeUnmountRequest, opts ...grpc.CallOption) (*VolumeUnmountResponse, error)
+	Unmount(ctx context.Context, in *SdkVolumeUnmountRequest, opts ...grpc.CallOption) (*SdkVolumeUnmountResponse, error)
 }
 
 type openStorageVolumeClient struct {
@@ -5596,141 +5595,142 @@ func NewOpenStorageVolumeClient(cc *grpc.ClientConn) OpenStorageVolumeClient {
 	return &openStorageVolumeClient{cc}
 }
 
-func (c *openStorageVolumeClient) Create(ctx context.Context, in *OpenStorageVolumeCreateRequest, opts ...grpc.CallOption) (*OpenStorageVolumeCreateResponse, error) {
-	out := new(OpenStorageVolumeCreateResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/Create", in, out, opts...)
+func (c *openStorageVolumeClient) Create(ctx context.Context, in *SdkVolumeCreateRequest, opts ...grpc.CallOption) (*SdkVolumeCreateResponse, error) {
+	out := new(SdkVolumeCreateResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/Create", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageVolumeClient) CreateFromVolumeID(ctx context.Context, in *VolumeCreateFromVolumeIDRequest, opts ...grpc.CallOption) (*VolumeCreateFromVolumeIDResponse, error) {
-	out := new(VolumeCreateFromVolumeIDResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/CreateFromVolumeID", in, out, opts...)
+func (c *openStorageVolumeClient) CreateFromVolumeId(ctx context.Context, in *SdkVolumeCreateFromVolumeIdRequest, opts ...grpc.CallOption) (*SdkVolumeCreateFromVolumeIdResponse, error) {
+	out := new(SdkVolumeCreateFromVolumeIdResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/CreateFromVolumeId", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageVolumeClient) Delete(ctx context.Context, in *VolumeDeleteRequest, opts ...grpc.CallOption) (*VolumeDeleteResponse, error) {
-	out := new(VolumeDeleteResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/Delete", in, out, opts...)
+func (c *openStorageVolumeClient) Delete(ctx context.Context, in *SdkVolumeDeleteRequest, opts ...grpc.CallOption) (*SdkVolumeDeleteResponse, error) {
+	out := new(SdkVolumeDeleteResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/Delete", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageVolumeClient) Inspect(ctx context.Context, in *VolumeInspectRequest, opts ...grpc.CallOption) (*VolumeInspectResponse, error) {
-	out := new(VolumeInspectResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/Inspect", in, out, opts...)
+func (c *openStorageVolumeClient) Inspect(ctx context.Context, in *SdkVolumeInspectRequest, opts ...grpc.CallOption) (*SdkVolumeInspectResponse, error) {
+	out := new(SdkVolumeInspectResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/Inspect", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageVolumeClient) Enumerate(ctx context.Context, in *VolumeEnumerateRequest, opts ...grpc.CallOption) (*VolumeEnumerateResponse, error) {
-	out := new(VolumeEnumerateResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/Enumerate", in, out, opts...)
+func (c *openStorageVolumeClient) Enumerate(ctx context.Context, in *SdkVolumeEnumerateRequest, opts ...grpc.CallOption) (*SdkVolumeEnumerateResponse, error) {
+	out := new(SdkVolumeEnumerateResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/Enumerate", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageVolumeClient) SnapshotCreate(ctx context.Context, in *VolumeSnapshotCreateRequest, opts ...grpc.CallOption) (*VolumeSnapshotCreateResponse, error) {
-	out := new(VolumeSnapshotCreateResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/SnapshotCreate", in, out, opts...)
+func (c *openStorageVolumeClient) SnapshotCreate(ctx context.Context, in *SdkVolumeSnapshotCreateRequest, opts ...grpc.CallOption) (*SdkVolumeSnapshotCreateResponse, error) {
+	out := new(SdkVolumeSnapshotCreateResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/SnapshotCreate", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageVolumeClient) SnapshotRestore(ctx context.Context, in *VolumeSnapshotRestoreRequest, opts ...grpc.CallOption) (*VolumeSnapshotRestoreResponse, error) {
-	out := new(VolumeSnapshotRestoreResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/SnapshotRestore", in, out, opts...)
+func (c *openStorageVolumeClient) SnapshotRestore(ctx context.Context, in *SdkVolumeSnapshotRestoreRequest, opts ...grpc.CallOption) (*SdkVolumeSnapshotRestoreResponse, error) {
+	out := new(SdkVolumeSnapshotRestoreResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/SnapshotRestore", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageVolumeClient) SnapshotEnumerate(ctx context.Context, in *VolumeSnapshotEnumerateRequest, opts ...grpc.CallOption) (*VolumeSnapshotEnumerateResponse, error) {
-	out := new(VolumeSnapshotEnumerateResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/SnapshotEnumerate", in, out, opts...)
+func (c *openStorageVolumeClient) SnapshotEnumerate(ctx context.Context, in *SdkVolumeSnapshotEnumerateRequest, opts ...grpc.CallOption) (*SdkVolumeSnapshotEnumerateResponse, error) {
+	out := new(SdkVolumeSnapshotEnumerateResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/SnapshotEnumerate", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageVolumeClient) Attach(ctx context.Context, in *VolumeAttachRequest, opts ...grpc.CallOption) (*VolumeAttachResponse, error) {
-	out := new(VolumeAttachResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/Attach", in, out, opts...)
+func (c *openStorageVolumeClient) Attach(ctx context.Context, in *SdkVolumeAttachRequest, opts ...grpc.CallOption) (*SdkVolumeAttachResponse, error) {
+	out := new(SdkVolumeAttachResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/Attach", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageVolumeClient) Detach(ctx context.Context, in *VolumeDetachRequest, opts ...grpc.CallOption) (*VolumeDetachResponse, error) {
-	out := new(VolumeDetachResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/Detach", in, out, opts...)
+func (c *openStorageVolumeClient) Detach(ctx context.Context, in *SdkVolumeDetachRequest, opts ...grpc.CallOption) (*SdkVolumeDetachResponse, error) {
+	out := new(SdkVolumeDetachResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/Detach", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageVolumeClient) Mount(ctx context.Context, in *VolumeMountRequest, opts ...grpc.CallOption) (*VolumeMountResponse, error) {
-	out := new(VolumeMountResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/Mount", in, out, opts...)
+func (c *openStorageVolumeClient) Mount(ctx context.Context, in *SdkVolumeMountRequest, opts ...grpc.CallOption) (*SdkVolumeMountResponse, error) {
+	out := new(SdkVolumeMountResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/Mount", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageVolumeClient) Unmount(ctx context.Context, in *VolumeUnmountRequest, opts ...grpc.CallOption) (*VolumeUnmountResponse, error) {
-	out := new(VolumeUnmountResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/Unmount", in, out, opts...)
+func (c *openStorageVolumeClient) Unmount(ctx context.Context, in *SdkVolumeUnmountRequest, opts ...grpc.CallOption) (*SdkVolumeUnmountResponse, error) {
+	out := new(SdkVolumeUnmountResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageVolume/Unmount", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-// OpenStorageVolumeServer is the server API for OpenStorageVolume service.
+// Server API for OpenStorageVolume service
+
 type OpenStorageVolumeServer interface {
 	// Creates a new volume
-	Create(context.Context, *OpenStorageVolumeCreateRequest) (*OpenStorageVolumeCreateResponse, error)
-	// CreateFromVolumeID creates a new volume cloned from an existing volume
-	CreateFromVolumeID(context.Context, *VolumeCreateFromVolumeIDRequest) (*VolumeCreateFromVolumeIDResponse, error)
+	Create(context.Context, *SdkVolumeCreateRequest) (*SdkVolumeCreateResponse, error)
+	// CreateFromVolumeId creates a new volume cloned from an existing volume
+	CreateFromVolumeId(context.Context, *SdkVolumeCreateFromVolumeIdRequest) (*SdkVolumeCreateFromVolumeIdResponse, error)
 	// Delete a volume
-	Delete(context.Context, *VolumeDeleteRequest) (*VolumeDeleteResponse, error)
+	Delete(context.Context, *SdkVolumeDeleteRequest) (*SdkVolumeDeleteResponse, error)
 	// Get information on a volume
-	Inspect(context.Context, *VolumeInspectRequest) (*VolumeInspectResponse, error)
+	Inspect(context.Context, *SdkVolumeInspectRequest) (*SdkVolumeInspectResponse, error)
 	// Get a list of volumes
-	Enumerate(context.Context, *VolumeEnumerateRequest) (*VolumeEnumerateResponse, error)
+	Enumerate(context.Context, *SdkVolumeEnumerateRequest) (*SdkVolumeEnumerateResponse, error)
 	// Create a snapshot of a volume. This creates an immutable (read-only),
 	// point-in-time snapshot of a volume.
-	SnapshotCreate(context.Context, *VolumeSnapshotCreateRequest) (*VolumeSnapshotCreateResponse, error)
+	SnapshotCreate(context.Context, *SdkVolumeSnapshotCreateRequest) (*SdkVolumeSnapshotCreateResponse, error)
 	// Restores a volume to a specified snapshot
-	SnapshotRestore(context.Context, *VolumeSnapshotRestoreRequest) (*VolumeSnapshotRestoreResponse, error)
+	SnapshotRestore(context.Context, *SdkVolumeSnapshotRestoreRequest) (*SdkVolumeSnapshotRestoreResponse, error)
 	// List the number of snapshots for a specific volume
-	SnapshotEnumerate(context.Context, *VolumeSnapshotEnumerateRequest) (*VolumeSnapshotEnumerateResponse, error)
+	SnapshotEnumerate(context.Context, *SdkVolumeSnapshotEnumerateRequest) (*SdkVolumeSnapshotEnumerateResponse, error)
 	// Attach device to host
-	Attach(context.Context, *VolumeAttachRequest) (*VolumeAttachResponse, error)
+	Attach(context.Context, *SdkVolumeAttachRequest) (*SdkVolumeAttachResponse, error)
 	// Detaches the volume from the node.
-	Detach(context.Context, *VolumeDetachRequest) (*VolumeDetachResponse, error)
+	Detach(context.Context, *SdkVolumeDetachRequest) (*SdkVolumeDetachResponse, error)
 	// Attaches the volume to a node.
-	Mount(context.Context, *VolumeMountRequest) (*VolumeMountResponse, error)
+	Mount(context.Context, *SdkVolumeMountRequest) (*SdkVolumeMountResponse, error)
 	// Unmount volume at specified path
-	Unmount(context.Context, *VolumeUnmountRequest) (*VolumeUnmountResponse, error)
+	Unmount(context.Context, *SdkVolumeUnmountRequest) (*SdkVolumeUnmountResponse, error)
 }
 
 func RegisterOpenStorageVolumeServer(s *grpc.Server, srv OpenStorageVolumeServer) {
@@ -5738,7 +5738,7 @@ func RegisterOpenStorageVolumeServer(s *grpc.Server, srv OpenStorageVolumeServer
 }
 
 func _OpenStorageVolume_Create_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(OpenStorageVolumeCreateRequest)
+	in := new(SdkVolumeCreateRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -5750,31 +5750,31 @@ func _OpenStorageVolume_Create_Handler(srv interface{}, ctx context.Context, dec
 		FullMethod: "/openstorage.api.OpenStorageVolume/Create",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageVolumeServer).Create(ctx, req.(*OpenStorageVolumeCreateRequest))
+		return srv.(OpenStorageVolumeServer).Create(ctx, req.(*SdkVolumeCreateRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
-func _OpenStorageVolume_CreateFromVolumeID_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(VolumeCreateFromVolumeIDRequest)
+func _OpenStorageVolume_CreateFromVolumeId_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SdkVolumeCreateFromVolumeIdRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(OpenStorageVolumeServer).CreateFromVolumeID(ctx, in)
+		return srv.(OpenStorageVolumeServer).CreateFromVolumeId(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/openstorage.api.OpenStorageVolume/CreateFromVolumeID",
+		FullMethod: "/openstorage.api.OpenStorageVolume/CreateFromVolumeId",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageVolumeServer).CreateFromVolumeID(ctx, req.(*VolumeCreateFromVolumeIDRequest))
+		return srv.(OpenStorageVolumeServer).CreateFromVolumeId(ctx, req.(*SdkVolumeCreateFromVolumeIdRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageVolume_Delete_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(VolumeDeleteRequest)
+	in := new(SdkVolumeDeleteRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -5786,13 +5786,13 @@ func _OpenStorageVolume_Delete_Handler(srv interface{}, ctx context.Context, dec
 		FullMethod: "/openstorage.api.OpenStorageVolume/Delete",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageVolumeServer).Delete(ctx, req.(*VolumeDeleteRequest))
+		return srv.(OpenStorageVolumeServer).Delete(ctx, req.(*SdkVolumeDeleteRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageVolume_Inspect_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(VolumeInspectRequest)
+	in := new(SdkVolumeInspectRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -5804,13 +5804,13 @@ func _OpenStorageVolume_Inspect_Handler(srv interface{}, ctx context.Context, de
 		FullMethod: "/openstorage.api.OpenStorageVolume/Inspect",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageVolumeServer).Inspect(ctx, req.(*VolumeInspectRequest))
+		return srv.(OpenStorageVolumeServer).Inspect(ctx, req.(*SdkVolumeInspectRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageVolume_Enumerate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(VolumeEnumerateRequest)
+	in := new(SdkVolumeEnumerateRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -5822,13 +5822,13 @@ func _OpenStorageVolume_Enumerate_Handler(srv interface{}, ctx context.Context, 
 		FullMethod: "/openstorage.api.OpenStorageVolume/Enumerate",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageVolumeServer).Enumerate(ctx, req.(*VolumeEnumerateRequest))
+		return srv.(OpenStorageVolumeServer).Enumerate(ctx, req.(*SdkVolumeEnumerateRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageVolume_SnapshotCreate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(VolumeSnapshotCreateRequest)
+	in := new(SdkVolumeSnapshotCreateRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -5840,13 +5840,13 @@ func _OpenStorageVolume_SnapshotCreate_Handler(srv interface{}, ctx context.Cont
 		FullMethod: "/openstorage.api.OpenStorageVolume/SnapshotCreate",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageVolumeServer).SnapshotCreate(ctx, req.(*VolumeSnapshotCreateRequest))
+		return srv.(OpenStorageVolumeServer).SnapshotCreate(ctx, req.(*SdkVolumeSnapshotCreateRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageVolume_SnapshotRestore_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(VolumeSnapshotRestoreRequest)
+	in := new(SdkVolumeSnapshotRestoreRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -5858,13 +5858,13 @@ func _OpenStorageVolume_SnapshotRestore_Handler(srv interface{}, ctx context.Con
 		FullMethod: "/openstorage.api.OpenStorageVolume/SnapshotRestore",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageVolumeServer).SnapshotRestore(ctx, req.(*VolumeSnapshotRestoreRequest))
+		return srv.(OpenStorageVolumeServer).SnapshotRestore(ctx, req.(*SdkVolumeSnapshotRestoreRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageVolume_SnapshotEnumerate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(VolumeSnapshotEnumerateRequest)
+	in := new(SdkVolumeSnapshotEnumerateRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -5876,13 +5876,13 @@ func _OpenStorageVolume_SnapshotEnumerate_Handler(srv interface{}, ctx context.C
 		FullMethod: "/openstorage.api.OpenStorageVolume/SnapshotEnumerate",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageVolumeServer).SnapshotEnumerate(ctx, req.(*VolumeSnapshotEnumerateRequest))
+		return srv.(OpenStorageVolumeServer).SnapshotEnumerate(ctx, req.(*SdkVolumeSnapshotEnumerateRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageVolume_Attach_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(VolumeAttachRequest)
+	in := new(SdkVolumeAttachRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -5894,13 +5894,13 @@ func _OpenStorageVolume_Attach_Handler(srv interface{}, ctx context.Context, dec
 		FullMethod: "/openstorage.api.OpenStorageVolume/Attach",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageVolumeServer).Attach(ctx, req.(*VolumeAttachRequest))
+		return srv.(OpenStorageVolumeServer).Attach(ctx, req.(*SdkVolumeAttachRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageVolume_Detach_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(VolumeDetachRequest)
+	in := new(SdkVolumeDetachRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -5912,13 +5912,13 @@ func _OpenStorageVolume_Detach_Handler(srv interface{}, ctx context.Context, dec
 		FullMethod: "/openstorage.api.OpenStorageVolume/Detach",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageVolumeServer).Detach(ctx, req.(*VolumeDetachRequest))
+		return srv.(OpenStorageVolumeServer).Detach(ctx, req.(*SdkVolumeDetachRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageVolume_Mount_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(VolumeMountRequest)
+	in := new(SdkVolumeMountRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -5930,13 +5930,13 @@ func _OpenStorageVolume_Mount_Handler(srv interface{}, ctx context.Context, dec 
 		FullMethod: "/openstorage.api.OpenStorageVolume/Mount",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageVolumeServer).Mount(ctx, req.(*VolumeMountRequest))
+		return srv.(OpenStorageVolumeServer).Mount(ctx, req.(*SdkVolumeMountRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageVolume_Unmount_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(VolumeUnmountRequest)
+	in := new(SdkVolumeUnmountRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -5948,7 +5948,7 @@ func _OpenStorageVolume_Unmount_Handler(srv interface{}, ctx context.Context, de
 		FullMethod: "/openstorage.api.OpenStorageVolume/Unmount",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageVolumeServer).Unmount(ctx, req.(*VolumeUnmountRequest))
+		return srv.(OpenStorageVolumeServer).Unmount(ctx, req.(*SdkVolumeUnmountRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -5962,8 +5962,8 @@ var _OpenStorageVolume_serviceDesc = grpc.ServiceDesc{
 			Handler:    _OpenStorageVolume_Create_Handler,
 		},
 		{
-			MethodName: "CreateFromVolumeID",
-			Handler:    _OpenStorageVolume_CreateFromVolumeID_Handler,
+			MethodName: "CreateFromVolumeId",
+			Handler:    _OpenStorageVolume_CreateFromVolumeId_Handler,
 		},
 		{
 			MethodName: "Delete",
@@ -6010,29 +6010,28 @@ var _OpenStorageVolume_serviceDesc = grpc.ServiceDesc{
 	Metadata: "api/api.proto",
 }
 
-// OpenStorageCredentialsClient is the client API for OpenStorageCredentials service.
-//
-// For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
+// Client API for OpenStorageCredentials service
+
 type OpenStorageCredentialsClient interface {
 	// Create credential for AWS S3 and if valid ,
 	// returns a unique identifier
-	CreateForAWS(ctx context.Context, in *CredentialCreateAWSRequest, opts ...grpc.CallOption) (*CredentialCreateAWSResponse, error)
+	CreateForAWS(ctx context.Context, in *SdkCredentialCreateAWSRequest, opts ...grpc.CallOption) (*SdkCredentialCreateAWSResponse, error)
 	// Create credential for Azure and if valid ,
 	// returns a unique identifier
-	CreateForAzure(ctx context.Context, in *CredentialCreateAzureRequest, opts ...grpc.CallOption) (*CredentialCreateAzureResponse, error)
+	CreateForAzure(ctx context.Context, in *SdkCredentialCreateAzureRequest, opts ...grpc.CallOption) (*SdkCredentialCreateAzureResponse, error)
 	// Create credential for Google and if valid ,
 	// returns a unique identifier
-	CreateForGoogle(ctx context.Context, in *CredentialCreateGoogleRequest, opts ...grpc.CallOption) (*CredentialCreateGoogleResponse, error)
+	CreateForGoogle(ctx context.Context, in *SdkCredentialCreateGoogleRequest, opts ...grpc.CallOption) (*SdkCredentialCreateGoogleResponse, error)
 	// EnumerateForAWS lists the configured AWS credentials
-	EnumerateForAWS(ctx context.Context, in *CredentialEnumerateAWSRequest, opts ...grpc.CallOption) (*CredentialEnumerateAWSResponse, error)
+	EnumerateForAWS(ctx context.Context, in *SdkCredentialEnumerateAWSRequest, opts ...grpc.CallOption) (*SdkCredentialEnumerateAWSResponse, error)
 	// EnumerateForAzure lists the configured Azure credentials
-	EnumerateForAzure(ctx context.Context, in *CredentialEnumerateAzureRequest, opts ...grpc.CallOption) (*CredentialEnumerateAzureResponse, error)
+	EnumerateForAzure(ctx context.Context, in *SdkCredentialEnumerateAzureRequest, opts ...grpc.CallOption) (*SdkCredentialEnumerateAzureResponse, error)
 	// EnumerateForGoogle lists the configured Google credentials
-	EnumerateForGoogle(ctx context.Context, in *CredentialEnumerateGoogleRequest, opts ...grpc.CallOption) (*CredentialEnumerateGoogleResponse, error)
+	EnumerateForGoogle(ctx context.Context, in *SdkCredentialEnumerateGoogleRequest, opts ...grpc.CallOption) (*SdkCredentialEnumerateGoogleResponse, error)
 	// Delete a specified credential
-	CredentialDelete(ctx context.Context, in *CredentialDeleteRequest, opts ...grpc.CallOption) (*CredentialDeleteResponse, error)
+	CredentialDelete(ctx context.Context, in *SdkCredentialDeleteRequest, opts ...grpc.CallOption) (*SdkCredentialDeleteResponse, error)
 	// Validate a specified credential
-	CredentialValidate(ctx context.Context, in *CredentialValidateRequest, opts ...grpc.CallOption) (*CredentialValidateResponse, error)
+	CredentialValidate(ctx context.Context, in *SdkCredentialValidateRequest, opts ...grpc.CallOption) (*SdkCredentialValidateResponse, error)
 }
 
 type openStorageCredentialsClient struct {
@@ -6043,99 +6042,100 @@ func NewOpenStorageCredentialsClient(cc *grpc.ClientConn) OpenStorageCredentials
 	return &openStorageCredentialsClient{cc}
 }
 
-func (c *openStorageCredentialsClient) CreateForAWS(ctx context.Context, in *CredentialCreateAWSRequest, opts ...grpc.CallOption) (*CredentialCreateAWSResponse, error) {
-	out := new(CredentialCreateAWSResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageCredentials/CreateForAWS", in, out, opts...)
+func (c *openStorageCredentialsClient) CreateForAWS(ctx context.Context, in *SdkCredentialCreateAWSRequest, opts ...grpc.CallOption) (*SdkCredentialCreateAWSResponse, error) {
+	out := new(SdkCredentialCreateAWSResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageCredentials/CreateForAWS", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageCredentialsClient) CreateForAzure(ctx context.Context, in *CredentialCreateAzureRequest, opts ...grpc.CallOption) (*CredentialCreateAzureResponse, error) {
-	out := new(CredentialCreateAzureResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageCredentials/CreateForAzure", in, out, opts...)
+func (c *openStorageCredentialsClient) CreateForAzure(ctx context.Context, in *SdkCredentialCreateAzureRequest, opts ...grpc.CallOption) (*SdkCredentialCreateAzureResponse, error) {
+	out := new(SdkCredentialCreateAzureResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageCredentials/CreateForAzure", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageCredentialsClient) CreateForGoogle(ctx context.Context, in *CredentialCreateGoogleRequest, opts ...grpc.CallOption) (*CredentialCreateGoogleResponse, error) {
-	out := new(CredentialCreateGoogleResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageCredentials/CreateForGoogle", in, out, opts...)
+func (c *openStorageCredentialsClient) CreateForGoogle(ctx context.Context, in *SdkCredentialCreateGoogleRequest, opts ...grpc.CallOption) (*SdkCredentialCreateGoogleResponse, error) {
+	out := new(SdkCredentialCreateGoogleResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageCredentials/CreateForGoogle", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageCredentialsClient) EnumerateForAWS(ctx context.Context, in *CredentialEnumerateAWSRequest, opts ...grpc.CallOption) (*CredentialEnumerateAWSResponse, error) {
-	out := new(CredentialEnumerateAWSResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageCredentials/EnumerateForAWS", in, out, opts...)
+func (c *openStorageCredentialsClient) EnumerateForAWS(ctx context.Context, in *SdkCredentialEnumerateAWSRequest, opts ...grpc.CallOption) (*SdkCredentialEnumerateAWSResponse, error) {
+	out := new(SdkCredentialEnumerateAWSResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageCredentials/EnumerateForAWS", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageCredentialsClient) EnumerateForAzure(ctx context.Context, in *CredentialEnumerateAzureRequest, opts ...grpc.CallOption) (*CredentialEnumerateAzureResponse, error) {
-	out := new(CredentialEnumerateAzureResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageCredentials/EnumerateForAzure", in, out, opts...)
+func (c *openStorageCredentialsClient) EnumerateForAzure(ctx context.Context, in *SdkCredentialEnumerateAzureRequest, opts ...grpc.CallOption) (*SdkCredentialEnumerateAzureResponse, error) {
+	out := new(SdkCredentialEnumerateAzureResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageCredentials/EnumerateForAzure", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageCredentialsClient) EnumerateForGoogle(ctx context.Context, in *CredentialEnumerateGoogleRequest, opts ...grpc.CallOption) (*CredentialEnumerateGoogleResponse, error) {
-	out := new(CredentialEnumerateGoogleResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageCredentials/EnumerateForGoogle", in, out, opts...)
+func (c *openStorageCredentialsClient) EnumerateForGoogle(ctx context.Context, in *SdkCredentialEnumerateGoogleRequest, opts ...grpc.CallOption) (*SdkCredentialEnumerateGoogleResponse, error) {
+	out := new(SdkCredentialEnumerateGoogleResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageCredentials/EnumerateForGoogle", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageCredentialsClient) CredentialDelete(ctx context.Context, in *CredentialDeleteRequest, opts ...grpc.CallOption) (*CredentialDeleteResponse, error) {
-	out := new(CredentialDeleteResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageCredentials/CredentialDelete", in, out, opts...)
+func (c *openStorageCredentialsClient) CredentialDelete(ctx context.Context, in *SdkCredentialDeleteRequest, opts ...grpc.CallOption) (*SdkCredentialDeleteResponse, error) {
+	out := new(SdkCredentialDeleteResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageCredentials/CredentialDelete", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-func (c *openStorageCredentialsClient) CredentialValidate(ctx context.Context, in *CredentialValidateRequest, opts ...grpc.CallOption) (*CredentialValidateResponse, error) {
-	out := new(CredentialValidateResponse)
-	err := c.cc.Invoke(ctx, "/openstorage.api.OpenStorageCredentials/CredentialValidate", in, out, opts...)
+func (c *openStorageCredentialsClient) CredentialValidate(ctx context.Context, in *SdkCredentialValidateRequest, opts ...grpc.CallOption) (*SdkCredentialValidateResponse, error) {
+	out := new(SdkCredentialValidateResponse)
+	err := grpc.Invoke(ctx, "/openstorage.api.OpenStorageCredentials/CredentialValidate", in, out, c.cc, opts...)
 	if err != nil {
 		return nil, err
 	}
 	return out, nil
 }
 
-// OpenStorageCredentialsServer is the server API for OpenStorageCredentials service.
+// Server API for OpenStorageCredentials service
+
 type OpenStorageCredentialsServer interface {
 	// Create credential for AWS S3 and if valid ,
 	// returns a unique identifier
-	CreateForAWS(context.Context, *CredentialCreateAWSRequest) (*CredentialCreateAWSResponse, error)
+	CreateForAWS(context.Context, *SdkCredentialCreateAWSRequest) (*SdkCredentialCreateAWSResponse, error)
 	// Create credential for Azure and if valid ,
 	// returns a unique identifier
-	CreateForAzure(context.Context, *CredentialCreateAzureRequest) (*CredentialCreateAzureResponse, error)
+	CreateForAzure(context.Context, *SdkCredentialCreateAzureRequest) (*SdkCredentialCreateAzureResponse, error)
 	// Create credential for Google and if valid ,
 	// returns a unique identifier
-	CreateForGoogle(context.Context, *CredentialCreateGoogleRequest) (*CredentialCreateGoogleResponse, error)
+	CreateForGoogle(context.Context, *SdkCredentialCreateGoogleRequest) (*SdkCredentialCreateGoogleResponse, error)
 	// EnumerateForAWS lists the configured AWS credentials
-	EnumerateForAWS(context.Context, *CredentialEnumerateAWSRequest) (*CredentialEnumerateAWSResponse, error)
+	EnumerateForAWS(context.Context, *SdkCredentialEnumerateAWSRequest) (*SdkCredentialEnumerateAWSResponse, error)
 	// EnumerateForAzure lists the configured Azure credentials
-	EnumerateForAzure(context.Context, *CredentialEnumerateAzureRequest) (*CredentialEnumerateAzureResponse, error)
+	EnumerateForAzure(context.Context, *SdkCredentialEnumerateAzureRequest) (*SdkCredentialEnumerateAzureResponse, error)
 	// EnumerateForGoogle lists the configured Google credentials
-	EnumerateForGoogle(context.Context, *CredentialEnumerateGoogleRequest) (*CredentialEnumerateGoogleResponse, error)
+	EnumerateForGoogle(context.Context, *SdkCredentialEnumerateGoogleRequest) (*SdkCredentialEnumerateGoogleResponse, error)
 	// Delete a specified credential
-	CredentialDelete(context.Context, *CredentialDeleteRequest) (*CredentialDeleteResponse, error)
+	CredentialDelete(context.Context, *SdkCredentialDeleteRequest) (*SdkCredentialDeleteResponse, error)
 	// Validate a specified credential
-	CredentialValidate(context.Context, *CredentialValidateRequest) (*CredentialValidateResponse, error)
+	CredentialValidate(context.Context, *SdkCredentialValidateRequest) (*SdkCredentialValidateResponse, error)
 }
 
 func RegisterOpenStorageCredentialsServer(s *grpc.Server, srv OpenStorageCredentialsServer) {
@@ -6143,7 +6143,7 @@ func RegisterOpenStorageCredentialsServer(s *grpc.Server, srv OpenStorageCredent
 }
 
 func _OpenStorageCredentials_CreateForAWS_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CredentialCreateAWSRequest)
+	in := new(SdkCredentialCreateAWSRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -6155,13 +6155,13 @@ func _OpenStorageCredentials_CreateForAWS_Handler(srv interface{}, ctx context.C
 		FullMethod: "/openstorage.api.OpenStorageCredentials/CreateForAWS",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageCredentialsServer).CreateForAWS(ctx, req.(*CredentialCreateAWSRequest))
+		return srv.(OpenStorageCredentialsServer).CreateForAWS(ctx, req.(*SdkCredentialCreateAWSRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageCredentials_CreateForAzure_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CredentialCreateAzureRequest)
+	in := new(SdkCredentialCreateAzureRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -6173,13 +6173,13 @@ func _OpenStorageCredentials_CreateForAzure_Handler(srv interface{}, ctx context
 		FullMethod: "/openstorage.api.OpenStorageCredentials/CreateForAzure",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageCredentialsServer).CreateForAzure(ctx, req.(*CredentialCreateAzureRequest))
+		return srv.(OpenStorageCredentialsServer).CreateForAzure(ctx, req.(*SdkCredentialCreateAzureRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageCredentials_CreateForGoogle_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CredentialCreateGoogleRequest)
+	in := new(SdkCredentialCreateGoogleRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -6191,13 +6191,13 @@ func _OpenStorageCredentials_CreateForGoogle_Handler(srv interface{}, ctx contex
 		FullMethod: "/openstorage.api.OpenStorageCredentials/CreateForGoogle",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageCredentialsServer).CreateForGoogle(ctx, req.(*CredentialCreateGoogleRequest))
+		return srv.(OpenStorageCredentialsServer).CreateForGoogle(ctx, req.(*SdkCredentialCreateGoogleRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageCredentials_EnumerateForAWS_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CredentialEnumerateAWSRequest)
+	in := new(SdkCredentialEnumerateAWSRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -6209,13 +6209,13 @@ func _OpenStorageCredentials_EnumerateForAWS_Handler(srv interface{}, ctx contex
 		FullMethod: "/openstorage.api.OpenStorageCredentials/EnumerateForAWS",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageCredentialsServer).EnumerateForAWS(ctx, req.(*CredentialEnumerateAWSRequest))
+		return srv.(OpenStorageCredentialsServer).EnumerateForAWS(ctx, req.(*SdkCredentialEnumerateAWSRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageCredentials_EnumerateForAzure_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CredentialEnumerateAzureRequest)
+	in := new(SdkCredentialEnumerateAzureRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -6227,13 +6227,13 @@ func _OpenStorageCredentials_EnumerateForAzure_Handler(srv interface{}, ctx cont
 		FullMethod: "/openstorage.api.OpenStorageCredentials/EnumerateForAzure",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageCredentialsServer).EnumerateForAzure(ctx, req.(*CredentialEnumerateAzureRequest))
+		return srv.(OpenStorageCredentialsServer).EnumerateForAzure(ctx, req.(*SdkCredentialEnumerateAzureRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageCredentials_EnumerateForGoogle_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CredentialEnumerateGoogleRequest)
+	in := new(SdkCredentialEnumerateGoogleRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -6245,13 +6245,13 @@ func _OpenStorageCredentials_EnumerateForGoogle_Handler(srv interface{}, ctx con
 		FullMethod: "/openstorage.api.OpenStorageCredentials/EnumerateForGoogle",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageCredentialsServer).EnumerateForGoogle(ctx, req.(*CredentialEnumerateGoogleRequest))
+		return srv.(OpenStorageCredentialsServer).EnumerateForGoogle(ctx, req.(*SdkCredentialEnumerateGoogleRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageCredentials_CredentialDelete_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CredentialDeleteRequest)
+	in := new(SdkCredentialDeleteRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -6263,13 +6263,13 @@ func _OpenStorageCredentials_CredentialDelete_Handler(srv interface{}, ctx conte
 		FullMethod: "/openstorage.api.OpenStorageCredentials/CredentialDelete",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageCredentialsServer).CredentialDelete(ctx, req.(*CredentialDeleteRequest))
+		return srv.(OpenStorageCredentialsServer).CredentialDelete(ctx, req.(*SdkCredentialDeleteRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
 
 func _OpenStorageCredentials_CredentialValidate_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
-	in := new(CredentialValidateRequest)
+	in := new(SdkCredentialValidateRequest)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
@@ -6281,7 +6281,7 @@ func _OpenStorageCredentials_CredentialValidate_Handler(srv interface{}, ctx con
 		FullMethod: "/openstorage.api.OpenStorageCredentials/CredentialValidate",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(OpenStorageCredentialsServer).CredentialValidate(ctx, req.(*CredentialValidateRequest))
+		return srv.(OpenStorageCredentialsServer).CredentialValidate(ctx, req.(*SdkCredentialValidateRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -6327,338 +6327,339 @@ var _OpenStorageCredentials_serviceDesc = grpc.ServiceDesc{
 	Metadata: "api/api.proto",
 }
 
-func init() { proto.RegisterFile("api/api.proto", fileDescriptor_api_045a0b9d887bb59a) }
+func init() { proto.RegisterFile("api/api.proto", fileDescriptor_api_ac37319a59d075f7) }
 
-var fileDescriptor_api_045a0b9d887bb59a = []byte{
-	// 5272 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x5b, 0x4d, 0x8c, 0x1b, 0xc7,
-	0x72, 0xf6, 0x90, 0xbb, 0xfc, 0xa9, 0xfd, 0x1b, 0xb5, 0xa4, 0x5d, 0x8a, 0x5a, 0x69, 0x57, 0x63,
-	0xcb, 0x96, 0x69, 0x7b, 0x57, 0x5e, 0xff, 0x4a, 0x2f, 0xfe, 0xa1, 0xc8, 0xd9, 0x5d, 0x5a, 0x5c,
-	0x72, 0xdf, 0x90, 0x2b, 0xd9, 0x7e, 0x09, 0x26, 0x23, 0xb2, 0xb5, 0xa2, 0x4d, 0xce, 0x50, 0x33,
-	0xc3, 0x35, 0xa4, 0x43, 0x02, 0xbc, 0x1c, 0x1e, 0x12, 0xe4, 0x0f, 0xf9, 0x7f, 0x40, 0xfe, 0x0e,
-	0x09, 0x10, 0xe0, 0x21, 0x40, 0x72, 0x7e, 0x87, 0x1c, 0x72, 0x08, 0x82, 0xe4, 0xe5, 0x92, 0x43,
-	0x72, 0xc8, 0x2d, 0xb9, 0x04, 0x08, 0x72, 0x4e, 0x6e, 0x41, 0x57, 0xf7, 0x0c, 0x67, 0x86, 0x33,
-	0x5c, 0x32, 0xb6, 0xdf, 0x45, 0x62, 0x57, 0x57, 0x57, 0x7d, 0xdd, 0x5d, 0x55, 0x5d, 0x5d, 0xd3,
-	0x0b, 0x2b, 0xc6, 0xb0, 0xb7, 0x6b, 0x0c, 0x7b, 0x3b, 0x43, 0xdb, 0x72, 0x2d, 0xb2, 0x66, 0x0d,
-	0xa9, 0xe9, 0xb8, 0x96, 0x6d, 0x9c, 0xd2, 0x1d, 0x63, 0xd8, 0x2b, 0x6e, 0x9d, 0x5a, 0xd6, 0x69,
-	0x9f, 0xee, 0x62, 0xf7, 0xa3, 0xd1, 0xe3, 0x5d, 0xb7, 0x37, 0xa0, 0x8e, 0x6b, 0x0c, 0x86, 0x7c,
-	0x44, 0x71, 0x53, 0x30, 0xa0, 0x1c, 0xd3, 0xb4, 0x5c, 0xc3, 0xed, 0x59, 0xa6, 0xc3, 0x7b, 0x95,
-	0x5f, 0x4b, 0xc3, 0x5a, 0x8b, 0x8b, 0xd3, 0xa8, 0x63, 0x8d, 0xec, 0x0e, 0x25, 0xab, 0x90, 0xea,
-	0x75, 0x0b, 0xd2, 0xb6, 0x74, 0x2b, 0xaf, 0xa5, 0x7a, 0x5d, 0x42, 0x60, 0x61, 0x68, 0xb8, 0x4f,
-	0x0a, 0x29, 0xa4, 0xe0, 0x6f, 0xf2, 0x2e, 0x64, 0x06, 0xb4, 0xdb, 0x1b, 0x0d, 0x0a, 0xe9, 0x6d,
-	0xe9, 0xd6, 0xea, 0xde, 0xf5, 0x9d, 0x08, 0xb0, 0x1d, 0x21, 0xf5, 0x08, 0xb9, 0x34, 0xc1, 0x4d,
-	0xd6, 0x21, 0x63, 0x99, 0xfd, 0x9e, 0x49, 0x0b, 0x0b, 0xdb, 0xd2, 0xad, 0x9c, 0x26, 0x5a, 0x4c,
-	0x47, 0xcf, 0x1a, 0x3a, 0x85, 0xc5, 0x6d, 0xe9, 0xd6, 0x82, 0x86, 0xbf, 0xc9, 0x55, 0xc8, 0x3b,
-	0xf4, 0xa9, 0xfe, 0x95, 0xdd, 0x73, 0x69, 0x21, 0xb3, 0x2d, 0xdd, 0x92, 0xb4, 0x9c, 0x43, 0x9f,
-	0x3e, 0x64, 0x6d, 0x72, 0x05, 0xd8, 0x6f, 0xdd, 0xa6, 0x46, 0xb7, 0x90, 0xc5, 0xbe, 0xac, 0x43,
-	0x9f, 0x6a, 0xd4, 0xe8, 0x32, 0x1d, 0xb6, 0x61, 0x76, 0xb5, 0x87, 0x85, 0x1c, 0x76, 0x88, 0x16,
-	0xd3, 0xe1, 0xf4, 0x9e, 0xd3, 0x42, 0x9e, 0xeb, 0x60, 0xbf, 0x19, 0x6d, 0xe4, 0xd0, 0x6e, 0x01,
-	0x38, 0x8d, 0xfd, 0x26, 0x37, 0x61, 0xd5, 0x16, 0xcb, 0xa4, 0x3b, 0x43, 0x4a, 0xbb, 0x85, 0x25,
-	0x9c, 0xf9, 0x8a, 0x47, 0x6d, 0x31, 0x22, 0x79, 0x0f, 0xf2, 0x7d, 0xc3, 0x71, 0x75, 0xa7, 0x63,
-	0x98, 0x85, 0xe5, 0x6d, 0xe9, 0xd6, 0xd2, 0x5e, 0x71, 0x87, 0x2f, 0xf6, 0x8e, 0xb7, 0x1b, 0x3b,
-	0x6d, 0x6f, 0x37, 0xb4, 0x1c, 0x63, 0x6e, 0x75, 0x0c, 0x93, 0x14, 0x21, 0x37, 0xa0, 0xae, 0xd1,
-	0x35, 0x5c, 0xa3, 0xb0, 0x82, 0xab, 0xe0, 0xb7, 0x95, 0x7f, 0x4a, 0xc1, 0x92, 0x58, 0xb9, 0x63,
-	0xcb, 0xea, 0xb3, 0xbd, 0xa8, 0x55, 0x71, 0x2f, 0x16, 0xb5, 0x54, 0xad, 0x4a, 0x4a, 0x90, 0xae,
-	0x58, 0x0e, 0x6e, 0xc5, 0xea, 0x5e, 0x61, 0x62, 0xd1, 0x2b, 0x96, 0xd3, 0x7e, 0x36, 0xa4, 0x1a,
-	0x63, 0x62, 0x7b, 0x74, 0x34, 0xd7, 0x1e, 0xf1, 0xff, 0xc9, 0x26, 0xe4, 0x35, 0xa3, 0xd7, 0xad,
-	0xd3, 0x33, 0xda, 0xc7, 0x6d, 0xca, 0x6b, 0x63, 0x02, 0xeb, 0x6d, 0x5b, 0xae, 0xd1, 0x6f, 0xb1,
-	0xa5, 0xcc, 0xe2, 0xb2, 0x8d, 0x09, 0x6c, 0x3d, 0x4f, 0xd8, 0x7a, 0xe6, 0xf8, 0x7a, 0xb2, 0xdf,
-	0xe4, 0x63, 0xc8, 0xf4, 0x8d, 0x47, 0xb4, 0xef, 0x14, 0xf2, 0xdb, 0xe9, 0x5b, 0x4b, 0x7b, 0xb7,
-	0x92, 0x70, 0xb0, 0x19, 0xef, 0xd4, 0x91, 0x55, 0x35, 0x5d, 0xfb, 0x99, 0x26, 0xc6, 0x15, 0xef,
-	0xc0, 0x52, 0x80, 0x4c, 0x64, 0x48, 0x7f, 0x49, 0x9f, 0x09, 0x0b, 0x65, 0x3f, 0xc9, 0x25, 0x58,
-	0x3c, 0x33, 0xfa, 0x23, 0x2a, 0x6c, 0x94, 0x37, 0xee, 0xa6, 0xde, 0x97, 0x94, 0x1f, 0x4b, 0xb0,
-	0xf2, 0xc0, 0xea, 0x8f, 0x06, 0xb4, 0x6e, 0x75, 0x0c, 0xd7, 0xb2, 0x19, 0x44, 0xd3, 0x18, 0x50,
-	0x31, 0x1c, 0x7f, 0x93, 0x13, 0x58, 0x39, 0x43, 0x26, 0x5d, 0x20, 0x4d, 0x21, 0xd2, 0xdb, 0x13,
-	0x48, 0x43, 0xa2, 0xbc, 0x56, 0x00, 0xf1, 0xf2, 0x59, 0x80, 0x54, 0xfc, 0x08, 0x2e, 0x4c, 0xb0,
-	0xcc, 0x85, 0xfe, 0x6d, 0xc8, 0xb4, 0xb8, 0x53, 0xae, 0x43, 0x66, 0x68, 0xd8, 0xd4, 0x74, 0xc5,
-	0x40, 0xd1, 0x42, 0xa3, 0x66, 0x26, 0x2a, 0x9c, 0x93, 0xfd, 0x56, 0x36, 0x60, 0xf1, 0xc0, 0xb6,
-	0x46, 0xc3, 0xa8, 0x27, 0x2b, 0x3f, 0xc9, 0x02, 0x70, 0x40, 0xad, 0x21, 0xed, 0xb0, 0xad, 0xa4,
-	0xc3, 0x27, 0x74, 0x40, 0x6d, 0xa3, 0x8f, 0x5c, 0x39, 0x6d, 0x4c, 0xf0, 0xdd, 0x25, 0x15, 0x70,
-	0x97, 0x5d, 0xc8, 0x3c, 0xb6, 0xec, 0x81, 0xe1, 0x0a, 0x93, 0xda, 0x98, 0x58, 0xa0, 0xfd, 0x16,
-	0x1a, 0xa0, 0x60, 0x23, 0xd7, 0x00, 0x1e, 0xf5, 0xad, 0xce, 0x97, 0x3a, 0x8a, 0x62, 0xc6, 0x94,
-	0xd6, 0xf2, 0x48, 0x41, 0x73, 0xb9, 0x02, 0xb9, 0x27, 0x86, 0xde, 0x47, 0x4b, 0x5b, 0xc4, 0xce,
-	0xec, 0x13, 0x83, 0xdb, 0x59, 0x09, 0xd2, 0x1d, 0xcb, 0x41, 0xbf, 0x9f, 0x6a, 0xe9, 0x1d, 0xcb,
-	0x21, 0x77, 0x00, 0x7a, 0x96, 0x3e, 0xb4, 0xad, 0xc7, 0xbd, 0x3e, 0x37, 0xca, 0xd5, 0xbd, 0xe2,
-	0xc4, 0x90, 0x9a, 0x75, 0xcc, 0x39, 0xb4, 0x7c, 0xcf, 0xfb, 0xc9, 0xd6, 0xb5, 0x4b, 0xbb, 0xa3,
-	0x21, 0x45, 0x93, 0xcd, 0x69, 0xa2, 0x45, 0x5e, 0x83, 0x0b, 0x8e, 0x69, 0x0c, 0x9d, 0x27, 0x96,
-	0xab, 0xf7, 0x4c, 0x97, 0xda, 0x67, 0x46, 0x1f, 0x23, 0xc7, 0x8a, 0x26, 0x7b, 0x1d, 0x35, 0x41,
-	0x27, 0x5a, 0xd4, 0x7c, 0x00, 0xcd, 0xe7, 0x8d, 0x04, 0xf3, 0x61, 0x8b, 0x7f, 0x9e, 0xed, 0x30,
-	0x60, 0xce, 0x13, 0xc3, 0x16, 0xd1, 0x27, 0xa7, 0x89, 0x16, 0xf9, 0x19, 0x58, 0xb2, 0xe9, 0xb0,
-	0xdf, 0xeb, 0x18, 0xba, 0x43, 0x5d, 0x11, 0x78, 0xae, 0x4e, 0x68, 0xd2, 0x38, 0x4f, 0x8b, 0xba,
-	0x1a, 0xd8, 0xfe, 0x6f, 0x36, 0x2d, 0xe3, 0xf4, 0xd4, 0xa6, 0xa7, 0x3c, 0xbc, 0xf1, 0x95, 0x5f,
-	0xe1, 0xd3, 0x0a, 0x74, 0xf8, 0xae, 0x4e, 0xcd, 0x8e, 0xfd, 0x6c, 0xe8, 0xd2, 0x6e, 0x61, 0x55,
-	0xd8, 0x87, 0x47, 0x20, 0xd7, 0x01, 0x86, 0x86, 0xe3, 0x0c, 0x9f, 0xd8, 0x86, 0x43, 0x0b, 0x6b,
-	0x68, 0x64, 0x01, 0x4a, 0x68, 0x05, 0x9d, 0xce, 0x13, 0xda, 0x1d, 0xf5, 0x69, 0x41, 0x46, 0x36,
-	0x7f, 0x05, 0x5b, 0x82, 0xce, 0x5c, 0xc0, 0xe9, 0x18, 0x7d, 0x5a, 0xb8, 0x80, 0x58, 0x78, 0x03,
-	0xd7, 0xc0, 0xed, 0x75, 0xbe, 0x7c, 0x56, 0x20, 0x62, 0x0d, 0xb0, 0x45, 0x5e, 0x87, 0xc5, 0x53,
-	0x66, 0xe0, 0x85, 0xcb, 0x38, 0xfb, 0xf5, 0x89, 0xd9, 0xa3, 0xf9, 0x6b, 0x9c, 0x89, 0xc5, 0x73,
-	0xfc, 0xa1, 0x53, 0xf3, 0xb1, 0x65, 0x77, 0x68, 0xb7, 0xb0, 0x8e, 0xd2, 0x56, 0x90, 0xaa, 0x0a,
-	0x22, 0x9b, 0x4f, 0xc7, 0x1a, 0x0c, 0x6d, 0xea, 0xb0, 0x00, 0xb6, 0x81, 0x2c, 0x01, 0x0a, 0x0b,
-	0xdb, 0x1d, 0xc3, 0xe9, 0x18, 0x5d, 0xda, 0x2d, 0x14, 0x78, 0xd8, 0xf6, 0xda, 0xa4, 0x00, 0xd9,
-	0x2f, 0xac, 0x91, 0x6d, 0x1a, 0xfd, 0xc2, 0x15, 0xec, 0xf2, 0x9a, 0x6c, 0x14, 0xdf, 0xb8, 0xb3,
-	0xb7, 0x0b, 0x45, 0x3e, 0xca, 0x6b, 0x7f, 0xfd, 0xf0, 0xa0, 0x00, 0x8c, 0xf7, 0x99, 0xf1, 0x99,
-	0x56, 0x97, 0x3a, 0x05, 0x69, 0x3b, 0xcd, 0xf8, 0xb0, 0xa1, 0xfc, 0x48, 0x82, 0x35, 0x6d, 0x64,
-	0xb2, 0xb4, 0xa0, 0xe5, 0x1a, 0x2e, 0x3d, 0x32, 0x86, 0xe4, 0x21, 0xac, 0xd8, 0x9c, 0xa4, 0x3b,
-	0x8c, 0x86, 0x23, 0x96, 0xf6, 0xf6, 0x26, 0xad, 0x28, 0x3c, 0x30, 0xd4, 0x16, 0x46, 0x6b, 0x07,
-	0x48, 0x6c, 0x46, 0x13, 0x2c, 0x73, 0xcd, 0xe8, 0xdf, 0x73, 0x90, 0xe1, 0x6b, 0x32, 0x91, 0x86,
-	0xec, 0x42, 0x86, 0x27, 0x28, 0x38, 0x6a, 0x29, 0x26, 0xf6, 0xf0, 0x50, 0xa9, 0x09, 0xb6, 0xb1,
-	0x95, 0xa4, 0x67, 0xb1, 0x92, 0x22, 0xe4, 0x58, 0x32, 0x61, 0x99, 0xfd, 0x67, 0x22, 0x37, 0xf1,
-	0xdb, 0xe4, 0x7d, 0xc8, 0xf6, 0x79, 0xc8, 0xc7, 0x28, 0xb5, 0x14, 0x73, 0x94, 0x86, 0x0e, 0x06,
-	0xcd, 0x63, 0x27, 0xb7, 0x61, 0xb1, 0xc3, 0x96, 0x03, 0xe3, 0xd8, 0xf4, 0x04, 0x81, 0x33, 0x92,
-	0x5d, 0x58, 0x70, 0x86, 0xb4, 0x83, 0x51, 0x2c, 0xce, 0xb1, 0xc7, 0x21, 0x44, 0x43, 0x46, 0xb6,
-	0x98, 0x23, 0xc7, 0x38, 0xa5, 0xe2, 0xcc, 0xe5, 0x8d, 0x70, 0x76, 0x92, 0x9f, 0x23, 0x3b, 0x19,
-	0x87, 0x78, 0x98, 0x2d, 0xc4, 0xbf, 0xc3, 0x9c, 0xd4, 0x70, 0x47, 0x0e, 0x06, 0xaa, 0xd5, 0xbd,
-	0x6b, 0x49, 0x90, 0x91, 0x49, 0x13, 0xcc, 0x64, 0x0f, 0x16, 0xb9, 0xed, 0x2d, 0xe3, 0xa8, 0xcd,
-	0x29, 0xa3, 0xa8, 0xc6, 0x59, 0xc9, 0x16, 0x2c, 0x19, 0xae, 0x6b, 0xb0, 0xa0, 0xa1, 0x5b, 0x26,
-	0xc6, 0xad, 0xbc, 0x06, 0x1e, 0xa9, 0x69, 0x92, 0x0a, 0xac, 0xfa, 0x0c, 0x5c, 0xfa, 0x6a, 0x82,
-	0xf4, 0x32, 0xb2, 0x71, 0xe9, 0x2b, 0xde, 0x98, 0x96, 0xa7, 0xa5, 0x4b, 0xcf, 0x7a, 0x1d, 0xaa,
-	0x63, 0xda, 0x2b, 0x22, 0x1b, 0x27, 0x1d, 0xb3, 0xe4, 0xf7, 0x75, 0x20, 0x0e, 0xed, 0x8c, 0x6c,
-	0xaa, 0x07, 0xf9, 0xbc, 0xd0, 0x86, 0x3d, 0xd5, 0x31, 0xb7, 0x0f, 0x9a, 0xb3, 0x5d, 0x40, 0xe7,
-	0x14, 0xa0, 0x91, 0xe1, 0xd0, 0x67, 0xe8, 0x99, 0x8f, 0xad, 0x02, 0x41, 0x5f, 0x7c, 0x25, 0x61,
-	0x3d, 0x04, 0xf0, 0x9a, 0xf9, 0xd8, 0xe2, 0x0e, 0x28, 0x24, 0x31, 0x02, 0xf9, 0x10, 0x96, 0x03,
-	0x67, 0x83, 0x53, 0xb8, 0x88, 0xa2, 0xa6, 0x1e, 0x0e, 0x4b, 0xe3, 0xc3, 0xc1, 0x21, 0x6a, 0x34,
-	0x2e, 0x5c, 0x42, 0x01, 0xdb, 0xe7, 0xc5, 0x85, 0x70, 0x14, 0x60, 0x16, 0x49, 0x6d, 0xdb, 0xb2,
-	0x31, 0x3c, 0xe7, 0x35, 0xde, 0x20, 0x9f, 0x80, 0x2c, 0x0e, 0xc9, 0x8e, 0x65, 0x3a, 0xa3, 0x01,
-	0xb5, 0x9d, 0xc2, 0x3a, 0xca, 0xdf, 0x4a, 0x98, 0x6b, 0x45, 0xf0, 0x69, 0x6b, 0x67, 0xa1, 0xb6,
-	0x53, 0xfc, 0x00, 0xd6, 0x22, 0xeb, 0x30, 0x57, 0x94, 0xf9, 0x93, 0x14, 0x2c, 0x32, 0xa8, 0x0e,
-	0xe3, 0x61, 0x5e, 0xee, 0xe0, 0xb8, 0x05, 0x8d, 0x37, 0xc8, 0x06, 0x64, 0xd9, 0x0f, 0x7d, 0xe0,
-	0x88, 0xec, 0x27, 0xc3, 0x9a, 0x47, 0x0e, 0x4b, 0x67, 0xb0, 0xe3, 0xd1, 0x33, 0x97, 0x3a, 0x18,
-	0x57, 0x16, 0xb4, 0x3c, 0xa3, 0xdc, 0x63, 0x04, 0x76, 0x5e, 0xe1, 0x6d, 0xc5, 0xc1, 0x08, 0xb2,
-	0xa0, 0x89, 0x16, 0x4b, 0x73, 0xf0, 0x17, 0x13, 0xc8, 0x6f, 0x38, 0x59, 0x6c, 0x1f, 0x39, 0xcc,
-	0x3a, 0x78, 0x17, 0x17, 0x99, 0xc1, 0x5e, 0x40, 0x12, 0x97, 0xb9, 0x05, 0x4b, 0x3c, 0xb7, 0x39,
-	0x65, 0xe7, 0x90, 0xc8, 0xb8, 0x01, 0x13, 0x18, 0xa4, 0x90, 0x8b, 0xb0, 0xd8, 0xb3, 0x98, 0xe4,
-	0x9c, 0x77, 0x77, 0xe2, 0x40, 0x51, 0xa0, 0x8e, 0xb7, 0x1b, 0x7e, 0xe3, 0xc9, 0x23, 0x05, 0x53,
-	0x72, 0x26, 0x54, 0x24, 0x2f, 0x6c, 0x24, 0x08, 0xa1, 0x82, 0x74, 0xe4, 0x28, 0xff, 0x95, 0x82,
-	0xc5, 0x72, 0x9f, 0xda, 0x6e, 0x20, 0x0c, 0xa7, 0x31, 0x0c, 0xdf, 0x61, 0x17, 0xaf, 0x33, 0x6a,
-	0xf7, 0xdc, 0x67, 0xe2, 0x1a, 0x32, 0xe9, 0xf0, 0x2d, 0xc1, 0x80, 0x71, 0xc2, 0x67, 0x67, 0xa0,
-	0x0c, 0x26, 0x53, 0x77, 0x9f, 0x0d, 0x29, 0xae, 0x5e, 0x5a, 0xcb, 0x23, 0x85, 0x31, 0xb2, 0x43,
-	0x74, 0x40, 0x1d, 0x0c, 0x65, 0xfc, 0xd6, 0xe1, 0x35, 0xc9, 0xfb, 0x90, 0xf7, 0xaf, 0xb5, 0x22,
-	0x02, 0x4f, 0x0b, 0x66, 0x63, 0x66, 0x36, 0x51, 0x5b, 0xdc, 0x6b, 0xf5, 0x5e, 0x17, 0x97, 0x37,
-	0xcf, 0x12, 0x22, 0x4e, 0xaa, 0xe1, 0x74, 0xbc, 0x96, 0x48, 0x1c, 0xaf, 0xc5, 0xb8, 0x0b, 0x67,
-	0xe0, 0xd3, 0xf1, 0xd8, 0x19, 0xde, 0x4e, 0x9f, 0x62, 0x8a, 0xc6, 0x73, 0x47, 0xaf, 0xc9, 0x6c,
-	0xd1, 0x75, 0xfb, 0x62, 0xd9, 0xd9, 0x4f, 0x36, 0xf5, 0x91, 0xd9, 0x7b, 0x3a, 0xa2, 0xba, 0x6b,
-	0x9c, 0xe2, 0x7a, 0xe7, 0xb5, 0x3c, 0xa7, 0xb4, 0x8d, 0x53, 0xe5, 0x5d, 0xc8, 0xe0, 0x6a, 0x3b,
-	0xec, 0xd0, 0xc2, 0x15, 0x11, 0x47, 0xf2, 0xe4, 0xa1, 0x85, 0x7c, 0x1a, 0x67, 0x52, 0xfe, 0x31,
-	0x05, 0x6b, 0xcd, 0x47, 0x5f, 0xd0, 0x8e, 0xcb, 0x58, 0x28, 0x06, 0x01, 0x76, 0xa5, 0x1d, 0xf9,
-	0x27, 0x27, 0xfe, 0x66, 0x57, 0x69, 0xe1, 0x7b, 0x3d, 0xef, 0xaa, 0x90, 0xe3, 0x84, 0x1a, 0x26,
-	0x2f, 0xd4, 0x34, 0x1e, 0xf5, 0x69, 0x17, 0xf7, 0x24, 0xa7, 0x79, 0x4d, 0x9e, 0x7f, 0x61, 0x68,
-	0xe7, 0x1b, 0xe2, 0xc5, 0xee, 0x75, 0xc8, 0x18, 0x1d, 0x96, 0x27, 0x8a, 0xa4, 0x5d, 0xb4, 0x70,
-	0x83, 0x3b, 0x1d, 0xea, 0x38, 0x3a, 0x73, 0x45, 0xbe, 0xd8, 0x79, 0x4e, 0xb9, 0x4f, 0x71, 0xff,
-	0x1d, 0xda, 0xb1, 0xa9, 0x8b, 0xdd, 0x59, 0xde, 0xcd, 0x29, 0xac, 0x1b, 0xd3, 0xcd, 0xee, 0xd0,
-	0xea, 0x99, 0x2e, 0x33, 0x66, 0x16, 0x26, 0xc7, 0x04, 0xf2, 0x2a, 0xc8, 0x9d, 0x91, 0xcd, 0xee,
-	0x3c, 0x3a, 0x35, 0xbb, 0xc7, 0x8c, 0x88, 0x0b, 0x9c, 0xd7, 0xd6, 0x04, 0x5d, 0x15, 0x64, 0x8c,
-	0xb8, 0x1c, 0xc6, 0xd0, 0xb2, 0xf9, 0x39, 0x96, 0xd6, 0x04, 0xb2, 0x63, 0xcb, 0x76, 0xb1, 0x42,
-	0x40, 0x4f, 0x19, 0x7e, 0x7e, 0xb3, 0x17, 0x2d, 0xe5, 0xaf, 0x25, 0xb8, 0x28, 0x42, 0x8f, 0x4d,
-	0xd9, 0xc9, 0x40, 0x9f, 0x8e, 0xa8, 0xe3, 0x06, 0xcf, 0x7f, 0x69, 0xbe, 0xf3, 0x7f, 0xee, 0xa4,
-	0xc5, 0x3b, 0xfe, 0xd3, 0x33, 0x1e, 0xff, 0xca, 0xcb, 0xb0, 0xca, 0x69, 0x1a, 0x75, 0x86, 0x96,
-	0xe9, 0x04, 0xc2, 0xaf, 0x14, 0x08, 0xbf, 0xca, 0x10, 0x2e, 0x85, 0xa7, 0x26, 0xb8, 0xa3, 0x69,
-	0xd6, 0x21, 0x88, 0x68, 0xab, 0xdb, 0x82, 0x45, 0x40, 0x4f, 0x8a, 0xd2, 0x9e, 0x24, 0x6d, 0xf5,
-	0x2c, 0xd4, 0x56, 0xfe, 0x5e, 0xf2, 0xf2, 0x5b, 0x3c, 0x16, 0xca, 0xdc, 0x46, 0xee, 0x42, 0x86,
-	0x9f, 0x58, 0xa8, 0x73, 0x75, 0x4f, 0x49, 0x10, 0xcb, 0xd9, 0x8f, 0x0d, 0xdb, 0x18, 0x68, 0x62,
-	0x04, 0x79, 0x1f, 0x16, 0x07, 0xd6, 0xc8, 0x74, 0x45, 0xe0, 0x99, 0x65, 0x28, 0x1f, 0xc0, 0x4c,
-	0x0f, 0x7f, 0xf0, 0x33, 0x38, 0xcd, 0x4d, 0x0f, 0x29, 0xde, 0x19, 0x1d, 0x3c, 0xca, 0x17, 0xa2,
-	0x47, 0xbe, 0xf2, 0x37, 0x29, 0x90, 0xc5, 0x5c, 0xa8, 0xfb, 0x4d, 0x98, 0x05, 0xdf, 0xe5, 0xd4,
-	0xac, 0x49, 0xde, 0x5d, 0xdf, 0xe3, 0xb8, 0x61, 0x28, 0xd3, 0xd2, 0x25, 0x3e, 0x7f, 0xdf, 0x2b,
-	0x0f, 0x21, 0x6b, 0x0d, 0xb1, 0xe8, 0x57, 0x58, 0xc0, 0xa0, 0xb2, 0x93, 0x34, 0xd8, 0x9f, 0xda,
-	0x4e, 0x93, 0x0f, 0xe0, 0x29, 0x86, 0x37, 0xbc, 0x78, 0x17, 0x96, 0x83, 0x1d, 0x73, 0x9d, 0xb9,
-	0xbf, 0x3e, 0xb6, 0x06, 0xa6, 0x46, 0x58, 0xdf, 0x2e, 0x64, 0xb8, 0xd5, 0x88, 0x15, 0xdc, 0x48,
-	0x32, 0x32, 0xc1, 0xf6, 0x0d, 0x9a, 0xe7, 0x33, 0xb8, 0xd0, 0x32, 0x8d, 0x61, 0xd8, 0xd3, 0xa3,
-	0xde, 0x10, 0xd8, 0xe2, 0xd4, 0x7c, 0x5b, 0x1c, 0xbc, 0x4f, 0xa4, 0xc3, 0xf7, 0x09, 0xe5, 0x29,
-	0x90, 0xa0, 0x6a, 0xb1, 0x16, 0xdf, 0x83, 0x75, 0x2f, 0x41, 0xc2, 0x8e, 0xf1, 0x0c, 0xf9, 0xda,
-	0xdc, 0x4c, 0x4a, 0x93, 0x42, 0x62, 0xb4, 0x4b, 0x67, 0x31, 0x54, 0xc5, 0xf5, 0x2a, 0x3f, 0x78,
-	0x46, 0x84, 0xce, 0x03, 0x29, 0x72, 0x1e, 0xc4, 0xd5, 0x7b, 0xdf, 0x81, 0xac, 0x50, 0x3c, 0x4b,
-	0x64, 0xf2, 0x78, 0x95, 0xbf, 0x94, 0xbc, 0xe8, 0xe4, 0xe5, 0x6e, 0xb1, 0xe5, 0xb7, 0x4d, 0xc8,
-	0xb3, 0xff, 0x9d, 0xa1, 0xd1, 0xf1, 0x2c, 0x67, 0x4c, 0x60, 0x23, 0xfc, 0x84, 0x21, 0xaf, 0xe1,
-	0x6f, 0x96, 0xa1, 0xb1, 0xeb, 0x2d, 0x83, 0x2f, 0x8e, 0x26, 0xd6, 0xac, 0x75, 0x99, 0xa3, 0x5b,
-	0x5f, 0x99, 0xd4, 0xd6, 0x51, 0xc9, 0x22, 0x97, 0x85, 0x94, 0x06, 0xd3, 0xe4, 0x77, 0xa3, 0xc4,
-	0x4c, 0xa0, 0x9b, 0x1d, 0xee, 0x4a, 0x17, 0xc8, 0x81, 0x6d, 0x0c, 0x9f, 0x54, 0xed, 0xde, 0x19,
-	0xb5, 0x2b, 0x4f, 0x0c, 0xf3, 0x94, 0x3a, 0xfe, 0x82, 0x48, 0x81, 0x05, 0xb9, 0x0b, 0x0b, 0x5f,
-	0xf6, 0xcc, 0xae, 0x88, 0x44, 0x2f, 0xc7, 0xdc, 0x2d, 0x23, 0x62, 0x30, 0x79, 0xc0, 0x31, 0xca,
-	0x2b, 0xb0, 0x56, 0xe9, 0x8f, 0x1c, 0x97, 0xda, 0xe7, 0xc4, 0xec, 0xdf, 0x93, 0x60, 0x85, 0x39,
-	0xf3, 0x99, 0x6f, 0x9f, 0x87, 0x90, 0xd3, 0xe8, 0x53, 0xea, 0xb8, 0xf7, 0x1f, 0x88, 0x0c, 0xe1,
-	0xf5, 0xc9, 0x0c, 0x21, 0x38, 0x62, 0xc7, 0x63, 0xe7, 0xae, 0xec, 0x8f, 0x2e, 0x7e, 0x07, 0x56,
-	0x42, 0x5d, 0x41, 0x67, 0x4e, 0x9f, 0xe7, 0xcc, 0xcf, 0x61, 0x35, 0xa4, 0xc5, 0x21, 0x0a, 0x2c,
-	0x8b, 0xdf, 0x15, 0x8c, 0xd0, 0x5c, 0x4c, 0x88, 0x46, 0xaa, 0x91, 0xd9, 0x88, 0x2a, 0xeb, 0xf5,
-	0xe9, 0x33, 0xd0, 0xc2, 0x83, 0x94, 0xbf, 0x92, 0x60, 0x1d, 0x6f, 0xee, 0xe7, 0x7b, 0xef, 0x7d,
-	0xc8, 0xd4, 0x83, 0xf5, 0xdc, 0xb7, 0xe2, 0x4b, 0x00, 0x13, 0x82, 0xc2, 0x45, 0xe8, 0xfa, 0xd7,
-	0x2e, 0x42, 0xff, 0xa7, 0x04, 0x1b, 0x13, 0x9a, 0xc4, 0xce, 0x9f, 0x40, 0xde, 0xab, 0x86, 0x39,
-	0x62, 0x4b, 0xdf, 0x3b, 0x1f, 0x26, 0x1f, 0xbc, 0xd3, 0xf2, 0x46, 0x72, 0xa8, 0x63, 0x49, 0x63,
-	0x83, 0x4a, 0x05, 0x0c, 0xaa, 0x68, 0xc0, 0x6a, 0x78, 0x48, 0xcc, 0x34, 0xee, 0x04, 0xa7, 0xb1,
-	0xb4, 0xf7, 0xe2, 0x64, 0xc6, 0x32, 0x81, 0x23, 0x38, 0xd7, 0xff, 0x5d, 0xf0, 0xbf, 0x60, 0x34,
-	0xac, 0xee, 0x64, 0x7e, 0x21, 0x43, 0xba, 0x33, 0x1c, 0xa1, 0x70, 0x49, 0x63, 0x3f, 0x59, 0x30,
-	0x1a, 0xd0, 0x81, 0xee, 0x5a, 0xae, 0xd1, 0x17, 0x77, 0xaa, 0xdc, 0x80, 0x0e, 0xf0, 0xa3, 0x02,
-	0xbb, 0x3a, 0xb1, 0x4e, 0xbc, 0xc6, 0xf0, 0x4b, 0x55, 0x76, 0x40, 0x07, 0x78, 0x89, 0x11, 0x5d,
-	0x8f, 0x6d, 0x4a, 0xbd, 0x5b, 0xd5, 0x80, 0x0e, 0xf6, 0x6d, 0x8a, 0x75, 0x65, 0xe3, 0xec, 0x54,
-	0xef, 0x5b, 0x06, 0xcf, 0xf9, 0xd3, 0x5a, 0xd6, 0x38, 0x3b, 0xad, 0x5b, 0x06, 0x2f, 0x23, 0xf1,
-	0x9c, 0x36, 0x9b, 0x50, 0xdf, 0x88, 0x14, 0x2a, 0x3e, 0x80, 0xc5, 0x6e, 0xcf, 0xf9, 0xd2, 0xfb,
-	0x7a, 0xf1, 0x4a, 0xd2, 0xd7, 0x0b, 0x36, 0xdb, 0x9d, 0x2a, 0xe3, 0xe4, 0x9b, 0xc1, 0x47, 0x91,
-	0x3d, 0x58, 0x1c, 0x5a, 0x96, 0x5f, 0x13, 0xde, 0x9c, 0xf6, 0xf1, 0x43, 0xe3, 0xac, 0x2c, 0xba,
-	0x0d, 0x4e, 0x07, 0xae, 0xde, 0x1b, 0x7a, 0x09, 0x2a, 0x6b, 0xd6, 0x86, 0xac, 0xa3, 0x6b, 0xb8,
-	0x06, 0xeb, 0x58, 0xe6, 0x1d, 0xac, 0x59, 0xc3, 0xea, 0xd5, 0x13, 0xcb, 0x71, 0x31, 0xe8, 0xf1,
-	0x82, 0x85, 0xdf, 0x26, 0x47, 0xb0, 0x84, 0xb1, 0x52, 0xd4, 0xa6, 0xe5, 0x84, 0xb0, 0x11, 0x9c,
-	0x06, 0xfb, 0x27, 0xe8, 0x03, 0x60, 0xfa, 0x84, 0xe2, 0xe7, 0x00, 0xe3, 0x59, 0xc6, 0xd8, 0xcf,
-	0xbb, 0x61, 0xfb, 0xd9, 0x4e, 0x52, 0xe4, 0xdd, 0xaa, 0x02, 0xc6, 0xc3, 0xee, 0xf5, 0x11, 0xd5,
-	0x73, 0xf9, 0xd9, 0x1f, 0x4b, 0xb0, 0x2a, 0xa4, 0x8b, 0x00, 0x1b, 0xd8, 0x6e, 0x69, 0xb6, 0xed,
-	0xe6, 0xf6, 0x9a, 0xf2, 0xed, 0x35, 0x70, 0xd2, 0xa4, 0x43, 0x27, 0xcd, 0x9e, 0x57, 0x6e, 0x5d,
-	0x98, 0xbe, 0xb1, 0x6c, 0x42, 0x5e, 0x31, 0xf6, 0xe7, 0x61, 0xb3, 0x62, 0xd3, 0x2e, 0x35, 0xdd,
-	0x9e, 0xd1, 0xe7, 0x3e, 0x54, 0x7e, 0x3e, 0xb2, 0xfd, 0x00, 0xf6, 0x31, 0x40, 0xc7, 0xef, 0x17,
-	0xc7, 0xfe, 0xe4, 0x02, 0xe2, 0x90, 0xb1, 0x1c, 0x2d, 0x30, 0x46, 0xa9, 0xc2, 0xb5, 0x04, 0x0d,
-	0x22, 0xde, 0xbc, 0x08, 0x2b, 0x63, 0xf6, 0xf1, 0xf1, 0xbf, 0x3c, 0x26, 0xd6, 0xba, 0xca, 0xa3,
-	0x49, 0x29, 0x07, 0x78, 0xdd, 0xf6, 0x80, 0x96, 0x63, 0x80, 0xde, 0x98, 0x0c, 0x5b, 0x38, 0x26,
-	0x01, 0xa9, 0x0a, 0xd7, 0x93, 0x74, 0xcc, 0x03, 0xf5, 0x7b, 0x50, 0x9c, 0x98, 0xf0, 0xc3, 0x96,
-	0x87, 0xf3, 0x83, 0x18, 0x9c, 0x31, 0xf5, 0x8a, 0xb7, 0x12, 0x30, 0xde, 0x83, 0xab, 0xb1, 0xc2,
-	0xe7, 0x01, 0xf8, 0xe7, 0x12, 0x2c, 0x07, 0x15, 0xcc, 0x34, 0x2a, 0x72, 0x95, 0x4e, 0x4d, 0xbf,
-	0x4a, 0xa7, 0xa3, 0x57, 0xe9, 0x22, 0xe4, 0xbc, 0x9b, 0xb3, 0xc8, 0x8f, 0xfc, 0x76, 0xe0, 0xf2,
-	0xbb, 0x18, 0xba, 0xfc, 0x3e, 0x87, 0xb5, 0x88, 0x61, 0xcd, 0x86, 0xf4, 0x06, 0x2c, 0x1b, 0x9d,
-	0x0e, 0x5e, 0xae, 0x30, 0xfc, 0x70, 0xac, 0x4b, 0x82, 0x86, 0x59, 0x17, 0xbf, 0x90, 0x23, 0xcb,
-	0x18, 0x2e, 0x08, 0xd2, 0x7d, 0xca, 0x12, 0x62, 0x39, 0x6a, 0x2b, 0x33, 0x2f, 0xd3, 0xd0, 0xb6,
-	0xbe, 0xa0, 0x1d, 0x77, 0x5c, 0xd9, 0xc8, 0x0b, 0x4a, 0x0d, 0x8f, 0x88, 0x2f, 0x1c, 0xcb, 0x0c,
-	0x68, 0xcd, 0xb2, 0x36, 0x53, 0x19, 0x72, 0x14, 0xd5, 0x64, 0xb9, 0x69, 0xd8, 0x74, 0x66, 0xda,
-	0x5c, 0x3d, 0x68, 0xc4, 0x61, 0x29, 0xc2, 0x46, 0xa2, 0x16, 0x98, 0x9e, 0xcf, 0x02, 0xf7, 0x61,
-	0x2b, 0x4e, 0x41, 0x30, 0x68, 0xcc, 0x04, 0xb4, 0x0b, 0xdb, 0xc9, 0x72, 0x04, 0xd4, 0x8f, 0x63,
-	0xa0, 0xce, 0x17, 0x7d, 0x0e, 0x62, 0xb5, 0x84, 0x43, 0xc7, 0x4c, 0x70, 0x1f, 0xc3, 0x8d, 0x29,
-	0x82, 0x04, 0xde, 0x72, 0x0c, 0xde, 0x39, 0x83, 0xd0, 0x87, 0xb0, 0x31, 0xee, 0xa9, 0xd2, 0x3e,
-	0x75, 0xe7, 0xc3, 0x59, 0x84, 0xc2, 0xe4, 0x78, 0x71, 0xe5, 0xfa, 0x18, 0xae, 0x8c, 0xfb, 0x1e,
-	0x18, 0xfd, 0x5e, 0xd7, 0x98, 0x53, 0xfa, 0x66, 0x30, 0xb6, 0x8d, 0x25, 0x08, 0xf9, 0xff, 0x2a,
-	0x01, 0xe1, 0x97, 0xab, 0x23, 0xe6, 0x47, 0x9e, 0xe4, 0xa9, 0x77, 0xbb, 0x70, 0x1d, 0x24, 0x15,
-	0xad, 0x83, 0x7c, 0x32, 0x2e, 0x15, 0xa4, 0xa7, 0xbe, 0x80, 0x08, 0x6a, 0xfc, 0x16, 0x8a, 0x05,
-	0x97, 0xbd, 0x3a, 0x9c, 0xd0, 0x23, 0x66, 0xfc, 0x6f, 0x92, 0x57, 0xc4, 0x3a, 0x31, 0x07, 0xdf,
-	0xd4, 0x9c, 0xeb, 0xd1, 0x39, 0xef, 0x25, 0xcc, 0x39, 0xac, 0xf3, 0x5b, 0x98, 0xf5, 0x06, 0x5c,
-	0x8e, 0x68, 0x12, 0xf3, 0xfe, 0xb1, 0x5f, 0x97, 0xe4, 0x5f, 0x3d, 0x66, 0x9a, 0xf6, 0xfd, 0xf1,
-	0xbc, 0xf8, 0xed, 0xe7, 0xcd, 0xa4, 0x72, 0x59, 0x50, 0xe6, 0xb7, 0x30, 0xad, 0xf7, 0xbc, 0x4d,
-	0xf3, 0x14, 0x09, 0xf7, 0x8d, 0x14, 0xdd, 0xa4, 0x89, 0xa2, 0xdb, 0x9e, 0x37, 0xeb, 0x2a, 0x9d,
-	0x75, 0xd6, 0xca, 0xba, 0xa7, 0xcc, 0x1b, 0x23, 0x96, 0x90, 0xc2, 0xf5, 0xe6, 0x90, 0x9a, 0x22,
-	0x27, 0x8b, 0x2b, 0xf2, 0xc6, 0x15, 0x26, 0xe6, 0xad, 0xd3, 0x29, 0x1f, 0xc2, 0x56, 0xa2, 0x1a,
-	0x31, 0xed, 0xa9, 0xf0, 0x7f, 0x49, 0x82, 0xad, 0xe0, 0xa8, 0x7d, 0xdb, 0x1a, 0x88, 0xba, 0x4d,
-	0x75, 0x1a, 0xd0, 0xab, 0x90, 0xe7, 0x0f, 0x82, 0x02, 0x05, 0x7e, 0x4e, 0xa8, 0x75, 0xe7, 0xaf,
-	0x29, 0x7f, 0x04, 0xdb, 0xc9, 0x20, 0x66, 0x99, 0x46, 0x60, 0xe7, 0x82, 0x21, 0x75, 0xd6, 0x9d,
-	0x0b, 0x85, 0xd1, 0xb7, 0x3c, 0x7a, 0xcd, 0x64, 0xe0, 0x66, 0xf2, 0x79, 0xe5, 0xd0, 0x73, 0x25,
-	0x7f, 0xd0, 0xff, 0xb3, 0xe0, 0xa8, 0x68, 0xb0, 0xce, 0x29, 0xfe, 0x29, 0xf4, 0xb5, 0xcb, 0xbf,
-	0x4a, 0x1d, 0x36, 0x26, 0x64, 0x0a, 0x7c, 0x6f, 0x42, 0x96, 0x2b, 0xf6, 0x8a, 0x01, 0x89, 0x00,
-	0x3d, 0x3e, 0xe5, 0xef, 0x24, 0xb8, 0x2a, 0xb6, 0x50, 0xdc, 0xed, 0xc3, 0x86, 0x3d, 0x35, 0x4a,
-	0x1c, 0xfb, 0x8f, 0xf3, 0x78, 0x90, 0x78, 0x3f, 0xc9, 0x3a, 0xe2, 0x44, 0x7f, 0xd3, 0x8f, 0xf5,
-	0x3e, 0x82, 0xcd, 0x78, 0x6d, 0xe3, 0x88, 0x31, 0x7e, 0x94, 0xe5, 0xcd, 0x05, 0xfc, 0xe7, 0x58,
-	0x5d, 0xe5, 0x67, 0xa3, 0x02, 0x34, 0x8a, 0x1f, 0xc6, 0x66, 0x5a, 0x8a, 0x88, 0xf4, 0xd4, 0x84,
-	0xf4, 0x2d, 0xb8, 0x96, 0x20, 0x5d, 0x98, 0xea, 0x4f, 0x24, 0xb8, 0x1e, 0xe6, 0x98, 0x30, 0x9a,
-	0xa9, 0x08, 0x5a, 0x91, 0xcd, 0xf8, 0xce, 0x39, 0x9b, 0x11, 0x95, 0xfe, 0x4d, 0xef, 0xc7, 0xa7,
-	0x5e, 0x30, 0x8a, 0x51, 0x28, 0xb6, 0xe4, 0x9d, 0xc9, 0xf2, 0x55, 0xa2, 0xc5, 0x8e, 0x39, 0x95,
-	0x2b, 0xb0, 0x21, 0x6e, 0xe8, 0xd1, 0x39, 0x28, 0x27, 0x50, 0x98, 0xec, 0x12, 0xda, 0xee, 0x40,
-	0xb6, 0xc3, 0xfb, 0x84, 0xcb, 0x6d, 0x25, 0xdd, 0xba, 0xbd, 0x02, 0xab, 0xc7, 0xaf, 0xdc, 0x86,
-	0xcb, 0x82, 0x16, 0x89, 0x23, 0x81, 0x0b, 0xbe, 0x14, 0xbc, 0xe0, 0x2b, 0x9f, 0xc0, 0x7a, 0x74,
-	0x84, 0x80, 0x71, 0x1b, 0x16, 0x18, 0x8f, 0xc0, 0x30, 0xfd, 0xe6, 0x8f, 0x9c, 0xca, 0x3f, 0x48,
-	0xb0, 0x29, 0x84, 0xe1, 0x07, 0xdc, 0x09, 0xbb, 0xb8, 0x03, 0xe0, 0xbd, 0xbb, 0xb0, 0x5d, 0x21,
-	0xf8, 0xdc, 0x6f, 0xdc, 0x2d, 0xc6, 0x4c, 0xde, 0x81, 0x1c, 0x0e, 0xa5, 0xa2, 0x1c, 0x3d, 0x7d,
-	0x60, 0x96, 0xf1, 0xaa, 0x66, 0xf8, 0xcb, 0x77, 0x7a, 0xae, 0x2f, 0xdf, 0xca, 0x31, 0x5c, 0x4b,
-	0x98, 0xcc, 0x38, 0xca, 0xe2, 0x07, 0x6a, 0x27, 0x31, 0xca, 0xf2, 0xcf, 0xdd, 0x9a, 0x60, 0x53,
-	0x86, 0xfe, 0xa6, 0x63, 0x47, 0xa5, 0x4f, 0x0d, 0x7b, 0xbc, 0x34, 0x63, 0xa0, 0xd2, 0x7c, 0x9f,
-	0xe8, 0xaf, 0x40, 0x8e, 0xbf, 0x38, 0x10, 0xfe, 0x9c, 0xd6, 0xb2, 0xd8, 0xae, 0x75, 0x95, 0xab,
-	0x70, 0x25, 0x46, 0xa3, 0x70, 0xe4, 0x08, 0x1c, 0xd5, 0x36, 0x1c, 0xfa, 0x53, 0x85, 0x23, 0x34,
-	0x72, 0x38, 0xa5, 0xff, 0x4e, 0x41, 0x86, 0x97, 0xa9, 0xc8, 0x1a, 0x2c, 0xb5, 0xda, 0xe5, 0xf6,
-	0x49, 0x4b, 0x6f, 0x34, 0x1b, 0xaa, 0xfc, 0x42, 0x80, 0x50, 0x6b, 0xd4, 0xda, 0xb2, 0x44, 0x56,
-	0x20, 0x2f, 0x08, 0xcd, 0xfb, 0x72, 0x8a, 0x10, 0x58, 0xf5, 0x9a, 0xfb, 0xfb, 0xf5, 0x5a, 0x43,
-	0x95, 0xd3, 0x44, 0x86, 0x65, 0x41, 0x53, 0x35, 0xad, 0xa9, 0xc9, 0x0b, 0xa4, 0x00, 0x97, 0x7c,
-	0xb1, 0x6d, 0xbd, 0xd6, 0xd0, 0xbf, 0x7b, 0xd2, 0xd4, 0x4e, 0x8e, 0xe4, 0x45, 0xb2, 0x01, 0x17,
-	0x45, 0x4f, 0x55, 0xad, 0x34, 0x8f, 0x8e, 0x6a, 0xad, 0x56, 0xad, 0xd9, 0x90, 0x33, 0x64, 0x1d,
-	0x88, 0xe8, 0x38, 0x2a, 0xd7, 0x1a, 0x6d, 0xb5, 0x51, 0x6e, 0x54, 0x54, 0x39, 0x1b, 0x18, 0xd0,
-	0x6a, 0x37, 0xb5, 0xf2, 0x81, 0xaa, 0x57, 0x9b, 0x0f, 0x1b, 0x72, 0x8e, 0x5c, 0x85, 0x8d, 0x68,
-	0x87, 0x7a, 0xa0, 0x95, 0xab, 0x6a, 0x55, 0xce, 0x07, 0x46, 0x35, 0x54, 0xb5, 0xda, 0xd2, 0x35,
-	0xf5, 0x5e, 0xb3, 0xd9, 0x96, 0x81, 0x6c, 0x42, 0x21, 0x32, 0x4a, 0x53, 0xef, 0x95, 0xeb, 0xa8,
-	0x6c, 0x89, 0x6c, 0xc3, 0x66, 0x54, 0xa6, 0x56, 0x7b, 0xc0, 0x78, 0x8e, 0xeb, 0xe5, 0x8a, 0x2a,
-	0x2f, 0x93, 0x17, 0x61, 0x2b, 0x6e, 0x66, 0x7a, 0xa3, 0xe9, 0x0d, 0x91, 0x57, 0xc8, 0x2a, 0x80,
-	0x3f, 0x97, 0x4f, 0xe5, 0xd5, 0xd2, 0x0f, 0x25, 0x00, 0xfe, 0xf1, 0x06, 0x5f, 0xa6, 0x5c, 0x02,
-	0x19, 0xc5, 0x6a, 0x7a, 0xfb, 0xb3, 0x63, 0xd5, 0x5b, 0xf9, 0x08, 0x75, 0xbf, 0x56, 0x57, 0x65,
-	0x89, 0x5c, 0x86, 0x0b, 0x41, 0xea, 0xbd, 0x7a, 0xb3, 0xc2, 0xb6, 0x61, 0x1d, 0x48, 0x90, 0xdc,
-	0xbc, 0xf7, 0x89, 0x5a, 0x69, 0xcb, 0x69, 0x72, 0x05, 0x2e, 0x07, 0xe9, 0x95, 0xfa, 0x49, 0xab,
-	0xad, 0x6a, 0x6a, 0x55, 0x5e, 0x88, 0x4a, 0x3a, 0xd0, 0xca, 0xc7, 0x87, 0xf2, 0x62, 0xe9, 0x77,
-	0x25, 0xc8, 0xf0, 0x27, 0x78, 0x6c, 0x1f, 0xf7, 0x5b, 0x21, 0x4c, 0x17, 0x60, 0xc5, 0xa3, 0xdc,
-	0x6b, 0x6b, 0xfb, 0x2d, 0x59, 0x0a, 0x32, 0xa9, 0x9f, 0xb6, 0xdf, 0x96, 0x53, 0x41, 0xca, 0xfe,
-	0x49, 0x8b, 0x19, 0xc4, 0x1a, 0x2c, 0xf9, 0x82, 0xf6, 0x5b, 0xf2, 0x42, 0x90, 0xf0, 0x60, 0xbf,
-	0x25, 0x2f, 0x06, 0x09, 0x9f, 0xee, 0xb7, 0xe4, 0x4c, 0x90, 0xf0, 0xf9, 0x7e, 0x4b, 0xce, 0x96,
-	0x7e, 0x24, 0xc1, 0xe5, 0xd8, 0xaf, 0x5e, 0xe4, 0x06, 0x5c, 0x43, 0xf0, 0xba, 0x98, 0x4e, 0xe5,
-	0xb0, 0xdc, 0x38, 0x50, 0x43, 0xb8, 0x6f, 0xc2, 0x8d, 0x44, 0x96, 0xa3, 0x66, 0xb5, 0xb6, 0x5f,
-	0x53, 0xab, 0xb2, 0x44, 0x14, 0xb8, 0x9e, 0xc8, 0x56, 0xae, 0x32, 0x4b, 0x4a, 0x91, 0x97, 0x60,
-	0x3b, 0x91, 0xa7, 0xaa, 0xd6, 0xd5, 0xb6, 0x5a, 0x95, 0xd3, 0x25, 0x17, 0x96, 0x83, 0xaf, 0x94,
-	0xd0, 0x9a, 0xd5, 0x07, 0xaa, 0x56, 0x6b, 0x7f, 0x16, 0x02, 0xc6, 0xec, 0x32, 0x44, 0x2f, 0xd7,
-	0xcb, 0xda, 0x91, 0x2c, 0xb1, 0x8d, 0x0b, 0x77, 0x3c, 0x2c, 0x6b, 0x8d, 0x5a, 0xe3, 0x40, 0x4e,
-	0xa1, 0x33, 0x45, 0x64, 0xb5, 0x6b, 0xfb, 0x9f, 0xc9, 0xe9, 0xd2, 0xaf, 0x4a, 0xb0, 0x1c, 0x8c,
-	0x0d, 0x4c, 0xad, 0xa6, 0xb6, 0x9a, 0x27, 0x5a, 0x25, 0xbc, 0x1e, 0x05, 0xb8, 0x14, 0xa6, 0x3f,
-	0x68, 0xd6, 0x4f, 0x8e, 0x98, 0x7d, 0xc5, 0x8c, 0xa8, 0xaa, 0x72, 0x8a, 0xe1, 0x09, 0xd3, 0x85,
-	0x29, 0xc9, 0x69, 0x36, 0x87, 0x70, 0x17, 0xae, 0x8c, 0xbc, 0x50, 0xfa, 0x81, 0x04, 0x6b, 0x18,
-	0x6e, 0xf8, 0x8b, 0x01, 0x44, 0x54, 0x84, 0xf5, 0x72, 0x5d, 0xd5, 0xda, 0x7a, 0xb9, 0xd2, 0xae,
-	0x35, 0x1b, 0x21, 0x54, 0x9b, 0x50, 0x98, 0xec, 0xe3, 0x6b, 0x2a, 0x4b, 0xf1, 0xbd, 0x15, 0x4d,
-	0x2d, 0xb7, 0x19, 0xbe, 0xd8, 0xde, 0x93, 0xe3, 0x2a, 0xeb, 0x4d, 0x97, 0xbe, 0xf0, 0x1e, 0x07,
-	0x04, 0xde, 0x6e, 0xb0, 0x21, 0x7c, 0xda, 0xde, 0x98, 0xe3, 0xb2, 0x56, 0x3e, 0xf2, 0xc0, 0x5c,
-	0x85, 0x8d, 0xb8, 0xde, 0xe6, 0xfe, 0xbe, 0x2c, 0xb1, 0x59, 0xc4, 0x76, 0x36, 0xe4, 0x54, 0x69,
-	0x0f, 0xb2, 0xe2, 0xaf, 0x07, 0x48, 0x0e, 0x16, 0x84, 0xb4, 0x2c, 0xa4, 0xeb, 0xcd, 0x87, 0xb2,
-	0x44, 0x00, 0x32, 0x47, 0x6a, 0xb5, 0x76, 0x72, 0x24, 0xa7, 0x58, 0xf7, 0x61, 0xed, 0xe0, 0x50,
-	0x4e, 0x97, 0x7e, 0x01, 0xf2, 0xfe, 0x9f, 0x0f, 0xb0, 0xa5, 0xae, 0x35, 0xf5, 0x63, 0xad, 0xc9,
-	0x5c, 0x5e, 0x6f, 0xa9, 0xdf, 0x3d, 0x51, 0x1b, 0xed, 0x5a, 0xb9, 0x2e, 0xbf, 0xc0, 0x7c, 0x36,
-	0xd0, 0xa5, 0x95, 0x1b, 0xd5, 0x26, 0x33, 0x96, 0x0b, 0xb0, 0x12, 0x20, 0x57, 0xef, 0x71, 0x23,
-	0x09, 0x91, 0x74, 0x4d, 0x3d, 0x6a, 0xb2, 0xb5, 0x60, 0x11, 0x3b, 0xd0, 0x53, 0x39, 0x6a, 0xc9,
-	0x0b, 0xa5, 0x1f, 0xa6, 0x60, 0x29, 0xf0, 0xc2, 0x83, 0xe9, 0x11, 0xf3, 0x63, 0x71, 0x2b, 0x68,
-	0x36, 0x21, 0xf2, 0xb1, 0xda, 0xa8, 0x32, 0x9b, 0x0c, 0x2e, 0x08, 0xef, 0x29, 0x3f, 0x28, 0xd7,
-	0xea, 0xe5, 0x7b, 0x75, 0x61, 0x3a, 0xe1, 0xbe, 0x76, 0xbb, 0x5c, 0x39, 0x64, 0x6e, 0x32, 0xd1,
-	0x55, 0x55, 0x45, 0xd7, 0x42, 0x60, 0xfd, 0xc7, 0x5d, 0xed, 0xca, 0x21, 0x53, 0xb7, 0xc8, 0xac,
-	0x34, 0xd4, 0xc9, 0xcf, 0x99, 0xcc, 0x04, 0x40, 0xcf, 0x21, 0xb3, 0xe4, 0x3a, 0x14, 0x43, 0x3d,
-	0x6d, 0xed, 0x33, 0xa1, 0x8d, 0x49, 0xcc, 0x4d, 0x8c, 0xd4, 0x54, 0x16, 0xbe, 0x55, 0x39, 0x5f,
-	0xfa, 0x0d, 0x09, 0x96, 0x83, 0x4f, 0x8c, 0x23, 0xca, 0xc7, 0x47, 0xe5, 0x35, 0xb8, 0x12, 0xa5,
-	0xb7, 0xf5, 0x63, 0x4d, 0x6d, 0xa9, 0x0d, 0x76, 0x70, 0x5e, 0x02, 0x39, 0xdc, 0x7d, 0x72, 0xcc,
-	0x03, 0x77, 0x98, 0x8a, 0xa7, 0x59, 0x3a, 0xb2, 0xa0, 0x78, 0x3c, 0x8a, 0xc3, 0x6c, 0xa1, 0xf4,
-	0x73, 0xb0, 0x12, 0xfa, 0xd3, 0x2a, 0x7e, 0xf4, 0xf1, 0xf3, 0x89, 0x1b, 0x97, 0x7e, 0x54, 0x3e,
-	0x68, 0xa8, 0xed, 0x5a, 0x45, 0x7e, 0x81, 0x1f, 0xa4, 0xa1, 0xce, 0x56, 0x8b, 0x05, 0x3b, 0x3c,
-	0x12, 0x43, 0xf4, 0xc6, 0x83, 0x23, 0x55, 0x4e, 0x95, 0x6e, 0xc1, 0x8a, 0xc8, 0x15, 0x1a, 0x96,
-	0xdb, 0x7b, 0xfc, 0x8c, 0x71, 0x0a, 0x6f, 0x17, 0xa1, 0x86, 0x83, 0x7c, 0xa1, 0x44, 0x61, 0x29,
-	0xf0, 0xd0, 0x99, 0xed, 0x26, 0xdf, 0x5b, 0x6f, 0x57, 0x3e, 0x6d, 0xab, 0x5a, 0x03, 0x0d, 0x37,
-	0xda, 0xc5, 0x4e, 0x74, 0xec, 0x92, 0xd8, 0x19, 0x1b, 0xdb, 0xa5, 0xb7, 0x1e, 0xd6, 0xda, 0x95,
-	0x43, 0x39, 0x55, 0x6a, 0xc3, 0x6a, 0x73, 0xc8, 0x32, 0xc0, 0x9e, 0x65, 0xee, 0xf7, 0x8d, 0x53,
-	0x87, 0xad, 0x65, 0xf3, 0x58, 0xdf, 0xaf, 0x97, 0x0f, 0x5a, 0xfa, 0x49, 0xe3, 0x7e, 0x03, 0xe1,
-	0x30, 0x37, 0xf0, 0xa9, 0xb8, 0x27, 0x18, 0x46, 0x7d, 0x12, 0xdf, 0x6e, 0x7d, 0xbf, 0xa9, 0x55,
-	0x54, 0x39, 0xb5, 0xf7, 0xb7, 0x8b, 0x40, 0x02, 0xc5, 0x14, 0xef, 0x8b, 0xde, 0xf7, 0x25, 0xc8,
-	0xfb, 0x19, 0x27, 0x99, 0xfc, 0x63, 0xb2, 0x84, 0x7b, 0x45, 0xf1, 0xd5, 0x19, 0x38, 0x45, 0xfa,
-	0xb7, 0xfd, 0xfd, 0x7f, 0xfe, 0x8f, 0xdf, 0x4e, 0x15, 0x95, 0xcb, 0xbb, 0x67, 0x6f, 0xee, 0x8a,
-	0x0b, 0xc4, 0x2e, 0xf5, 0xd8, 0xee, 0x4a, 0x25, 0xf2, 0x1c, 0xb2, 0xe2, 0x52, 0x40, 0x5e, 0x4e,
-	0x92, 0x1b, 0xbe, 0x67, 0x14, 0x5f, 0x39, 0x97, 0x4f, 0x68, 0xbf, 0x8e, 0xda, 0x0b, 0xca, 0xc5,
-	0xa0, 0xf6, 0x1e, 0x67, 0x62, 0xba, 0x7f, 0x5f, 0x82, 0xd5, 0x70, 0xde, 0x4d, 0xde, 0x48, 0x92,
-	0x1d, 0x7b, 0xd9, 0x28, 0xee, 0xcc, 0xca, 0x2e, 0x10, 0xbd, 0x8c, 0x88, 0xb6, 0x95, 0xab, 0x41,
-	0x44, 0x98, 0xb9, 0x86, 0x57, 0xe5, 0x07, 0x12, 0xc0, 0x38, 0x9b, 0x26, 0xaf, 0x4e, 0x55, 0x13,
-	0xcc, 0xf1, 0x8b, 0xa5, 0x59, 0x58, 0x05, 0x1a, 0x05, 0xd1, 0x6c, 0x2a, 0x1b, 0x93, 0x68, 0xf0,
-	0x01, 0x6e, 0x08, 0x09, 0x26, 0xd2, 0xe7, 0x20, 0x09, 0xa6, 0xf7, 0xe7, 0x20, 0x09, 0xe5, 0xe5,
-	0xd3, 0x90, 0x50, 0xc6, 0x78, 0x57, 0x2a, 0xed, 0xfd, 0xcb, 0x32, 0x5c, 0x98, 0x28, 0x09, 0x92,
-	0x5f, 0x96, 0x20, 0xc3, 0x8b, 0x1b, 0x64, 0x77, 0x42, 0xe1, 0xf4, 0x42, 0x65, 0xf1, 0xf6, 0xec,
-	0x03, 0x04, 0xce, 0x4d, 0xc4, 0xb9, 0xae, 0x5c, 0x60, 0x38, 0x79, 0xb5, 0x61, 0x97, 0xbf, 0x31,
-	0x63, 0x6b, 0xf5, 0x47, 0x12, 0x90, 0xc9, 0x42, 0x1f, 0xb9, 0x3d, 0xf5, 0xb9, 0x59, 0x4c, 0x61,
-	0xb2, 0xf8, 0xe6, 0x1c, 0x23, 0xe2, 0x56, 0x30, 0x84, 0xec, 0xb1, 0x6d, 0x0d, 0x7a, 0x5d, 0x86,
-	0xcf, 0x81, 0x0c, 0x2f, 0x09, 0x92, 0x97, 0x12, 0x14, 0x84, 0xaa, 0x8c, 0xc5, 0x9b, 0xe7, 0x70,
-	0x4d, 0x59, 0x94, 0x2e, 0xb2, 0x30, 0xa5, 0x5f, 0x8d, 0x1d, 0x3c, 0x49, 0x5e, 0xc4, 0xbf, 0x5f,
-	0x3e, 0x8f, 0x4d, 0xe8, 0xbd, 0x86, 0x7a, 0x37, 0x14, 0x12, 0xd0, 0x1b, 0xf0, 0xee, 0x5f, 0x0c,
-	0x46, 0xb7, 0xa4, 0xbf, 0x02, 0x99, 0xf0, 0xe8, 0x5b, 0xe7, 0x33, 0x0a, 0xf5, 0x5b, 0xa8, 0xfe,
-	0x8a, 0x72, 0x29, 0xa0, 0x3e, 0xe4, 0xc4, 0xbf, 0x23, 0x8d, 0x1f, 0x09, 0x09, 0x13, 0x7d, 0x7d,
-	0x9e, 0xa2, 0x60, 0xf1, 0x8d, 0x19, 0xb9, 0x05, 0xa0, 0x9b, 0x08, 0x68, 0x4b, 0x29, 0x06, 0x00,
-	0x79, 0x85, 0xa2, 0x80, 0x95, 0xfe, 0x81, 0x04, 0x6b, 0x91, 0xba, 0x1b, 0x39, 0x4f, 0x53, 0xb8,
-	0xfa, 0x57, 0xdc, 0x99, 0x95, 0x3d, 0x2e, 0xec, 0x45, 0x91, 0xd9, 0x9c, 0x99, 0x41, 0xfb, 0x53,
-	0x89, 0x3f, 0x25, 0x0d, 0x55, 0xc8, 0x62, 0xfc, 0x7a, 0x7a, 0xf1, 0xae, 0x78, 0x7b, 0xf6, 0x01,
-	0x02, 0xe0, 0x2d, 0x04, 0xa8, 0x28, 0xd7, 0xe2, 0x00, 0x86, 0x36, 0xd5, 0x81, 0x0c, 0x4f, 0x04,
-	0x12, 0x7d, 0x28, 0xf4, 0x15, 0x28, 0xd1, 0x87, 0xc2, 0x9f, 0x70, 0x62, 0x7d, 0x88, 0xbf, 0xd5,
-	0xf6, 0x1d, 0x77, 0xaa, 0xd2, 0xd0, 0x87, 0x9d, 0x29, 0x8e, 0x7b, 0xae, 0xd2, 0x2e, 0xf5, 0x94,
-	0x5a, 0xb0, 0x88, 0x1f, 0x0d, 0xc9, 0x8b, 0x33, 0x7c, 0xba, 0x2c, 0xbe, 0x34, 0x9d, 0x49, 0x68,
-	0xbc, 0x8a, 0x1a, 0x2f, 0x2b, 0x72, 0x40, 0x23, 0x7e, 0xa1, 0x13, 0x91, 0x42, 0x7c, 0xaf, 0x4b,
-	0x8c, 0x14, 0xe1, 0x2f, 0x87, 0x89, 0x91, 0x22, 0xfa, 0xd9, 0x2f, 0x2e, 0x52, 0x8c, 0x4c, 0x4f,
-	0xf1, 0xde, 0xff, 0xe4, 0x61, 0x3d, 0x98, 0x1f, 0xf9, 0x5f, 0x8a, 0x1d, 0xf2, 0x9b, 0x12, 0x2c,
-	0x8b, 0xa8, 0x6b, 0xd9, 0xe5, 0x87, 0x2d, 0xf2, 0xda, 0xe4, 0xa9, 0x96, 0xf8, 0x68, 0xa6, 0xf8,
-	0xfa, 0x6c, 0xcc, 0x71, 0xfe, 0x3b, 0xfe, 0x7c, 0xed, 0x08, 0xdf, 0xdd, 0x35, 0xbe, 0x72, 0x84,
-	0xff, 0xae, 0x8e, 0x21, 0x3d, 0x1f, 0xc5, 0xba, 0xef, 0xb4, 0xc7, 0x51, 0x71, 0x59, 0xcb, 0xb4,
-	0x97, 0x4e, 0xca, 0x2b, 0x08, 0xec, 0x86, 0xb2, 0x99, 0x04, 0x8c, 0x71, 0x33, 0x68, 0x7f, 0x28,
-	0xc1, 0x9a, 0x0f, 0x8d, 0x3f, 0x17, 0x20, 0xe7, 0x2b, 0x0b, 0xbd, 0x6a, 0x28, 0xee, 0xce, 0xcc,
-	0x1f, 0xe7, 0xbb, 0x31, 0xe8, 0x78, 0x05, 0xd7, 0x83, 0xe7, 0xfb, 0xbe, 0xd8, 0xcf, 0x69, 0xf0,
-	0x62, 0x1e, 0xb3, 0x4c, 0x85, 0x17, 0xf7, 0x6c, 0x25, 0x19, 0x9e, 0x1f, 0x56, 0xbc, 0x8d, 0xfd,
-	0x33, 0x09, 0x2e, 0x84, 0xe0, 0xe1, 0xde, 0xde, 0x9e, 0x49, 0x61, 0x70, 0x7b, 0xdf, 0x9c, 0x63,
-	0x84, 0x00, 0x59, 0x42, 0x90, 0x2f, 0x29, 0x5b, 0x53, 0x40, 0x7a, 0x9b, 0xfc, 0x17, 0x12, 0x90,
-	0x20, 0x4c, 0xb1, 0xcf, 0x33, 0x69, 0x0d, 0x6f, 0xf5, 0xde, 0x3c, 0x43, 0x04, 0xd2, 0xd7, 0x10,
-	0xe9, 0x4d, 0x65, 0x3b, 0x19, 0xe9, 0x78, 0xc3, 0x7f, 0x45, 0x02, 0x39, 0xfa, 0xaa, 0x24, 0xee,
-	0xa2, 0x13, 0xff, 0x70, 0x25, 0xee, 0xa2, 0x93, 0xf4, 0x44, 0xe5, 0x06, 0xc2, 0xba, 0xaa, 0xac,
-	0x47, 0x61, 0x8d, 0x13, 0xa1, 0xdf, 0xe2, 0xd9, 0x61, 0xe4, 0x11, 0x0a, 0x29, 0x4d, 0x51, 0x12,
-	0x79, 0xeb, 0x52, 0x7c, 0x6d, 0x26, 0x5e, 0x01, 0xe9, 0x45, 0x84, 0x74, 0x4d, 0x29, 0x44, 0x21,
-	0x9d, 0x09, 0xce, 0xbb, 0x52, 0xe9, 0xde, 0x26, 0x5c, 0xec, 0x58, 0x83, 0xa8, 0xd8, 0x63, 0xe9,
-	0xf3, 0xb4, 0x31, 0xec, 0x3d, 0xca, 0xe0, 0x67, 0x8f, 0xb7, 0xfe, 0x2f, 0x00, 0x00, 0xff, 0xff,
-	0x45, 0xd0, 0x21, 0xb2, 0x3c, 0x47, 0x00, 0x00,
+var fileDescriptor_api_ac37319a59d075f7 = []byte{
+	// 5289 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x7b, 0x5d, 0x8c, 0x1b, 0x47,
+	0x72, 0xbf, 0x87, 0xdc, 0xe5, 0x47, 0xed, 0xd7, 0xa8, 0x25, 0xed, 0x52, 0xd4, 0x4a, 0x5a, 0x8d,
+	0x3f, 0x24, 0xd3, 0xf6, 0xae, 0xbd, 0x92, 0x7c, 0x96, 0xee, 0xef, 0xfb, 0x9b, 0x22, 0x67, 0x77,
+	0x69, 0x2d, 0xc9, 0xbd, 0x21, 0x57, 0xb2, 0x7d, 0xb8, 0x0c, 0x46, 0x64, 0x6b, 0x45, 0x8b, 0x9c,
+	0xa1, 0x66, 0x86, 0x6b, 0xac, 0x81, 0x04, 0x41, 0x80, 0x7c, 0x01, 0xb9, 0x24, 0x40, 0x90, 0x43,
+	0x2e, 0x40, 0x2e, 0x40, 0x82, 0x04, 0x41, 0x0e, 0x09, 0x92, 0xe7, 0x3c, 0x04, 0x79, 0x0c, 0x90,
+	0xbb, 0x97, 0x7b, 0xcf, 0xc3, 0x25, 0x2f, 0x01, 0x82, 0xbc, 0xe7, 0x2d, 0xe8, 0xea, 0x9e, 0xe1,
+	0xcc, 0x70, 0x86, 0x4b, 0xc6, 0x76, 0x5e, 0x24, 0x76, 0x75, 0x75, 0xd5, 0xaf, 0xbb, 0xab, 0xaa,
+	0xab, 0x6b, 0x7a, 0x61, 0xc5, 0x18, 0xf6, 0x76, 0x8c, 0x61, 0x6f, 0x7b, 0x68, 0x5b, 0xae, 0x45,
+	0xd6, 0xac, 0x21, 0x35, 0x1d, 0xd7, 0xb2, 0x8d, 0x13, 0xba, 0x6d, 0x0c, 0x7b, 0xc5, 0x1b, 0x27,
+	0x96, 0x75, 0xd2, 0xa7, 0x3b, 0xd8, 0xfd, 0x74, 0xf4, 0x6c, 0xc7, 0xed, 0x0d, 0xa8, 0xe3, 0x1a,
+	0x83, 0x21, 0x1f, 0x51, 0xdc, 0x14, 0x0c, 0x28, 0xc7, 0x34, 0x2d, 0xd7, 0x70, 0x7b, 0x96, 0xe9,
+	0xf0, 0x5e, 0xe5, 0x07, 0x69, 0x58, 0x6b, 0x71, 0x71, 0x1a, 0x75, 0xac, 0x91, 0xdd, 0xa1, 0x64,
+	0x15, 0x52, 0xbd, 0x6e, 0x41, 0xda, 0x92, 0x6e, 0xe7, 0xb5, 0x54, 0xaf, 0x4b, 0x08, 0x2c, 0x0c,
+	0x0d, 0xf7, 0x79, 0x21, 0x85, 0x14, 0xfc, 0x4d, 0xde, 0x87, 0xcc, 0x80, 0x76, 0x7b, 0xa3, 0x41,
+	0x21, 0xbd, 0x25, 0xdd, 0x5e, 0xdd, 0xbd, 0xbe, 0x1d, 0x01, 0xb6, 0x2d, 0xa4, 0xd6, 0x91, 0x4b,
+	0x13, 0xdc, 0x64, 0x1d, 0x32, 0x96, 0xd9, 0xef, 0x99, 0xb4, 0xb0, 0xb0, 0x25, 0xdd, 0xce, 0x69,
+	0xa2, 0xc5, 0x74, 0xf4, 0xac, 0xa1, 0x53, 0x58, 0xdc, 0x92, 0x6e, 0x2f, 0x68, 0xf8, 0x9b, 0x5c,
+	0x85, 0xbc, 0x43, 0x5f, 0xea, 0x5f, 0xd8, 0x3d, 0x97, 0x16, 0x32, 0x5b, 0xd2, 0x6d, 0x49, 0xcb,
+	0x39, 0xf4, 0xe5, 0x13, 0xd6, 0x26, 0x57, 0x80, 0xfd, 0xd6, 0x6d, 0x6a, 0x74, 0x0b, 0x59, 0xec,
+	0xcb, 0x3a, 0xf4, 0xa5, 0x46, 0x8d, 0x2e, 0xd3, 0x61, 0x1b, 0x66, 0x57, 0x7b, 0x52, 0xc8, 0x61,
+	0x87, 0x68, 0x31, 0x1d, 0x4e, 0xef, 0x4b, 0x5a, 0xc8, 0x73, 0x1d, 0xec, 0x37, 0xa3, 0x8d, 0x1c,
+	0xda, 0x2d, 0x00, 0xa7, 0xb1, 0xdf, 0xe4, 0x75, 0x58, 0xb5, 0xc5, 0x32, 0xe9, 0xce, 0x90, 0xd2,
+	0x6e, 0x61, 0x09, 0x67, 0xbe, 0xe2, 0x51, 0x5b, 0x8c, 0x48, 0xbe, 0x05, 0xf9, 0xbe, 0xe1, 0xb8,
+	0xba, 0xd3, 0x31, 0xcc, 0xc2, 0xf2, 0x96, 0x74, 0x7b, 0x69, 0xb7, 0xb8, 0xcd, 0x17, 0x7b, 0xdb,
+	0xdb, 0x8d, 0xed, 0xb6, 0xb7, 0x1b, 0x5a, 0x8e, 0x31, 0xb7, 0x3a, 0x86, 0x49, 0x8a, 0x90, 0x1b,
+	0x50, 0xd7, 0xe8, 0x1a, 0xae, 0x51, 0x58, 0xc1, 0x55, 0xf0, 0xdb, 0xca, 0xcf, 0x52, 0xb0, 0x24,
+	0x56, 0xee, 0xc8, 0xb2, 0xfa, 0x6c, 0x2f, 0x6a, 0x55, 0xdc, 0x8b, 0x45, 0x2d, 0x55, 0xab, 0x92,
+	0x12, 0xa4, 0x2b, 0x96, 0x83, 0x5b, 0xb1, 0xba, 0x5b, 0x98, 0x58, 0xf4, 0x8a, 0xe5, 0xb4, 0xcf,
+	0x86, 0x54, 0x63, 0x4c, 0x6c, 0x8f, 0xea, 0x73, 0xed, 0x11, 0xff, 0x9f, 0x6c, 0x42, 0x5e, 0x33,
+	0x7a, 0xdd, 0x43, 0x7a, 0x4a, 0xfb, 0xb8, 0x4d, 0x79, 0x6d, 0x4c, 0x60, 0xbd, 0x6d, 0xcb, 0x35,
+	0xfa, 0x2d, 0xb6, 0x94, 0x59, 0x5c, 0xb6, 0x31, 0x81, 0xad, 0xe7, 0x31, 0x5b, 0xcf, 0x1c, 0x5f,
+	0x4f, 0xf6, 0x9b, 0x7c, 0x04, 0x99, 0xbe, 0xf1, 0x94, 0xf6, 0x9d, 0x42, 0x7e, 0x2b, 0x7d, 0x7b,
+	0x69, 0xf7, 0x76, 0x12, 0x0e, 0x36, 0xe3, 0xed, 0x43, 0x64, 0x55, 0x4d, 0xd7, 0x3e, 0xd3, 0xc4,
+	0xb8, 0xe2, 0x7d, 0x58, 0x0a, 0x90, 0x89, 0x0c, 0xe9, 0x17, 0xf4, 0x4c, 0x58, 0x28, 0xfb, 0x49,
+	0x2e, 0xc1, 0xe2, 0xa9, 0xd1, 0x1f, 0x51, 0x61, 0xa3, 0xbc, 0xf1, 0x20, 0xf5, 0x81, 0xa4, 0xfc,
+	0x83, 0x04, 0x2b, 0x8f, 0xad, 0xfe, 0x68, 0x40, 0x0f, 0xad, 0x8e, 0xe1, 0x5a, 0x36, 0x83, 0x68,
+	0x1a, 0x03, 0x2a, 0x86, 0xe3, 0x6f, 0x72, 0x0c, 0x2b, 0xa7, 0xc8, 0xa4, 0x0b, 0xa4, 0x29, 0x44,
+	0xfa, 0xee, 0x04, 0xd2, 0x90, 0x28, 0xaf, 0x15, 0x40, 0xbc, 0x7c, 0x1a, 0x20, 0x15, 0xff, 0x3f,
+	0x5c, 0x98, 0x60, 0x99, 0x0b, 0xfd, 0x5d, 0xc8, 0xb4, 0xb8, 0x53, 0xae, 0x43, 0x66, 0x68, 0xd8,
+	0xd4, 0x74, 0xc5, 0x40, 0xd1, 0x42, 0xa3, 0x66, 0x26, 0x2a, 0x9c, 0x93, 0xfd, 0x56, 0x36, 0x60,
+	0x71, 0xdf, 0xb6, 0x46, 0xc3, 0xa8, 0x27, 0x2b, 0x3f, 0xcd, 0x02, 0x70, 0x40, 0xad, 0x21, 0xed,
+	0xb0, 0xad, 0xa4, 0xc3, 0xe7, 0x74, 0x40, 0x6d, 0xa3, 0x8f, 0x5c, 0x39, 0x6d, 0x4c, 0xf0, 0xdd,
+	0x25, 0x15, 0x70, 0x97, 0x1d, 0xc8, 0x3c, 0xb3, 0xec, 0x81, 0xe1, 0x0a, 0x93, 0xda, 0x98, 0x58,
+	0xa0, 0xbd, 0x16, 0x1a, 0xa0, 0x60, 0x23, 0xd7, 0x00, 0x9e, 0xf6, 0xad, 0xce, 0x0b, 0x1d, 0x45,
+	0x31, 0x63, 0x4a, 0x6b, 0x79, 0xa4, 0xa0, 0xb9, 0x5c, 0x81, 0xdc, 0x73, 0x43, 0xef, 0xa3, 0xa5,
+	0x2d, 0x62, 0x67, 0xf6, 0xb9, 0xc1, 0xed, 0xac, 0x04, 0xe9, 0x8e, 0xe5, 0xa0, 0xdf, 0x4f, 0xb5,
+	0xf4, 0x8e, 0xe5, 0x90, 0xfb, 0x00, 0x3d, 0x4b, 0x1f, 0xda, 0xd6, 0xb3, 0x5e, 0x9f, 0x1b, 0xe5,
+	0xea, 0x6e, 0x71, 0x62, 0x48, 0xcd, 0x3a, 0xe2, 0x1c, 0x5a, 0xbe, 0xe7, 0xfd, 0x64, 0xeb, 0xda,
+	0xa5, 0xdd, 0xd1, 0x90, 0xa2, 0xc9, 0xe6, 0x34, 0xd1, 0x22, 0x6f, 0xc1, 0x05, 0xc7, 0x34, 0x86,
+	0xce, 0x73, 0xcb, 0xd5, 0x7b, 0xa6, 0x4b, 0xed, 0x53, 0xa3, 0x8f, 0x91, 0x63, 0x45, 0x93, 0xbd,
+	0x8e, 0x9a, 0xa0, 0x13, 0x2d, 0x6a, 0x3e, 0x80, 0xe6, 0xf3, 0x4e, 0x82, 0xf9, 0xb0, 0xc5, 0x3f,
+	0xcf, 0x76, 0x18, 0x30, 0xe7, 0xb9, 0x61, 0x8b, 0xe8, 0x93, 0xd3, 0x44, 0x8b, 0xfc, 0x3f, 0x58,
+	0xb2, 0xe9, 0xb0, 0xdf, 0xeb, 0x18, 0xba, 0x43, 0x5d, 0x11, 0x78, 0xae, 0x4e, 0x68, 0xd2, 0x38,
+	0x4f, 0x8b, 0xba, 0x1a, 0xd8, 0xfe, 0x6f, 0x36, 0x2d, 0xe3, 0xe4, 0xc4, 0xa6, 0x27, 0x3c, 0xbc,
+	0xf1, 0x95, 0x5f, 0xe1, 0xd3, 0x0a, 0x74, 0xf8, 0xae, 0x4e, 0xcd, 0x8e, 0x7d, 0x36, 0x74, 0x69,
+	0xb7, 0xb0, 0x2a, 0xec, 0xc3, 0x23, 0x90, 0xeb, 0x00, 0x43, 0xc3, 0x71, 0x86, 0xcf, 0x6d, 0xc3,
+	0xa1, 0x85, 0x35, 0x34, 0xb2, 0x00, 0x25, 0xb4, 0x82, 0x4e, 0xe7, 0x39, 0xed, 0x8e, 0xfa, 0xb4,
+	0x20, 0x23, 0x9b, 0xbf, 0x82, 0x2d, 0x41, 0x67, 0x2e, 0xe0, 0x74, 0x8c, 0x3e, 0x2d, 0x5c, 0x40,
+	0x2c, 0xbc, 0x81, 0x6b, 0xe0, 0xf6, 0x3a, 0x2f, 0xce, 0x0a, 0x44, 0xac, 0x01, 0xb6, 0xc8, 0xdb,
+	0xb0, 0x78, 0xc2, 0x0c, 0xbc, 0x70, 0x19, 0x67, 0xbf, 0x3e, 0x31, 0x7b, 0x34, 0x7f, 0x8d, 0x33,
+	0xb1, 0x78, 0x8e, 0x3f, 0x74, 0x6a, 0x3e, 0xb3, 0xec, 0x0e, 0xed, 0x16, 0xd6, 0x51, 0xda, 0x0a,
+	0x52, 0x55, 0x41, 0x64, 0xf3, 0xe9, 0x58, 0x83, 0xa1, 0x4d, 0x1d, 0x16, 0xc0, 0x36, 0x90, 0x25,
+	0x40, 0x61, 0x61, 0xbb, 0x63, 0x38, 0x1d, 0xa3, 0x4b, 0xbb, 0x85, 0x02, 0x0f, 0xdb, 0x5e, 0x9b,
+	0x14, 0x20, 0xfb, 0xb9, 0x35, 0xb2, 0x4d, 0xa3, 0x5f, 0xb8, 0x82, 0x5d, 0x5e, 0x93, 0x8d, 0xe2,
+	0x1b, 0x77, 0x7a, 0xb7, 0x50, 0xe4, 0xa3, 0xbc, 0xf6, 0x57, 0x0f, 0x0f, 0x0a, 0xc0, 0x78, 0x9f,
+	0x19, 0x9f, 0x69, 0x75, 0xa9, 0x53, 0x90, 0xb6, 0xd2, 0x8c, 0x0f, 0x1b, 0xca, 0x4f, 0x24, 0x58,
+	0xd3, 0x46, 0x26, 0x4b, 0x0b, 0x5a, 0xae, 0xe1, 0xd2, 0xba, 0x31, 0x24, 0x4f, 0x60, 0xc5, 0xe6,
+	0x24, 0xdd, 0x61, 0x34, 0x1c, 0xb1, 0xb4, 0xbb, 0x3b, 0x69, 0x45, 0xe1, 0x81, 0xa1, 0xb6, 0x30,
+	0x5a, 0x3b, 0x40, 0x62, 0x33, 0x9a, 0x60, 0x99, 0x6b, 0x46, 0xff, 0x96, 0x83, 0x0c, 0x5f, 0x93,
+	0x89, 0x34, 0x64, 0x07, 0x32, 0x3c, 0x41, 0xc1, 0x51, 0x4b, 0x31, 0xb1, 0x87, 0x87, 0x4a, 0x4d,
+	0xb0, 0x8d, 0xad, 0x24, 0x3d, 0x8b, 0x95, 0x14, 0x21, 0xc7, 0x92, 0x09, 0xcb, 0xec, 0x9f, 0x89,
+	0xdc, 0xc4, 0x6f, 0x93, 0x0f, 0x20, 0xdb, 0xe7, 0x21, 0x1f, 0xa3, 0xd4, 0x52, 0xcc, 0x51, 0x1a,
+	0x3a, 0x18, 0x34, 0x8f, 0x9d, 0xbc, 0x0b, 0x8b, 0x1d, 0xb6, 0x1c, 0x18, 0xc7, 0xa6, 0x27, 0x08,
+	0x9c, 0x91, 0xec, 0xc0, 0x82, 0x33, 0xa4, 0x1d, 0x8c, 0x62, 0x71, 0x8e, 0x3d, 0x0e, 0x21, 0x1a,
+	0x32, 0xb2, 0xc5, 0x1c, 0x39, 0xc6, 0x09, 0x15, 0x67, 0x2e, 0x6f, 0x84, 0xb3, 0x93, 0xfc, 0x1c,
+	0xd9, 0xc9, 0x38, 0xc4, 0xc3, 0x6c, 0x21, 0xfe, 0x1e, 0x73, 0x52, 0xc3, 0x1d, 0x39, 0x18, 0xa8,
+	0x56, 0x77, 0xaf, 0x25, 0x41, 0x46, 0x26, 0x4d, 0x30, 0x93, 0x5d, 0x58, 0xe4, 0xb6, 0xb7, 0x8c,
+	0xa3, 0x36, 0xa7, 0x8c, 0xa2, 0x1a, 0x67, 0x25, 0x37, 0x60, 0xc9, 0x70, 0x5d, 0x83, 0x05, 0x0d,
+	0xdd, 0x32, 0x31, 0x6e, 0xe5, 0x35, 0xf0, 0x48, 0x4d, 0x93, 0x54, 0x60, 0xd5, 0x67, 0xe0, 0xd2,
+	0x57, 0x13, 0xa4, 0x97, 0x91, 0x8d, 0x4b, 0x5f, 0xf1, 0xc6, 0xb4, 0x3c, 0x2d, 0x5d, 0x7a, 0xda,
+	0xeb, 0x50, 0x1d, 0xd3, 0x5e, 0x11, 0xd9, 0x38, 0xe9, 0x88, 0x25, 0xbf, 0x6f, 0x03, 0x71, 0x68,
+	0x67, 0x64, 0x53, 0x3d, 0xc8, 0xe7, 0x85, 0x36, 0xec, 0xa9, 0x8e, 0xb9, 0x7d, 0xd0, 0x9c, 0xed,
+	0x02, 0x3a, 0xa7, 0x00, 0x8d, 0x0c, 0x07, 0x3e, 0x43, 0xcf, 0x7c, 0x66, 0x15, 0x08, 0xfa, 0xe2,
+	0xad, 0x84, 0xf5, 0x10, 0xc0, 0x6b, 0xe6, 0x33, 0x8b, 0x3b, 0xa0, 0x90, 0xc4, 0x08, 0xe4, 0x3b,
+	0xb0, 0x1c, 0x38, 0x1b, 0x9c, 0xc2, 0x45, 0x14, 0x35, 0xf5, 0x70, 0x58, 0x1a, 0x1f, 0x0e, 0x0e,
+	0x51, 0xa3, 0x71, 0xe1, 0x12, 0x0a, 0xd8, 0x3a, 0x2f, 0x2e, 0x84, 0xa3, 0x00, 0xb3, 0x48, 0x6a,
+	0xdb, 0x96, 0x8d, 0xe1, 0x39, 0xaf, 0xf1, 0x06, 0xf9, 0x18, 0x64, 0x71, 0x48, 0x76, 0x2c, 0xd3,
+	0x19, 0x0d, 0xa8, 0xed, 0x14, 0xd6, 0x51, 0xfe, 0x8d, 0x84, 0xb9, 0x56, 0x04, 0x9f, 0xb6, 0x76,
+	0x1a, 0x6a, 0x3b, 0xc5, 0x0f, 0x61, 0x2d, 0xb2, 0x0e, 0x73, 0x45, 0x99, 0x3f, 0x4d, 0xc1, 0x22,
+	0x83, 0xea, 0x30, 0x1e, 0xe6, 0xe5, 0x0e, 0x8e, 0x5b, 0xd0, 0x78, 0x83, 0x6c, 0x40, 0x96, 0xfd,
+	0xd0, 0x07, 0x8e, 0xc8, 0x7e, 0x32, 0xac, 0x59, 0x77, 0x58, 0x3a, 0x83, 0x1d, 0x4f, 0xcf, 0x5c,
+	0xea, 0x60, 0x5c, 0x59, 0xd0, 0xf2, 0x8c, 0xf2, 0x90, 0x11, 0xd8, 0x79, 0x85, 0xb7, 0x15, 0x07,
+	0x23, 0xc8, 0x82, 0x26, 0x5a, 0x2c, 0xcd, 0xc1, 0x5f, 0x4c, 0x20, 0xbf, 0xe1, 0x64, 0xb1, 0x5d,
+	0x77, 0x98, 0x75, 0xf0, 0x2e, 0x2e, 0x32, 0x83, 0xbd, 0x80, 0x24, 0x2e, 0xf3, 0x06, 0x2c, 0xf1,
+	0xdc, 0xe6, 0x84, 0x9d, 0x43, 0x22, 0xe3, 0x06, 0x4c, 0x60, 0x90, 0x42, 0x2e, 0xc2, 0x62, 0xcf,
+	0x62, 0x92, 0x73, 0xde, 0xdd, 0x89, 0x03, 0x45, 0x81, 0x3a, 0xde, 0x6e, 0xf8, 0x8d, 0x27, 0x8f,
+	0x14, 0x4c, 0xc9, 0x99, 0x50, 0x91, 0xbc, 0xb0, 0x91, 0x20, 0x84, 0x0a, 0x52, 0xdd, 0x51, 0xfe,
+	0x33, 0x05, 0x8b, 0xe5, 0x3e, 0xb5, 0xdd, 0x40, 0x18, 0x4e, 0x63, 0x18, 0xbe, 0xcf, 0x2e, 0x5e,
+	0xa7, 0xd4, 0xee, 0xb9, 0x67, 0xe2, 0x1a, 0x32, 0xe9, 0xf0, 0x2d, 0xc1, 0x80, 0x71, 0xc2, 0x67,
+	0x67, 0xa0, 0x0c, 0x26, 0x53, 0x77, 0xcf, 0x86, 0x14, 0x57, 0x2f, 0xad, 0xe5, 0x91, 0xc2, 0x18,
+	0xd9, 0x21, 0x3a, 0xa0, 0x0e, 0x86, 0x32, 0x7e, 0xeb, 0xf0, 0x9a, 0xe4, 0x03, 0xc8, 0xfb, 0xd7,
+	0x5a, 0x11, 0x81, 0xa7, 0x05, 0xb3, 0x31, 0x33, 0x9b, 0xa8, 0x2d, 0xee, 0xb5, 0x7a, 0xaf, 0x8b,
+	0xcb, 0x9b, 0x67, 0x09, 0x11, 0x27, 0xd5, 0x70, 0x3a, 0x5e, 0x4b, 0x24, 0x8e, 0xd7, 0x62, 0xdc,
+	0x85, 0x33, 0xf0, 0xe9, 0x78, 0xec, 0x0c, 0x6f, 0xa7, 0x4f, 0x31, 0x45, 0xe3, 0xb9, 0xa3, 0xd7,
+	0x64, 0xb6, 0xe8, 0xba, 0x7d, 0xb1, 0xec, 0xec, 0x27, 0x9b, 0xfa, 0xc8, 0xec, 0xbd, 0x1c, 0x51,
+	0xdd, 0x35, 0x4e, 0x70, 0xbd, 0xf3, 0x5a, 0x9e, 0x53, 0xda, 0xc6, 0x89, 0xf2, 0x3e, 0x64, 0x70,
+	0xb5, 0x1d, 0x76, 0x68, 0xe1, 0x8a, 0x88, 0x23, 0x79, 0xf2, 0xd0, 0x42, 0x3e, 0x8d, 0x33, 0x29,
+	0xff, 0x92, 0x82, 0xb5, 0xe6, 0xd3, 0xcf, 0x69, 0xc7, 0x65, 0x2c, 0x14, 0x83, 0x00, 0xbb, 0xd2,
+	0x8e, 0xfc, 0x93, 0x13, 0x7f, 0xb3, 0xab, 0xb4, 0xf0, 0xbd, 0x9e, 0x77, 0x55, 0xc8, 0x71, 0x42,
+	0x0d, 0x93, 0x17, 0x6a, 0x1a, 0x4f, 0xfb, 0xb4, 0x8b, 0x7b, 0x92, 0xd3, 0xbc, 0x26, 0xcf, 0xbf,
+	0x30, 0xb4, 0xf3, 0x0d, 0xf1, 0x62, 0xf7, 0x3a, 0x64, 0x8c, 0x0e, 0xcb, 0x13, 0x45, 0xd2, 0x2e,
+	0x5a, 0xb8, 0xc1, 0x9d, 0x0e, 0x75, 0x1c, 0x9d, 0xb9, 0x22, 0x5f, 0xec, 0x3c, 0xa7, 0x3c, 0xa2,
+	0xb8, 0xff, 0x0e, 0xed, 0xd8, 0xd4, 0xc5, 0xee, 0x2c, 0xef, 0xe6, 0x14, 0xd6, 0x8d, 0xe9, 0x66,
+	0x77, 0x68, 0xf5, 0x4c, 0x97, 0x19, 0x33, 0x0b, 0x93, 0x63, 0x02, 0x79, 0x13, 0xe4, 0xce, 0xc8,
+	0x66, 0x77, 0x1e, 0x9d, 0x9a, 0xdd, 0x23, 0x46, 0xc4, 0x05, 0xce, 0x6b, 0x6b, 0x82, 0xae, 0x0a,
+	0x32, 0x46, 0x5c, 0x0e, 0x63, 0x68, 0xd9, 0xfc, 0x1c, 0x4b, 0x6b, 0x02, 0xd9, 0x91, 0x65, 0xbb,
+	0x58, 0x21, 0xa0, 0x27, 0x0c, 0x3f, 0xbf, 0xd9, 0x8b, 0x96, 0xf2, 0xf7, 0x12, 0x5c, 0x14, 0xa1,
+	0xc7, 0xa6, 0xec, 0x64, 0xa0, 0x2f, 0x47, 0xd4, 0x71, 0x83, 0xe7, 0xbf, 0x34, 0xdf, 0xf9, 0x3f,
+	0x77, 0xd2, 0xe2, 0x1d, 0xff, 0xe9, 0x19, 0x8f, 0x7f, 0xe5, 0x0d, 0x58, 0xe5, 0x34, 0x8d, 0x3a,
+	0x43, 0xcb, 0x74, 0x02, 0xe1, 0x57, 0x0a, 0x84, 0x5f, 0x65, 0x08, 0x97, 0xc2, 0x53, 0x13, 0xdc,
+	0xd1, 0x34, 0xeb, 0x00, 0x44, 0xb4, 0xd5, 0x6d, 0xc1, 0x22, 0xa0, 0x27, 0x45, 0x69, 0x4f, 0x92,
+	0xb6, 0x7a, 0x1a, 0x6a, 0x2b, 0xff, 0x2c, 0x79, 0xf9, 0x2d, 0x1e, 0x0b, 0x65, 0x6e, 0x23, 0x0f,
+	0x20, 0xc3, 0x4f, 0x2c, 0xd4, 0xb9, 0xba, 0xab, 0x24, 0x88, 0xe5, 0xec, 0x47, 0x86, 0x6d, 0x0c,
+	0x34, 0x31, 0x82, 0x7c, 0x00, 0x8b, 0x03, 0x6b, 0x64, 0xba, 0x22, 0xf0, 0xcc, 0x32, 0x94, 0x0f,
+	0x60, 0xa6, 0x87, 0x3f, 0xf8, 0x19, 0x9c, 0xe6, 0xa6, 0x87, 0x14, 0xef, 0x8c, 0x0e, 0x1e, 0xe5,
+	0x0b, 0xd1, 0x23, 0x5f, 0xf9, 0xc7, 0x14, 0xc8, 0x62, 0x2e, 0xd4, 0xfd, 0x3a, 0xcc, 0x82, 0xef,
+	0x72, 0x6a, 0xd6, 0x24, 0xef, 0x81, 0xef, 0x71, 0xdc, 0x30, 0x94, 0x69, 0xe9, 0x12, 0x9f, 0xbf,
+	0xef, 0x95, 0x07, 0x90, 0xb5, 0x86, 0x58, 0xf4, 0x2b, 0x2c, 0x60, 0x50, 0xd9, 0x4e, 0x1a, 0xec,
+	0x4f, 0x6d, 0xbb, 0xc9, 0x07, 0xf0, 0x14, 0xc3, 0x1b, 0x5e, 0x7c, 0x00, 0xcb, 0xc1, 0x8e, 0xb9,
+	0xce, 0xdc, 0xdf, 0x1d, 0x5b, 0x03, 0x53, 0x23, 0xac, 0x6f, 0x07, 0x32, 0xdc, 0x6a, 0xc4, 0x0a,
+	0x6e, 0x24, 0x19, 0x99, 0x60, 0xfb, 0x1a, 0xcd, 0xf3, 0x0c, 0x2e, 0xb4, 0x4c, 0x63, 0x18, 0xf6,
+	0xf4, 0xa8, 0x37, 0x04, 0xb6, 0x38, 0x35, 0xdf, 0x16, 0x07, 0xef, 0x13, 0xe9, 0xf0, 0x7d, 0x42,
+	0x79, 0x09, 0x24, 0xa8, 0x5a, 0xac, 0xc5, 0xf7, 0x60, 0xdd, 0x4b, 0x90, 0xb0, 0x63, 0x3c, 0x43,
+	0xbe, 0x36, 0xaf, 0x27, 0xa5, 0x49, 0x21, 0x31, 0xda, 0xa5, 0xd3, 0x18, 0xaa, 0xe2, 0x7a, 0x95,
+	0x1f, 0x3c, 0x23, 0x42, 0xe7, 0x81, 0x14, 0x39, 0x0f, 0xe2, 0xea, 0xbd, 0xf7, 0x20, 0x2b, 0x14,
+	0xcf, 0x12, 0x99, 0x3c, 0x5e, 0xe5, 0x6f, 0x24, 0x2f, 0x3a, 0x79, 0xb9, 0x5b, 0x6c, 0xf9, 0x6d,
+	0x13, 0xf2, 0xec, 0x7f, 0x67, 0x68, 0x74, 0x3c, 0xcb, 0x19, 0x13, 0xd8, 0x08, 0x3f, 0x61, 0xc8,
+	0x6b, 0xf8, 0x9b, 0x65, 0x68, 0xec, 0x7a, 0xcb, 0xe0, 0x8b, 0xa3, 0x89, 0x35, 0x6b, 0x5d, 0xe6,
+	0xe8, 0xd6, 0x17, 0x26, 0xb5, 0x75, 0x54, 0xb2, 0xc8, 0x65, 0x21, 0xa5, 0xc1, 0x34, 0xf9, 0xdd,
+	0x28, 0x31, 0x13, 0xe8, 0x66, 0x87, 0xbb, 0xd2, 0x05, 0xb2, 0x6f, 0x1b, 0xc3, 0xe7, 0x55, 0xbb,
+	0x77, 0x4a, 0xed, 0xca, 0x73, 0xc3, 0x3c, 0xa1, 0x8e, 0xbf, 0x20, 0x52, 0x60, 0x41, 0x1e, 0xc0,
+	0xc2, 0x8b, 0x9e, 0xd9, 0x15, 0x91, 0xe8, 0x8d, 0x98, 0xbb, 0x65, 0x44, 0x0c, 0x26, 0x0f, 0x38,
+	0x46, 0xb9, 0x05, 0x6b, 0x95, 0xfe, 0xc8, 0x71, 0xa9, 0x7d, 0x4e, 0xcc, 0xfe, 0xa1, 0x04, 0x2b,
+	0xcc, 0x99, 0x4f, 0x7d, 0xfb, 0x3c, 0x80, 0x9c, 0x46, 0x5f, 0x52, 0xc7, 0x7d, 0xf4, 0x58, 0x64,
+	0x08, 0x6f, 0x4f, 0x66, 0x08, 0xc1, 0x11, 0xdb, 0x1e, 0x3b, 0x77, 0x65, 0x7f, 0x74, 0xf1, 0xdb,
+	0xb0, 0x12, 0xea, 0x0a, 0x3a, 0x73, 0xfa, 0x3c, 0x67, 0xfe, 0x12, 0x56, 0x43, 0x5a, 0x1c, 0xa2,
+	0xc0, 0xb2, 0xf8, 0x5d, 0xc1, 0x08, 0xcd, 0xc5, 0x84, 0x68, 0xa4, 0x1a, 0x99, 0x8d, 0xa8, 0xb2,
+	0x5e, 0x9f, 0x3e, 0x03, 0x2d, 0x3c, 0x48, 0xf9, 0x3b, 0x09, 0xd6, 0xf1, 0xe6, 0x7e, 0xbe, 0xf7,
+	0x3e, 0x82, 0xcc, 0x61, 0xb0, 0x9e, 0x7b, 0x27, 0xbe, 0x04, 0x30, 0x21, 0x28, 0x5c, 0x84, 0x3e,
+	0xfc, 0xca, 0x45, 0xe8, 0xff, 0x90, 0x60, 0x63, 0x42, 0x93, 0xd8, 0xf9, 0x63, 0xc8, 0x7b, 0xd5,
+	0x30, 0x47, 0x6c, 0xe9, 0xb7, 0xce, 0x87, 0xc9, 0x07, 0x6f, 0xb7, 0xbc, 0x91, 0x1c, 0xea, 0x58,
+	0xd2, 0xd8, 0xa0, 0x52, 0x01, 0x83, 0x2a, 0x1a, 0xb0, 0x1a, 0x1e, 0x12, 0x33, 0x8d, 0xfb, 0xc1,
+	0x69, 0x2c, 0xed, 0xbe, 0x3a, 0x99, 0xb1, 0x4c, 0xe0, 0x08, 0xce, 0xf5, 0xbf, 0x17, 0xfc, 0x2f,
+	0x18, 0x0d, 0xab, 0x3b, 0x99, 0x5f, 0xc8, 0x90, 0xee, 0x0c, 0x47, 0x28, 0x5c, 0xd2, 0xd8, 0x4f,
+	0x16, 0x8c, 0x06, 0x74, 0xa0, 0xbb, 0x96, 0x6b, 0xf4, 0xc5, 0x9d, 0x2a, 0x37, 0xa0, 0x03, 0xfc,
+	0xa8, 0xc0, 0xae, 0x4e, 0xac, 0x13, 0xaf, 0x31, 0xfc, 0x52, 0x95, 0x1d, 0xd0, 0x01, 0x5e, 0x62,
+	0x44, 0xd7, 0x33, 0x9b, 0x52, 0xef, 0x56, 0x35, 0xa0, 0x83, 0x3d, 0x9b, 0x62, 0x5d, 0xd9, 0x38,
+	0x3d, 0xd1, 0xfb, 0x96, 0xc1, 0x73, 0xfe, 0xb4, 0x96, 0x35, 0x4e, 0x4f, 0x0e, 0x2d, 0x83, 0x97,
+	0x91, 0x78, 0x4e, 0x9b, 0x4d, 0xa8, 0x6f, 0x44, 0x0a, 0x15, 0x1f, 0xc2, 0x62, 0xb7, 0xe7, 0xbc,
+	0xf0, 0xbe, 0x5e, 0xdc, 0x4a, 0xfa, 0x7a, 0xc1, 0x66, 0xbb, 0x5d, 0x65, 0x9c, 0x7c, 0x33, 0xf8,
+	0x28, 0xb2, 0x0b, 0x8b, 0x43, 0xcb, 0xf2, 0x6b, 0xc2, 0x9b, 0xd3, 0x3e, 0x7e, 0x68, 0x9c, 0x95,
+	0x45, 0xb7, 0xc1, 0xc9, 0xc0, 0xd5, 0x7b, 0x43, 0x2f, 0x41, 0x65, 0xcd, 0xda, 0x90, 0x75, 0x74,
+	0x0d, 0xd7, 0x60, 0x1d, 0xcb, 0xbc, 0x83, 0x35, 0x6b, 0x58, 0xbd, 0x7a, 0x6e, 0x39, 0x2e, 0x06,
+	0x3d, 0x5e, 0xb0, 0xf0, 0xdb, 0xa4, 0x0e, 0x4b, 0x18, 0x2b, 0x45, 0x6d, 0x5a, 0x4e, 0x08, 0x1b,
+	0xc1, 0x69, 0xb0, 0x7f, 0x82, 0x3e, 0x00, 0xa6, 0x4f, 0x28, 0x7e, 0x06, 0x30, 0x9e, 0x65, 0x8c,
+	0xfd, 0xbc, 0x1f, 0xb6, 0x9f, 0xad, 0x24, 0x45, 0xde, 0xad, 0x2a, 0x60, 0x3c, 0xec, 0x5e, 0x1f,
+	0x51, 0x3d, 0x97, 0x9f, 0xfd, 0x58, 0x82, 0x55, 0x21, 0x5d, 0x04, 0xd8, 0xc0, 0x76, 0x4b, 0xb3,
+	0x6d, 0x37, 0xb7, 0xd7, 0x94, 0x6f, 0xaf, 0x81, 0x93, 0x26, 0x1d, 0x3a, 0x69, 0x76, 0xbd, 0x72,
+	0xeb, 0xc2, 0xf4, 0x8d, 0x65, 0x13, 0xf2, 0x8a, 0xb1, 0x1d, 0xb8, 0xd1, 0xea, 0xbe, 0xa8, 0xd8,
+	0xb4, 0x4b, 0x4d, 0xb7, 0x67, 0xf4, 0xb9, 0x1b, 0x95, 0xbf, 0x1c, 0xd9, 0x7e, 0x0c, 0xfb, 0x08,
+	0xa0, 0xe3, 0xf7, 0x8b, 0x93, 0x7f, 0x72, 0x0d, 0x71, 0xc8, 0x58, 0x8e, 0x16, 0x18, 0xa3, 0xec,
+	0xc3, 0x56, 0xb2, 0x12, 0x11, 0x75, 0x5e, 0x85, 0x95, 0xf1, 0x88, 0x71, 0x12, 0xb0, 0x3c, 0x26,
+	0xd6, 0xba, 0x0a, 0x8d, 0x15, 0xb4, 0x8f, 0xf7, 0x6e, 0x0f, 0x6e, 0x39, 0x06, 0xee, 0xcd, 0xc9,
+	0xf8, 0x85, 0x63, 0x12, 0xf0, 0x1e, 0xc0, 0xcd, 0x29, 0x6a, 0xe6, 0x01, 0xfc, 0x4b, 0x70, 0x2d,
+	0x6e, 0xe6, 0x4f, 0x5a, 0x1e, 0xda, 0x0f, 0x63, 0xd0, 0xc6, 0x94, 0x2f, 0xee, 0x24, 0x20, 0x55,
+	0xe1, 0x7a, 0x92, 0xfc, 0x79, 0x60, 0xfe, 0x85, 0x04, 0xcb, 0x41, 0x1d, 0x33, 0x8d, 0x8a, 0x5c,
+	0xae, 0x53, 0xd3, 0x2f, 0xd7, 0xe9, 0xe8, 0xe5, 0xba, 0x08, 0x39, 0xef, 0x2e, 0x2d, 0x32, 0x26,
+	0xbf, 0x1d, 0xb8, 0x0e, 0x2f, 0x86, 0xae, 0xc3, 0x5f, 0xc2, 0x5a, 0xc4, 0xce, 0x66, 0x43, 0x7a,
+	0x13, 0x96, 0x8d, 0x4e, 0x07, 0xaf, 0x5b, 0x18, 0x90, 0x38, 0xd6, 0x25, 0x41, 0xc3, 0x3c, 0x8c,
+	0x5f, 0xd1, 0x91, 0x65, 0x0c, 0x17, 0x04, 0xe9, 0x11, 0x65, 0x29, 0xb2, 0x1c, 0x35, 0x9a, 0x99,
+	0x97, 0x69, 0x68, 0x5b, 0x9f, 0xd3, 0x8e, 0x3b, 0xae, 0x75, 0xe4, 0x05, 0xa5, 0x86, 0x87, 0xc6,
+	0xe7, 0x8e, 0x65, 0x06, 0xb4, 0x66, 0x59, 0x9b, 0xa9, 0x8c, 0xfa, 0x8d, 0x6a, 0xb2, 0x84, 0x35,
+	0x6c, 0x40, 0x33, 0xed, 0xef, 0xd3, 0x88, 0x41, 0x87, 0x05, 0x09, 0x4b, 0x89, 0x9a, 0x62, 0x7a,
+	0x3e, 0x53, 0xac, 0x81, 0x92, 0xa0, 0x23, 0x18, 0x4c, 0x66, 0x82, 0x7b, 0x02, 0xaf, 0x4e, 0x15,
+	0x25, 0x00, 0x7f, 0x14, 0x03, 0x78, 0xbe, 0xc0, 0xf4, 0x71, 0x92, 0xa2, 0x70, 0x48, 0x99, 0x09,
+	0x74, 0x0f, 0x5e, 0x9b, 0x2e, 0x4b, 0xa0, 0x2e, 0xc7, 0xa0, 0x9e, 0x33, 0x3e, 0x95, 0xa1, 0x18,
+	0x52, 0x55, 0xa5, 0x7d, 0xea, 0xce, 0x87, 0xf6, 0x1a, 0x5c, 0x8d, 0x15, 0x21, 0x2e, 0x67, 0x15,
+	0xd8, 0x0c, 0x75, 0x3f, 0x36, 0xfa, 0xbd, 0xae, 0x31, 0xa7, 0x8e, 0x1b, 0x91, 0xe0, 0x37, 0x16,
+	0x22, 0xb4, 0xfc, 0xab, 0x04, 0x97, 0x5b, 0xdd, 0x17, 0xfc, 0x3e, 0x56, 0x67, 0x8e, 0xe6, 0xc9,
+	0x9f, 0x7a, 0x1d, 0x0c, 0x97, 0x4e, 0x52, 0xd1, 0xd2, 0x49, 0x7d, 0x5c, 0x5d, 0x48, 0x27, 0x24,
+	0xd9, 0xb1, 0x4a, 0xbf, 0x81, 0x12, 0x43, 0x01, 0xd6, 0xa3, 0xaa, 0xc4, 0xd4, 0x7f, 0x21, 0xc1,
+	0x86, 0xdf, 0x75, 0x6c, 0x0e, 0xbe, 0xae, 0xc9, 0x37, 0xa3, 0x93, 0xbf, 0x97, 0x3c, 0xf9, 0xb0,
+	0xda, 0x6f, 0x60, 0xfa, 0x45, 0x28, 0x4c, 0x2a, 0x13, 0x0b, 0xf0, 0x4f, 0x52, 0x60, 0x6d, 0xf8,
+	0xa7, 0x93, 0x99, 0xe6, 0xdf, 0x18, 0x4f, 0x90, 0x5f, 0xa1, 0xee, 0x26, 0x4f, 0x30, 0x24, 0xf6,
+	0x1b, 0x98, 0xdf, 0x83, 0xc0, 0x1e, 0x7a, 0xba, 0x84, 0x97, 0x47, 0xea, 0x77, 0xd2, 0x44, 0xfd,
+	0xee, 0x5e, 0x60, 0xfa, 0x55, 0x3a, 0xeb, 0xf4, 0x95, 0x2b, 0x01, 0x95, 0xde, 0x30, 0xb1, 0xa2,
+	0xdf, 0x0f, 0x48, 0x0c, 0xdf, 0x42, 0xe3, 0x2a, 0x1c, 0xf3, 0x16, 0xfc, 0x94, 0xf7, 0x03, 0x9a,
+	0x23, 0x37, 0xc6, 0xa9, 0x88, 0x7f, 0x43, 0xc2, 0x83, 0x21, 0x38, 0x70, 0xcf, 0xb6, 0x06, 0xa2,
+	0xf6, 0xd3, 0x9d, 0x86, 0xf1, 0x2a, 0xe4, 0xf9, 0xa3, 0xa2, 0xc0, 0x47, 0x02, 0x4e, 0xa8, 0x75,
+	0xe7, 0xaf, 0x4b, 0x3f, 0xc4, 0x60, 0x9f, 0x8c, 0x63, 0x96, 0xc9, 0x84, 0x77, 0x2d, 0x18, 0x75,
+	0xe7, 0xd8, 0xb5, 0x50, 0xa4, 0x0d, 0x2e, 0x6b, 0xcd, 0x64, 0x40, 0x67, 0x8a, 0x03, 0xca, 0xa3,
+	0x80, 0x6f, 0xf9, 0xe3, 0xfe, 0x97, 0x35, 0x4c, 0xe5, 0x18, 0xae, 0xf8, 0xc2, 0xfc, 0x73, 0xeb,
+	0x2b, 0x17, 0x95, 0x95, 0x26, 0x9e, 0x53, 0x13, 0x62, 0x05, 0xca, 0xf7, 0x20, 0xcb, 0xd5, 0x7b,
+	0x55, 0x86, 0x44, 0x98, 0x1e, 0x9f, 0xf2, 0x53, 0x09, 0xf3, 0x5d, 0xb1, 0xb5, 0xa2, 0x6e, 0x10,
+	0xb6, 0xf5, 0xa9, 0xc1, 0xa3, 0xe5, 0x3f, 0xfc, 0xe3, 0xb1, 0xe3, 0xdb, 0xc9, 0xb1, 0x23, 0x56,
+	0xfa, 0xd7, 0xfd, 0x16, 0xf0, 0x21, 0xde, 0xbe, 0xe2, 0x15, 0x8e, 0x03, 0xc9, 0xf8, 0xd9, 0x97,
+	0x37, 0x23, 0xf0, 0x1f, 0x7c, 0x75, 0x15, 0x3d, 0x46, 0x86, 0x46, 0xf1, 0xeb, 0xdb, 0x4c, 0x6b,
+	0x12, 0x51, 0x90, 0x9a, 0x50, 0xa0, 0x60, 0x16, 0x9a, 0xa0, 0x40, 0x58, 0xf1, 0xcf, 0x25, 0xcc,
+	0x30, 0xc3, 0x4c, 0x13, 0x96, 0x34, 0x15, 0xc7, 0xe3, 0xc8, 0xde, 0x7c, 0xe7, 0xfc, 0xbd, 0x89,
+	0x2a, 0xf8, 0xba, 0xb7, 0xe7, 0x7b, 0x81, 0xc8, 0x15, 0xa3, 0x53, 0xec, 0xd0, 0xbd, 0xc9, 0x7a,
+	0x59, 0xa2, 0x25, 0x8f, 0x39, 0x95, 0x4d, 0x9e, 0xc4, 0xf1, 0xaa, 0x40, 0x74, 0x26, 0xca, 0x27,
+	0x3c, 0x3f, 0x9b, 0xe8, 0x15, 0x3a, 0xef, 0x43, 0xb6, 0xc3, 0xfb, 0x84, 0x4f, 0xde, 0x48, 0xba,
+	0xec, 0x7b, 0x75, 0x5d, 0x8f, 0x5f, 0xb9, 0x83, 0x81, 0x43, 0x90, 0x23, 0x11, 0x27, 0x50, 0x5a,
+	0x90, 0x82, 0xa5, 0x05, 0xa5, 0x8e, 0x01, 0x22, 0x3a, 0x48, 0x80, 0x79, 0x17, 0x16, 0x18, 0x9b,
+	0x40, 0x32, 0xbd, 0xec, 0x80, 0x9c, 0xca, 0xcf, 0x24, 0x5e, 0x76, 0xe0, 0xf2, 0xf0, 0x03, 0xf2,
+	0x84, 0xb1, 0xdc, 0x07, 0xf0, 0xde, 0x7d, 0xd8, 0xae, 0x90, 0x7d, 0xee, 0x37, 0xf6, 0x16, 0x63,
+	0x26, 0xf7, 0x20, 0x87, 0x43, 0xa9, 0x28, 0x87, 0x4f, 0x1f, 0x98, 0x65, 0xbc, 0xaa, 0x19, 0xfe,
+	0xf2, 0x9e, 0x9e, 0xeb, 0xcb, 0xbb, 0xd2, 0xe2, 0x37, 0xb5, 0xf8, 0xf9, 0x8c, 0xa3, 0x32, 0x7e,
+	0x23, 0x77, 0x12, 0xa3, 0x32, 0xff, 0xe2, 0xae, 0x09, 0x36, 0xc5, 0x09, 0xda, 0x00, 0xf6, 0x55,
+	0xfa, 0xd4, 0xb0, 0xc7, 0x0b, 0x34, 0x86, 0x2b, 0xcd, 0xf7, 0x50, 0xe0, 0x0a, 0xe4, 0xf8, 0xbb,
+	0x07, 0xe1, 0xf0, 0x69, 0x2d, 0x8b, 0xed, 0x5a, 0x57, 0xb9, 0xce, 0x33, 0xff, 0x49, 0xa5, 0xc2,
+	0xd3, 0x27, 0x41, 0xa9, 0xb6, 0xe1, 0xd0, 0xff, 0x6b, 0x50, 0x42, 0x29, 0x07, 0x55, 0xfa, 0xaf,
+	0x14, 0x64, 0x78, 0xd5, 0x8c, 0xac, 0xc1, 0x52, 0xab, 0x5d, 0x6e, 0x1f, 0xb7, 0xf4, 0x46, 0xb3,
+	0xa1, 0xca, 0xaf, 0x04, 0x08, 0xb5, 0x46, 0xad, 0x2d, 0x4b, 0x64, 0x05, 0xf2, 0x82, 0xd0, 0x7c,
+	0x24, 0xa7, 0x08, 0x81, 0x55, 0xaf, 0xb9, 0xb7, 0x77, 0x58, 0x6b, 0xa8, 0x72, 0x9a, 0xc8, 0xb0,
+	0x2c, 0x68, 0xaa, 0xa6, 0x35, 0x35, 0x79, 0x81, 0x14, 0xe0, 0x92, 0x2f, 0xb6, 0xad, 0xd7, 0x1a,
+	0xfa, 0x77, 0x8f, 0x9b, 0xda, 0x71, 0x5d, 0x5e, 0x24, 0x1b, 0x70, 0x51, 0xf4, 0x54, 0xd5, 0x4a,
+	0xb3, 0x5e, 0xaf, 0xb5, 0x5a, 0xb5, 0x66, 0x43, 0xce, 0x90, 0x75, 0x20, 0xa2, 0xa3, 0x5e, 0xae,
+	0x35, 0xda, 0x6a, 0xa3, 0xdc, 0xa8, 0xa8, 0x72, 0x36, 0x30, 0xa0, 0xd5, 0x6e, 0x6a, 0xe5, 0x7d,
+	0x55, 0xaf, 0x36, 0x9f, 0x34, 0xe4, 0x1c, 0xb9, 0x0a, 0x1b, 0xd1, 0x0e, 0x75, 0x5f, 0x2b, 0x57,
+	0xd5, 0xaa, 0x9c, 0x0f, 0x8c, 0x6a, 0xa8, 0x6a, 0xb5, 0xa5, 0x6b, 0xea, 0xc3, 0x66, 0xb3, 0x2d,
+	0x03, 0xd9, 0x84, 0x42, 0x64, 0x94, 0xa6, 0x3e, 0x2c, 0x1f, 0xa2, 0xb2, 0x25, 0xb2, 0x05, 0x9b,
+	0x51, 0x99, 0x5a, 0xed, 0x31, 0xe3, 0x39, 0x3a, 0x2c, 0x57, 0x54, 0x79, 0x99, 0xbc, 0x0a, 0x37,
+	0xe2, 0x66, 0xa6, 0x37, 0x9a, 0xde, 0x10, 0x79, 0x85, 0xac, 0x02, 0xf8, 0x73, 0xf9, 0x44, 0x5e,
+	0x2d, 0xfd, 0x48, 0x02, 0xe0, 0xdf, 0x92, 0xf0, 0xa1, 0xcc, 0x25, 0x90, 0x51, 0xac, 0xa6, 0xb7,
+	0x3f, 0x3d, 0x52, 0xbd, 0x95, 0x8f, 0x50, 0xf7, 0x6a, 0x87, 0xaa, 0x2c, 0x91, 0xcb, 0x70, 0x21,
+	0x48, 0x7d, 0x78, 0xd8, 0xac, 0xb0, 0x6d, 0x58, 0x07, 0x12, 0x24, 0x37, 0x1f, 0x7e, 0xac, 0x56,
+	0xda, 0x72, 0x9a, 0x5c, 0x81, 0xcb, 0x41, 0x7a, 0xe5, 0xf0, 0xb8, 0xd5, 0x56, 0x35, 0xb5, 0x2a,
+	0x2f, 0x44, 0x25, 0xed, 0x6b, 0xe5, 0xa3, 0x03, 0x79, 0xb1, 0xf4, 0x87, 0x12, 0x64, 0xf8, 0x8b,
+	0x40, 0xb6, 0x8f, 0x7b, 0xad, 0x10, 0xa6, 0x0b, 0xb0, 0xe2, 0x51, 0x1e, 0xb6, 0xb5, 0xbd, 0x96,
+	0x2c, 0x05, 0x99, 0xd4, 0x4f, 0xda, 0x77, 0xe5, 0x54, 0x90, 0xb2, 0x77, 0xdc, 0x62, 0x06, 0xb1,
+	0x06, 0x4b, 0xbe, 0xa0, 0xbd, 0x96, 0xbc, 0x10, 0x24, 0x3c, 0xde, 0x6b, 0xc9, 0x8b, 0x41, 0xc2,
+	0x27, 0x7b, 0x2d, 0x39, 0x13, 0x24, 0x7c, 0xb6, 0xd7, 0x92, 0xb3, 0xa5, 0x9f, 0x48, 0x70, 0x39,
+	0xf6, 0x23, 0x1c, 0xb9, 0x09, 0xd7, 0x10, 0xbc, 0x2e, 0xa6, 0x53, 0x39, 0x28, 0x37, 0xf6, 0xd5,
+	0x10, 0xee, 0xd7, 0xe1, 0x66, 0x22, 0x4b, 0xbd, 0x59, 0xad, 0xed, 0xd5, 0xd4, 0xaa, 0x2c, 0x11,
+	0x05, 0xae, 0x27, 0xb2, 0x95, 0xab, 0xcc, 0x92, 0x52, 0xe4, 0x35, 0xd8, 0x4a, 0xe4, 0xa9, 0xaa,
+	0x87, 0x6a, 0x5b, 0xad, 0xca, 0xe9, 0x92, 0x0b, 0xcb, 0xc1, 0x47, 0x53, 0x68, 0xcd, 0xea, 0x63,
+	0x55, 0xab, 0xb5, 0x3f, 0x0d, 0x01, 0x63, 0x76, 0x19, 0xa2, 0x97, 0x0f, 0xcb, 0x5a, 0x5d, 0x96,
+	0xd8, 0xc6, 0x85, 0x3b, 0x9e, 0x94, 0xb5, 0x46, 0xad, 0xb1, 0x2f, 0xa7, 0xd0, 0x99, 0x22, 0xb2,
+	0xda, 0xb5, 0xbd, 0x4f, 0xe5, 0x74, 0xe9, 0x77, 0x24, 0x58, 0x0e, 0x86, 0x07, 0xa6, 0x56, 0x53,
+	0x5b, 0xcd, 0x63, 0xad, 0x12, 0x5e, 0x8f, 0x02, 0x5c, 0x0a, 0xd3, 0x1f, 0x37, 0x0f, 0x8f, 0xeb,
+	0xcc, 0xbe, 0x62, 0x46, 0x54, 0x55, 0x39, 0xc5, 0xf0, 0x84, 0xe9, 0xc2, 0x94, 0xe4, 0x34, 0x9b,
+	0x43, 0xb8, 0x0b, 0x57, 0x46, 0x5e, 0x28, 0xfd, 0xa6, 0x04, 0x6b, 0x18, 0x6e, 0xf8, 0x03, 0x06,
+	0x44, 0x54, 0x84, 0xf5, 0xf2, 0xa1, 0xaa, 0xb5, 0xf5, 0x72, 0xa5, 0x5d, 0x6b, 0x36, 0x42, 0xa8,
+	0x36, 0xa1, 0x30, 0xd9, 0xc7, 0xd7, 0x54, 0x96, 0xe2, 0x7b, 0x2b, 0x9a, 0x5a, 0x6e, 0x33, 0x7c,
+	0xb1, 0xbd, 0xc7, 0x47, 0x55, 0xd6, 0x9b, 0x2e, 0x7d, 0xee, 0xbd, 0x55, 0x08, 0x3c, 0x25, 0x61,
+	0x43, 0xf8, 0xb4, 0xbd, 0x31, 0x47, 0x65, 0xad, 0x5c, 0xf7, 0xc0, 0x5c, 0x85, 0x8d, 0xb8, 0xde,
+	0xe6, 0xde, 0x9e, 0x2c, 0xb1, 0x59, 0xc4, 0x76, 0x36, 0xe4, 0x54, 0x69, 0x17, 0xb2, 0xe2, 0x8f,
+	0x19, 0x48, 0x0e, 0x16, 0x84, 0xb4, 0x2c, 0xa4, 0x0f, 0x9b, 0x4f, 0x64, 0x89, 0x00, 0x64, 0xea,
+	0x6a, 0xb5, 0x76, 0x5c, 0x97, 0x53, 0xac, 0xfb, 0xa0, 0xb6, 0x7f, 0x20, 0xa7, 0x4b, 0xbf, 0x02,
+	0x79, 0xff, 0xaf, 0x19, 0xd8, 0x52, 0xd7, 0x9a, 0xfa, 0x91, 0xd6, 0x64, 0x2e, 0xaf, 0xb7, 0xd4,
+	0xef, 0x1e, 0xab, 0x8d, 0x76, 0xad, 0x7c, 0x28, 0xbf, 0xc2, 0x7c, 0x36, 0xd0, 0xa5, 0x95, 0x1b,
+	0xd5, 0x26, 0x33, 0x96, 0x0b, 0xb0, 0x12, 0x20, 0x57, 0x1f, 0x72, 0x23, 0x09, 0x91, 0x74, 0x4d,
+	0xad, 0x37, 0xd9, 0x5a, 0xb0, 0x88, 0x1d, 0xe8, 0xa9, 0xd4, 0x5b, 0xf2, 0x42, 0xe9, 0x47, 0x29,
+	0x58, 0x0a, 0x3c, 0x38, 0x61, 0x7a, 0xc4, 0xfc, 0x58, 0xdc, 0x0a, 0x9a, 0x4d, 0x88, 0x7c, 0xa4,
+	0x36, 0xaa, 0xcc, 0x26, 0x83, 0x0b, 0xc2, 0x7b, 0xca, 0x8f, 0xcb, 0xb5, 0xc3, 0xf2, 0xc3, 0x43,
+	0x61, 0x3a, 0xe1, 0xbe, 0x76, 0xbb, 0x5c, 0x39, 0x60, 0x6e, 0x32, 0xd1, 0x55, 0x55, 0x45, 0xd7,
+	0x42, 0x60, 0xfd, 0xc7, 0x5d, 0xed, 0xca, 0x01, 0x53, 0xb7, 0xc8, 0xac, 0x34, 0xd4, 0xc9, 0xcf,
+	0x99, 0xcc, 0x04, 0x40, 0xcf, 0x21, 0xb3, 0xe4, 0x3a, 0x14, 0x43, 0x3d, 0x6d, 0xed, 0x53, 0xa1,
+	0x8d, 0x49, 0xcc, 0x4d, 0x8c, 0xd4, 0x54, 0x16, 0xbe, 0x55, 0x39, 0x5f, 0xfa, 0x3d, 0x09, 0x96,
+	0x83, 0x2f, 0x9e, 0x23, 0xca, 0xc7, 0x47, 0xe5, 0x35, 0xb8, 0x12, 0xa5, 0xb7, 0xf5, 0x23, 0x4d,
+	0x6d, 0xa9, 0x0d, 0x76, 0x70, 0x5e, 0x02, 0x39, 0xdc, 0x7d, 0x7c, 0xc4, 0x03, 0x77, 0x98, 0x8a,
+	0xa7, 0x59, 0x3a, 0xb2, 0xa0, 0x78, 0x3c, 0x8a, 0xc3, 0x6c, 0xa1, 0xf4, 0x7d, 0x58, 0x09, 0xfd,
+	0xa5, 0x17, 0x3f, 0xfa, 0xf8, 0xf9, 0xc4, 0x8d, 0x4b, 0xaf, 0x97, 0xf7, 0x1b, 0x6a, 0xbb, 0x56,
+	0x91, 0x5f, 0xe1, 0x07, 0x69, 0xa8, 0xb3, 0xd5, 0x62, 0xc1, 0x0e, 0x8f, 0xc4, 0x10, 0xbd, 0xf1,
+	0xb8, 0xae, 0xca, 0xa9, 0xd2, 0x6d, 0x58, 0x11, 0xb9, 0x42, 0xc3, 0x72, 0x7b, 0xcf, 0xce, 0x18,
+	0xa7, 0xf0, 0x76, 0x11, 0x6a, 0x38, 0xc8, 0x57, 0x4a, 0x14, 0x96, 0x02, 0xef, 0xae, 0xd9, 0x6e,
+	0xf2, 0xbd, 0xf5, 0x76, 0xe5, 0x93, 0xb6, 0xaa, 0x35, 0xd0, 0x70, 0xa3, 0x5d, 0xec, 0x44, 0xc7,
+	0x2e, 0x89, 0x9d, 0xb1, 0xb1, 0x5d, 0x7a, 0xeb, 0x49, 0xad, 0x5d, 0x39, 0x90, 0x53, 0xa5, 0x36,
+	0xac, 0x36, 0x87, 0x2c, 0x1b, 0xec, 0x59, 0xe6, 0x5e, 0xdf, 0x38, 0x71, 0xd8, 0x5a, 0x36, 0x8f,
+	0xf4, 0xbd, 0xc3, 0xf2, 0x7e, 0x4b, 0x3f, 0x6e, 0x3c, 0x6a, 0x20, 0x1c, 0xe6, 0x06, 0x3e, 0x15,
+	0xf7, 0x04, 0xc3, 0xa8, 0x4f, 0xe2, 0xdb, 0xad, 0xef, 0x35, 0xb5, 0x8a, 0x2a, 0xa7, 0x76, 0x7f,
+	0xb1, 0x08, 0xa4, 0x39, 0xa4, 0x66, 0xe4, 0x03, 0xe3, 0x6f, 0x49, 0x90, 0xf7, 0xb3, 0x4f, 0xf2,
+	0x56, 0xdc, 0x35, 0x2a, 0xe1, 0xd6, 0x51, 0x7c, 0x7b, 0x36, 0x66, 0x91, 0x0a, 0x6e, 0xfd, 0xda,
+	0xcf, 0xff, 0xfd, 0x0f, 0x52, 0x45, 0xe5, 0xf2, 0xce, 0xe9, 0x7b, 0x3b, 0xe2, 0x7a, 0xb1, 0x43,
+	0x3d, 0xb6, 0x07, 0x52, 0x89, 0xfc, 0xaa, 0x04, 0x59, 0x71, 0x5b, 0x20, 0x6f, 0x4e, 0x91, 0x1d,
+	0xbe, 0x86, 0x14, 0x4b, 0xb3, 0xb0, 0x0a, 0x10, 0xd7, 0x11, 0x44, 0x41, 0xb9, 0x18, 0x04, 0xd1,
+	0xe3, 0x4c, 0x0c, 0xc2, 0x9f, 0x48, 0xb0, 0x1a, 0x4e, 0xc8, 0xc9, 0xbb, 0x53, 0xc4, 0xc7, 0xde,
+	0x45, 0x8a, 0xef, 0xcd, 0x31, 0x42, 0xe0, 0x7a, 0x03, 0x71, 0x6d, 0x29, 0x57, 0x83, 0xb8, 0x30,
+	0x9f, 0x0d, 0x2f, 0xd1, 0x0f, 0x24, 0x80, 0x71, 0x9a, 0x4d, 0xde, 0x3e, 0x4f, 0x53, 0xf0, 0x0a,
+	0x50, 0x7c, 0x67, 0x46, 0x6e, 0x81, 0x49, 0x41, 0x4c, 0x9b, 0xca, 0xc6, 0x24, 0x26, 0x7c, 0x28,
+	0x1c, 0xc2, 0x83, 0x19, 0xf6, 0xf9, 0x78, 0x82, 0xd9, 0xff, 0xf9, 0x78, 0x42, 0x69, 0xfb, 0x34,
+	0x3c, 0x94, 0x31, 0x3e, 0x90, 0x4a, 0xbb, 0xbf, 0xbd, 0x02, 0x17, 0x02, 0x46, 0x2e, 0xfe, 0x14,
+	0xe7, 0x0c, 0x32, 0xbc, 0x4e, 0x42, 0x6e, 0x25, 0x97, 0x09, 0x42, 0xa5, 0x9b, 0xe2, 0xed, 0xf3,
+	0x19, 0x05, 0xac, 0x4d, 0x84, 0xb5, 0xae, 0x5c, 0x60, 0xb0, 0x78, 0x7d, 0x62, 0x87, 0x3f, 0x80,
+	0x63, 0x0b, 0xf4, 0xe7, 0x12, 0x90, 0xc9, 0xf2, 0x21, 0xb9, 0x73, 0x9e, 0xf8, 0x98, 0xa2, 0x67,
+	0xf1, 0xee, 0x7c, 0x83, 0xe2, 0x96, 0x2d, 0x84, 0xef, 0x99, 0x6d, 0x0d, 0x7a, 0x5d, 0x86, 0xf2,
+	0x0c, 0x32, 0xbc, 0xd0, 0x38, 0x6d, 0x81, 0x42, 0x15, 0xcc, 0x69, 0x0b, 0x14, 0xa9, 0x59, 0xc6,
+	0x2d, 0x50, 0x17, 0x59, 0x98, 0xea, 0x5f, 0x1e, 0xfb, 0xfc, 0x14, 0x91, 0x11, 0x97, 0x7f, 0x73,
+	0x06, 0x4e, 0xa1, 0xfd, 0x1a, 0x6a, 0xdf, 0x50, 0x48, 0x40, 0x7b, 0xc0, 0xe1, 0x7f, 0x3d, 0x14,
+	0xfe, 0x4a, 0xc9, 0x72, 0x27, 0xbc, 0xfc, 0xad, 0x99, 0x78, 0x05, 0x8a, 0x1b, 0x88, 0xe2, 0x8a,
+	0x72, 0x29, 0x80, 0x22, 0xe4, 0xd8, 0x7f, 0x2c, 0x8d, 0x9f, 0x36, 0x09, 0x5b, 0xdd, 0x99, 0xb3,
+	0xdc, 0x58, 0x7c, 0x77, 0xf6, 0x01, 0x02, 0xd6, 0xeb, 0x08, 0xeb, 0x86, 0x52, 0x0c, 0xc0, 0xf2,
+	0x6a, 0x4e, 0x01, 0x23, 0xfe, 0xb1, 0x04, 0x6b, 0x91, 0x5a, 0x1e, 0x99, 0x41, 0x59, 0xb8, 0xae,
+	0x18, 0x1f, 0x16, 0xa7, 0x17, 0x0a, 0x43, 0x61, 0x31, 0x8a, 0xcf, 0xe6, 0xcc, 0x0c, 0xe0, 0x5f,
+	0x4a, 0xfc, 0x31, 0x6c, 0xa8, 0xe4, 0x46, 0x76, 0xe7, 0xaf, 0x09, 0x16, 0xef, 0xcc, 0x35, 0x46,
+	0xc0, 0xbc, 0x8d, 0x30, 0x15, 0xe5, 0x5a, 0x1c, 0xcc, 0xd0, 0x36, 0x9f, 0x41, 0x86, 0x67, 0x10,
+	0xd3, 0x1c, 0x2d, 0xf4, 0x21, 0x6a, 0x9a, 0xa3, 0x85, 0xbf, 0x22, 0xc5, 0x3a, 0x1a, 0x7f, 0x79,
+	0xee, 0xfb, 0xf8, 0x79, 0xaa, 0x43, 0xdf, 0x96, 0xa6, 0xfb, 0xf8, 0xb9, 0xaa, 0xbb, 0xd4, 0x53,
+	0x3d, 0x82, 0x45, 0xfc, 0x9e, 0x49, 0xde, 0x98, 0xed, 0xdb, 0x6a, 0xf1, 0xd6, 0xb9, 0x7c, 0x42,
+	0xef, 0x55, 0xd4, 0x7b, 0x59, 0x91, 0x03, 0x7a, 0xf1, 0xcb, 0xa1, 0x08, 0x2d, 0xe2, 0x3b, 0xe2,
+	0xb4, 0xd0, 0x12, 0xfe, 0xae, 0x39, 0x2d, 0xb4, 0x44, 0x3f, 0x4a, 0xc6, 0x85, 0x96, 0x91, 0xe9,
+	0xa9, 0xdf, 0xfd, 0x2b, 0x80, 0xf5, 0x60, 0xc2, 0xe5, 0x7f, 0xd9, 0x76, 0xc8, 0x0f, 0x25, 0x58,
+	0x16, 0x21, 0xdb, 0xb2, 0xcb, 0x4f, 0x5a, 0x64, 0x3b, 0xf6, 0x28, 0x4c, 0x7c, 0x08, 0x54, 0xdc,
+	0x99, 0x99, 0x3f, 0xce, 0xd3, 0xc7, 0xdf, 0xdd, 0x1d, 0xe1, 0xe5, 0x3b, 0xc6, 0x17, 0x8e, 0xf0,
+	0xf4, 0xd5, 0x31, 0xb0, 0x2f, 0x47, 0x49, 0x8e, 0x3e, 0xed, 0x09, 0x58, 0x42, 0xfe, 0x33, 0xed,
+	0x3d, 0x97, 0x72, 0x0b, 0xe1, 0xdd, 0x54, 0x36, 0x93, 0xe0, 0x31, 0x6e, 0x06, 0xf0, 0xcf, 0x24,
+	0x58, 0xf3, 0x01, 0xf2, 0x67, 0x0f, 0x64, 0x26, 0x7d, 0xa1, 0x37, 0x1a, 0xc5, 0xdd, 0x79, 0x86,
+	0xc4, 0x79, 0x79, 0x0c, 0x46, 0x5e, 0x33, 0xf6, 0x40, 0xfa, 0x51, 0x42, 0xec, 0xf0, 0x39, 0x20,
+	0x63, 0x1e, 0xeb, 0x9c, 0x07, 0x32, 0xee, 0x59, 0x4e, 0x32, 0x48, 0x3f, 0x0c, 0x79, 0x5b, 0xfd,
+	0xd7, 0x12, 0x5c, 0x08, 0x81, 0xc4, 0xdd, 0xbe, 0x33, 0xab, 0xce, 0xe0, 0x86, 0xdf, 0x9d, 0x6f,
+	0x90, 0x80, 0x5a, 0x42, 0xa8, 0xaf, 0x29, 0x37, 0xa6, 0x40, 0xf5, 0xb6, 0xfd, 0x6f, 0x25, 0x20,
+	0x41, 0xb0, 0x62, 0xe7, 0x67, 0x55, 0x1c, 0xde, 0xfc, 0x7b, 0x73, 0x8e, 0x12, 0x78, 0xdf, 0x42,
+	0xbc, 0xaf, 0x2b, 0x5b, 0xc9, 0x78, 0xc7, 0x26, 0xf0, 0xfb, 0x12, 0xc8, 0xd1, 0xf7, 0x32, 0x09,
+	0xb7, 0xab, 0xf8, 0x87, 0x39, 0x09, 0xb7, 0xab, 0xa4, 0x27, 0x38, 0x37, 0x11, 0xdc, 0x55, 0x65,
+	0x3d, 0x0a, 0x6e, 0x9c, 0x69, 0xfd, 0x11, 0x4f, 0x45, 0x23, 0xcf, 0x6b, 0xc8, 0x3b, 0xd3, 0xf5,
+	0x44, 0xde, 0xf2, 0x14, 0xb7, 0x67, 0x65, 0x17, 0xc0, 0x5e, 0x45, 0x60, 0xd7, 0x94, 0x42, 0x14,
+	0xd8, 0xa9, 0xe0, 0x7c, 0x20, 0x95, 0x1e, 0x6e, 0xc2, 0xc5, 0x8e, 0x35, 0x88, 0x4a, 0x3e, 0x92,
+	0x3e, 0x4b, 0x1b, 0xc3, 0xde, 0xd3, 0x0c, 0x7e, 0x86, 0xb9, 0xf3, 0x3f, 0x01, 0x00, 0x00, 0xff,
+	0xff, 0x22, 0x8b, 0x47, 0x76, 0x4c, 0x48, 0x00, 0x00,
 }

--- a/api/api.pb.gw.go
+++ b/api/api.pb.gw.go
@@ -29,7 +29,7 @@ var _ = runtime.String
 var _ = utilities.NewDoubleArray
 
 func request_OpenStorageCluster_Enumerate_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageClusterClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq ClusterEnumerateRequest
+	var protoReq SdkClusterEnumerateRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -42,7 +42,7 @@ func request_OpenStorageCluster_Enumerate_0(ctx context.Context, marshaler runti
 }
 
 func request_OpenStorageCluster_Inspect_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageClusterClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq ClusterInspectRequest
+	var protoReq SdkClusterInspectRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -55,7 +55,7 @@ func request_OpenStorageCluster_Inspect_0(ctx context.Context, marshaler runtime
 }
 
 func request_OpenStorageCluster_AlertEnumerate_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageClusterClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq ClusterAlertEnumerateRequest
+	var protoReq SdkClusterAlertEnumerateRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -68,7 +68,7 @@ func request_OpenStorageCluster_AlertEnumerate_0(ctx context.Context, marshaler 
 }
 
 func request_OpenStorageCluster_AlertClear_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageClusterClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq ClusterAlertClearRequest
+	var protoReq SdkClusterAlertClearRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -81,7 +81,7 @@ func request_OpenStorageCluster_AlertClear_0(ctx context.Context, marshaler runt
 }
 
 func request_OpenStorageCluster_AlertErase_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageClusterClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq ClusterAlertEraseRequest
+	var protoReq SdkClusterAlertEraseRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -94,7 +94,7 @@ func request_OpenStorageCluster_AlertErase_0(ctx context.Context, marshaler runt
 }
 
 func request_OpenStorageVolume_Create_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageVolumeClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq OpenStorageVolumeCreateRequest
+	var protoReq SdkVolumeCreateRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -106,21 +106,21 @@ func request_OpenStorageVolume_Create_0(ctx context.Context, marshaler runtime.M
 
 }
 
-func request_OpenStorageVolume_CreateFromVolumeID_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageVolumeClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq VolumeCreateFromVolumeIDRequest
+func request_OpenStorageVolume_CreateFromVolumeId_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageVolumeClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq SdkVolumeCreateFromVolumeIdRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
 		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
 	}
 
-	msg, err := client.CreateFromVolumeID(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	msg, err := client.CreateFromVolumeId(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
 	return msg, metadata, err
 
 }
 
 func request_OpenStorageVolume_Delete_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageVolumeClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq VolumeDeleteRequest
+	var protoReq SdkVolumeDeleteRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -133,7 +133,7 @@ func request_OpenStorageVolume_Delete_0(ctx context.Context, marshaler runtime.M
 }
 
 func request_OpenStorageVolume_Inspect_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageVolumeClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq VolumeInspectRequest
+	var protoReq SdkVolumeInspectRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -146,7 +146,7 @@ func request_OpenStorageVolume_Inspect_0(ctx context.Context, marshaler runtime.
 }
 
 func request_OpenStorageVolume_Enumerate_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageVolumeClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq VolumeEnumerateRequest
+	var protoReq SdkVolumeEnumerateRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -159,7 +159,7 @@ func request_OpenStorageVolume_Enumerate_0(ctx context.Context, marshaler runtim
 }
 
 func request_OpenStorageVolume_SnapshotCreate_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageVolumeClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq VolumeSnapshotCreateRequest
+	var protoReq SdkVolumeSnapshotCreateRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -172,7 +172,7 @@ func request_OpenStorageVolume_SnapshotCreate_0(ctx context.Context, marshaler r
 }
 
 func request_OpenStorageVolume_SnapshotRestore_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageVolumeClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq VolumeSnapshotRestoreRequest
+	var protoReq SdkVolumeSnapshotRestoreRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -185,7 +185,7 @@ func request_OpenStorageVolume_SnapshotRestore_0(ctx context.Context, marshaler 
 }
 
 func request_OpenStorageVolume_SnapshotEnumerate_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageVolumeClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq VolumeSnapshotEnumerateRequest
+	var protoReq SdkVolumeSnapshotEnumerateRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -198,7 +198,7 @@ func request_OpenStorageVolume_SnapshotEnumerate_0(ctx context.Context, marshale
 }
 
 func request_OpenStorageVolume_Attach_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageVolumeClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq VolumeAttachRequest
+	var protoReq SdkVolumeAttachRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -211,7 +211,7 @@ func request_OpenStorageVolume_Attach_0(ctx context.Context, marshaler runtime.M
 }
 
 func request_OpenStorageVolume_Detach_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageVolumeClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq VolumeDetachRequest
+	var protoReq SdkVolumeDetachRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -224,7 +224,7 @@ func request_OpenStorageVolume_Detach_0(ctx context.Context, marshaler runtime.M
 }
 
 func request_OpenStorageVolume_Mount_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageVolumeClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq VolumeMountRequest
+	var protoReq SdkVolumeMountRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -237,7 +237,7 @@ func request_OpenStorageVolume_Mount_0(ctx context.Context, marshaler runtime.Ma
 }
 
 func request_OpenStorageVolume_Unmount_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageVolumeClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq VolumeUnmountRequest
+	var protoReq SdkVolumeUnmountRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -250,7 +250,7 @@ func request_OpenStorageVolume_Unmount_0(ctx context.Context, marshaler runtime.
 }
 
 func request_OpenStorageCredentials_CreateForAWS_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageCredentialsClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq CredentialCreateAWSRequest
+	var protoReq SdkCredentialCreateAWSRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -263,7 +263,7 @@ func request_OpenStorageCredentials_CreateForAWS_0(ctx context.Context, marshale
 }
 
 func request_OpenStorageCredentials_CreateForAzure_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageCredentialsClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq CredentialCreateAzureRequest
+	var protoReq SdkCredentialCreateAzureRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -276,7 +276,7 @@ func request_OpenStorageCredentials_CreateForAzure_0(ctx context.Context, marsha
 }
 
 func request_OpenStorageCredentials_CreateForGoogle_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageCredentialsClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq CredentialCreateGoogleRequest
+	var protoReq SdkCredentialCreateGoogleRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -289,7 +289,7 @@ func request_OpenStorageCredentials_CreateForGoogle_0(ctx context.Context, marsh
 }
 
 func request_OpenStorageCredentials_EnumerateForAWS_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageCredentialsClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq CredentialEnumerateAWSRequest
+	var protoReq SdkCredentialEnumerateAWSRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -302,7 +302,7 @@ func request_OpenStorageCredentials_EnumerateForAWS_0(ctx context.Context, marsh
 }
 
 func request_OpenStorageCredentials_EnumerateForAzure_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageCredentialsClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq CredentialEnumerateAzureRequest
+	var protoReq SdkCredentialEnumerateAzureRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -315,7 +315,7 @@ func request_OpenStorageCredentials_EnumerateForAzure_0(ctx context.Context, mar
 }
 
 func request_OpenStorageCredentials_EnumerateForGoogle_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageCredentialsClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq CredentialEnumerateGoogleRequest
+	var protoReq SdkCredentialEnumerateGoogleRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -328,7 +328,7 @@ func request_OpenStorageCredentials_EnumerateForGoogle_0(ctx context.Context, ma
 }
 
 func request_OpenStorageCredentials_CredentialDelete_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageCredentialsClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq CredentialDeleteRequest
+	var protoReq SdkCredentialDeleteRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -341,7 +341,7 @@ func request_OpenStorageCredentials_CredentialDelete_0(ctx context.Context, mars
 }
 
 func request_OpenStorageCredentials_CredentialValidate_0(ctx context.Context, marshaler runtime.Marshaler, client OpenStorageCredentialsClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
-	var protoReq CredentialValidateRequest
+	var protoReq SdkCredentialValidateRequest
 	var metadata runtime.ServerMetadata
 
 	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && err != io.EOF {
@@ -630,7 +630,7 @@ func RegisterOpenStorageVolumeHandlerClient(ctx context.Context, mux *runtime.Se
 
 	})
 
-	mux.Handle("POST", pattern_OpenStorageVolume_CreateFromVolumeID_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+	mux.Handle("POST", pattern_OpenStorageVolume_CreateFromVolumeId_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
 		if cn, ok := w.(http.CloseNotifier); ok {
@@ -648,14 +648,14 @@ func RegisterOpenStorageVolumeHandlerClient(ctx context.Context, mux *runtime.Se
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
-		resp, md, err := request_OpenStorageVolume_CreateFromVolumeID_0(rctx, inboundMarshaler, client, req, pathParams)
+		resp, md, err := request_OpenStorageVolume_CreateFromVolumeId_0(rctx, inboundMarshaler, client, req, pathParams)
 		ctx = runtime.NewServerMetadataContext(ctx, md)
 		if err != nil {
 			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
 			return
 		}
 
-		forward_OpenStorageVolume_CreateFromVolumeID_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+		forward_OpenStorageVolume_CreateFromVolumeId_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 
 	})
 
@@ -955,7 +955,7 @@ func RegisterOpenStorageVolumeHandlerClient(ctx context.Context, mux *runtime.Se
 var (
 	pattern_OpenStorageVolume_Create_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "volume", "create"}, ""))
 
-	pattern_OpenStorageVolume_CreateFromVolumeID_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "volume", "createfromid"}, ""))
+	pattern_OpenStorageVolume_CreateFromVolumeId_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "volume", "createfromid"}, ""))
 
 	pattern_OpenStorageVolume_Delete_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"v1", "volume", "delete"}, ""))
 
@@ -981,7 +981,7 @@ var (
 var (
 	forward_OpenStorageVolume_Create_0 = runtime.ForwardResponseMessage
 
-	forward_OpenStorageVolume_CreateFromVolumeID_0 = runtime.ForwardResponseMessage
+	forward_OpenStorageVolume_CreateFromVolumeId_0 = runtime.ForwardResponseMessage
 
 	forward_OpenStorageVolume_Delete_0 = runtime.ForwardResponseMessage
 

--- a/api/api.proto
+++ b/api/api.proto
@@ -674,8 +674,8 @@ message StorageCluster {
 
 service OpenStorageCluster {
   // Enumerate lists all the nodes in the cluster.
-  rpc Enumerate(ClusterEnumerateRequest)
-    returns (ClusterEnumerateResponse) {
+  rpc Enumerate(SdkClusterEnumerateRequest)
+    returns (SdkClusterEnumerateResponse) {
       option(google.api.http) = {
         post: "/v1/cluster/enumerate"
         body: "*"
@@ -683,8 +683,8 @@ service OpenStorageCluster {
     }
 
   // Inspect the node given a UUID.
-  rpc Inspect(ClusterInspectRequest)
-    returns (ClusterInspectResponse) {
+  rpc Inspect(SdkClusterInspectRequest)
+    returns (SdkClusterInspectResponse) {
       option(google.api.http) = {
         post: "/v1/cluster/inspect"
         body: "*"
@@ -692,8 +692,8 @@ service OpenStorageCluster {
     }
 
   // Get a list of alerts from the storage cluster
-  rpc AlertEnumerate(ClusterAlertEnumerateRequest)
-    returns (ClusterAlertEnumerateResponse) {
+  rpc AlertEnumerate(SdkClusterAlertEnumerateRequest)
+    returns (SdkClusterAlertEnumerateResponse) {
       option(google.api.http) = {
         post: "/v1/cluster/alert/enumerate"
         body: "*"
@@ -701,8 +701,8 @@ service OpenStorageCluster {
     }
 
   // Clear the alert for a given resource
-  rpc AlertClear(ClusterAlertClearRequest)
-    returns (ClusterAlertClearResponse) {
+  rpc AlertClear(SdkClusterAlertClearRequest)
+    returns (SdkClusterAlertClearResponse) {
       option(google.api.http) = {
         post: "/v1/cluster/alert/clear"
         body: "*"
@@ -710,8 +710,8 @@ service OpenStorageCluster {
     }
 
   // Erases an alert for a given resource
-  rpc AlertErase(ClusterAlertEraseRequest)
-    returns (ClusterAlertEraseResponse) {
+  rpc AlertErase(SdkClusterAlertEraseRequest)
+    returns (SdkClusterAlertEraseResponse) {
       option(google.api.http) = {
         post: "/v1/cluster/alert/erase"
         body: "*"
@@ -721,17 +721,17 @@ service OpenStorageCluster {
 
 service OpenStorageVolume {
   // Creates a new volume
-  rpc Create(OpenStorageVolumeCreateRequest)
-    returns (OpenStorageVolumeCreateResponse) {
+  rpc Create(SdkVolumeCreateRequest)
+    returns (SdkVolumeCreateResponse) {
       option(google.api.http) = {
         post: "/v1/volume/create"
         body: "*"
       };
     }
 
-  // CreateFromVolumeID creates a new volume cloned from an existing volume
-  rpc CreateFromVolumeID(VolumeCreateFromVolumeIDRequest)
-    returns (VolumeCreateFromVolumeIDResponse) {
+  // CreateFromVolumeId creates a new volume cloned from an existing volume
+  rpc CreateFromVolumeId(SdkVolumeCreateFromVolumeIdRequest)
+    returns (SdkVolumeCreateFromVolumeIdResponse) {
       option(google.api.http) = {
         post: "/v1/volume/createfromid"
         body: "*"
@@ -739,8 +739,8 @@ service OpenStorageVolume {
     }
 
   // Delete a volume
-  rpc Delete(VolumeDeleteRequest)
-    returns (VolumeDeleteResponse) {
+  rpc Delete(SdkVolumeDeleteRequest)
+    returns (SdkVolumeDeleteResponse) {
       option(google.api.http) = {
         post: "/v1/volume/delete"
         body: "*"
@@ -748,8 +748,8 @@ service OpenStorageVolume {
     }
 
   // Get information on a volume
-  rpc Inspect(VolumeInspectRequest)
-    returns (VolumeInspectResponse) {
+  rpc Inspect(SdkVolumeInspectRequest)
+    returns (SdkVolumeInspectResponse) {
       option(google.api.http) = {
         post: "/v1/volume/inspect"
         body: "*"
@@ -757,8 +757,8 @@ service OpenStorageVolume {
     }
 
   // Get a list of volumes
-  rpc Enumerate(VolumeEnumerateRequest)
-    returns (VolumeEnumerateResponse) {
+  rpc Enumerate(SdkVolumeEnumerateRequest)
+    returns (SdkVolumeEnumerateResponse) {
       option(google.api.http) = {
         post: "/v1/volume/enumerate"
         body: "*"
@@ -767,8 +767,8 @@ service OpenStorageVolume {
 
   // Create a snapshot of a volume. This creates an immutable (read-only),
   // point-in-time snapshot of a volume.
-  rpc SnapshotCreate(VolumeSnapshotCreateRequest)
-    returns (VolumeSnapshotCreateResponse) {
+  rpc SnapshotCreate(SdkVolumeSnapshotCreateRequest)
+    returns (SdkVolumeSnapshotCreateResponse) {
       option(google.api.http) = {
         post: "/v1/volume/snapshot/create"
         body: "*"
@@ -776,8 +776,8 @@ service OpenStorageVolume {
     }
 
   // Restores a volume to a specified snapshot
-  rpc SnapshotRestore(VolumeSnapshotRestoreRequest)
-    returns (VolumeSnapshotRestoreResponse) {
+  rpc SnapshotRestore(SdkVolumeSnapshotRestoreRequest)
+    returns (SdkVolumeSnapshotRestoreResponse) {
       option(google.api.http) = {
         post: "/v1/volume/snapshot/restore"
         body: "*"
@@ -785,8 +785,8 @@ service OpenStorageVolume {
     }
 
   // List the number of snapshots for a specific volume
-  rpc SnapshotEnumerate(VolumeSnapshotEnumerateRequest)
-    returns (VolumeSnapshotEnumerateResponse) {
+  rpc SnapshotEnumerate(SdkVolumeSnapshotEnumerateRequest)
+    returns (SdkVolumeSnapshotEnumerateResponse) {
       option(google.api.http) = {
         post: "/v1/volume/snapshot/enumerate"
         body: "*"
@@ -794,8 +794,8 @@ service OpenStorageVolume {
     }
 
   // Attach device to host                                                      
-  rpc Attach(VolumeAttachRequest)                                               
-    returns (VolumeAttachResponse) {                                            
+  rpc Attach(SdkVolumeAttachRequest)                                               
+    returns (SdkVolumeAttachResponse) {                                            
       option(google.api.http) = {                                               
         post: "/v1/volume/attach"                                               
         body: "*"                                                               
@@ -803,8 +803,8 @@ service OpenStorageVolume {
     }  
 
   // Detaches the volume from the node.
-  rpc Detach(VolumeDetachRequest)
-    returns (VolumeDetachResponse) {
+  rpc Detach(SdkVolumeDetachRequest)
+    returns (SdkVolumeDetachResponse) {
       option(google.api.http) = {
         post: "/v1/volume/detach"
         body: "*"
@@ -812,8 +812,8 @@ service OpenStorageVolume {
     }
 
   // Attaches the volume to a node.
-  rpc Mount(VolumeMountRequest)
-    returns(VolumeMountResponse) {
+  rpc Mount(SdkVolumeMountRequest)
+    returns(SdkVolumeMountResponse) {
       option(google.api.http) = {
         post: "/v1/volume/mount"
         body: "*"
@@ -821,8 +821,8 @@ service OpenStorageVolume {
     }
 
   // Unmount volume at specified path                                           
-  rpc Unmount(VolumeUnmountRequest)                                             
-    returns (VolumeUnmountResponse) {                                         
+  rpc Unmount(SdkVolumeUnmountRequest)                                             
+      returns(SdkVolumeUnmountResponse) {                                         
       option(google.api.http) = {                                               
         post: "/v1/volume/unmount"                                              
         body: "*"                                                               
@@ -837,8 +837,8 @@ service OpenStorageCredentials {
 
   // Create credential for AWS S3 and if valid ,
   // returns a unique identifier
-  rpc CreateForAWS(CredentialCreateAWSRequest)
-    returns (CredentialCreateAWSResponse) {
+  rpc CreateForAWS(SdkCredentialCreateAWSRequest)
+    returns (SdkCredentialCreateAWSResponse) {
       option(google.api.http) = {
         post: "/v1/credentials/create/aws"
         body: "*"
@@ -847,8 +847,8 @@ service OpenStorageCredentials {
 
   // Create credential for Azure and if valid ,
   // returns a unique identifier
-  rpc CreateForAzure(CredentialCreateAzureRequest)
-    returns (CredentialCreateAzureResponse) {
+  rpc CreateForAzure(SdkCredentialCreateAzureRequest)
+    returns (SdkCredentialCreateAzureResponse) {
       option(google.api.http) = {
         post: "/v1/credentials/create/azure"
         body: "*"
@@ -857,8 +857,8 @@ service OpenStorageCredentials {
 
   // Create credential for Google and if valid ,
   // returns a unique identifier
-  rpc CreateForGoogle(CredentialCreateGoogleRequest)
-    returns (CredentialCreateGoogleResponse) {
+  rpc CreateForGoogle(SdkCredentialCreateGoogleRequest)
+    returns (SdkCredentialCreateGoogleResponse) {
       option(google.api.http) = {
         post: "/v1/credentials/create/google"
         body: "*"
@@ -866,8 +866,8 @@ service OpenStorageCredentials {
     }
 
   // EnumerateForAWS lists the configured AWS credentials                      
-  rpc EnumerateForAWS(CredentialEnumerateAWSRequest)                       
-    returns (CredentialEnumerateAWSResponse) {                             
+  rpc EnumerateForAWS(SdkCredentialEnumerateAWSRequest)                       
+    returns (SdkCredentialEnumerateAWSResponse) {                             
       option(google.api.http) = {                                                
         post: "/v1/credentials/enumerate/aws"                                    
         body: "*"                                                                
@@ -875,8 +875,8 @@ service OpenStorageCredentials {
     }                                                                            
                                                                                 
   // EnumerateForAzure lists the configured Azure credentials                  
-  rpc EnumerateForAzure(CredentialEnumerateAzureRequest)                   
-    returns (CredentialEnumerateAzureResponse) {                           
+  rpc EnumerateForAzure(SdkCredentialEnumerateAzureRequest)                   
+    returns (SdkCredentialEnumerateAzureResponse) {                           
       option(google.api.http) = {                                                
         post: "/v1/credentials/enumerate/azure"                                  
         body: "*"                                                                
@@ -884,8 +884,8 @@ service OpenStorageCredentials {
     }                                                                            
 
   // EnumerateForGoogle lists the configured Google credentials                
-  rpc EnumerateForGoogle(CredentialEnumerateGoogleRequest)                 
-    returns (CredentialEnumerateGoogleResponse) {                        
+  rpc EnumerateForGoogle(SdkCredentialEnumerateGoogleRequest)                 
+    returns (SdkCredentialEnumerateGoogleResponse) {                        
       option(google.api.http) = {                                              
         post: "/v1/credentials/enumerate/google"                               
         body: "*"                                                              
@@ -893,8 +893,8 @@ service OpenStorageCredentials {
     }                                                                          
                                                                                 
   // Delete a specified credential                                                 
-  rpc CredentialDelete(CredentialDeleteRequest)                                         
-    returns (CredentialDeleteResponse){                                             
+  rpc CredentialDelete(SdkCredentialDeleteRequest)                                         
+    returns (SdkCredentialDeleteResponse){                                             
       option(google.api.http) = {                                               
         post: "/v1/credentials/delete"                                       
         body: "*"                                                              
@@ -902,8 +902,8 @@ service OpenStorageCredentials {
     }                                               
 
   // Validate a specified credential
-  rpc CredentialValidate(CredentialValidateRequest)
-    returns (CredentialValidateResponse) {
+  rpc CredentialValidate(SdkCredentialValidateRequest)
+    returns (SdkCredentialValidateResponse) {
       option(google.api.http) = {
         post: "/v1/credentials/validate"
         body: "*"
@@ -911,32 +911,32 @@ service OpenStorageCredentials {
     }
 }
 
-message CredentialCreateAzureRequest {
+message SdkCredentialCreateAzureRequest {
   // Azure Credential
   AzureCredential credential = 1;
 }
 
-message CredentialCreateAzureResponse {
+message SdkCredentialCreateAzureResponse {
   // Id of the credentials
   string credential_id = 1;
 }
 
-message CredentialCreateGoogleRequest {
+message SdkCredentialCreateGoogleRequest {
   // Google Credential
   GoogleCredential credential = 1;
 }
 
-message CredentialCreateGoogleResponse {
+message SdkCredentialCreateGoogleResponse {
   // Id of the credentials
   string credential_id = 1;
 }
 
-message CredentialCreateAWSRequest {
+message SdkCredentialCreateAWSRequest {
   // AWS S3 Credential
   S3Credential credential = 1;
 }
 
-message CredentialCreateAWSResponse {
+message SdkCredentialCreateAWSResponse {
   // Id of the credentials
   string credential_id = 1;
 }
@@ -972,50 +972,50 @@ message GoogleCredential {
 }
 
 // should enumerate accept anything?                                            
-message CredentialEnumerateAWSRequest {                                     
+message SdkCredentialEnumerateAWSRequest {                                     
   // Id of the credentials                                                     
   string credential_id = 1;                                                    
 }                  
 
-message CredentialEnumerateAWSResponse {                                   
+message SdkCredentialEnumerateAWSResponse {                                   
 	// Array of Credentials for AWS
 	repeated S3Credential credential = 1;
 }                                                                               
                                                                                 
-message CredentialEnumerateAzureRequest {                                   
+message SdkCredentialEnumerateAzureRequest {                                   
   string credential_id = 1;                                                   
 }                                                                               
                                                                                 
-message CredentialEnumerateAzureResponse {                                  
+message SdkCredentialEnumerateAzureResponse {                                  
 	// List of Credentials for Azure
 	repeated AzureCredential credential = 1;
 }                                                                               
                                                                                 
-message CredentialEnumerateGoogleRequest {                                  
+message SdkCredentialEnumerateGoogleRequest {                                  
   string credential_id = 1;                                                   
 }                                                                               
                                                                                 
-message CredentialEnumerateGoogleResponse {                               
+message SdkCredentialEnumerateGoogleResponse {                               
 	// List of Credentials for Google 
 	repeated GoogleCredential credential = 1; 
 }                            
-message CredentialDeleteRequest {                                                   
+message SdkCredentialDeleteRequest {                                                   
   // ID for credentials                                                       
   string credential_id = 1;                                                   
 }  
 
-message CredentialDeleteResponse {                                                  
+message SdkCredentialDeleteResponse {                                                  
 }                                                                               
       
-message CredentialValidateRequest {
+message SdkCredentialValidateRequest {
   // Id of the credentials
   string credential_id = 1;
 }
 
-message CredentialValidateResponse {
+message SdkCredentialValidateResponse {
 }
 
-message VolumeMountRequest {
+message SdkVolumeMountRequest {
   // Id of the volume
   string volume_id = 1;
   // Mount path for mounting the volume.
@@ -1024,10 +1024,10 @@ message VolumeMountRequest {
   map<string, string> options = 3;  
 }
 
-message VolumeMountResponse {
+message SdkVolumeMountResponse {
 }
 
-message VolumeUnmountRequest {                                                  
+message SdkVolumeUnmountRequest {                                                  
   // Id of volume                                                             
   string volume_id = 1;                                                       
   // MountPath for device                                                     
@@ -1036,42 +1036,42 @@ message VolumeUnmountRequest {
   map<string, string> options = 3;                                            
 }
      
-message VolumeUnmountResponse {                                                 
+message SdkVolumeUnmountResponse {                                                 
 }
 
-message VolumeAttachRequest {                                                   
+message SdkVolumeAttachRequest {                                                   
   // Id of volume                                                             
   string volume_id = 1;                                                       
   // Options for attaching volume, right now only passphrase options is supported
   map<string, string>  options = 2;                                           
 }                                                                               
                                                                                 
-message VolumeAttachResponse {                                                  
+message SdkVolumeAttachResponse {                                                  
   // Device path where device is exported                                     
   string device_path = 1;                                                     
 }
           
-message VolumeDetachRequest {
+message SdkVolumeDetachRequest {
   // Id of the volume
   string volume_id = 1;
 }
 
-message VolumeDetachResponse {
+message SdkVolumeDetachResponse {
 }
 
-message OpenStorageVolumeCreateRequest {
+message SdkVolumeCreateRequest {
   // Unique name of the volume. This will be used for idempotency.
   string name = 1;
   // Volume specification
   VolumeSpec spec = 2;
 }
 
-message OpenStorageVolumeCreateResponse {
+message SdkVolumeCreateResponse {
   // Id of new volume
   string volume_id = 1;
 }
 
-message VolumeCreateFromVolumeIDRequest {
+message SdkVolumeCreateFromVolumeIdRequest {
   // Unique name of the volume. This will be used for idempotency.
   string name = 1;
   // Parent volume id, if specified will create a new volume as a clone of the parent.
@@ -1080,93 +1080,93 @@ message VolumeCreateFromVolumeIDRequest {
   VolumeSpec spec = 3;
 }
 
-message VolumeCreateFromVolumeIDResponse {
+message SdkVolumeCreateFromVolumeIdResponse {
   // Id of new volume
   string volume_id = 1;
 }
 
-message VolumeDeleteRequest {
+message SdkVolumeDeleteRequest {
   // Id of volume to delete
   string volume_id = 1;
 }
 
-message VolumeDeleteResponse {
+message SdkVolumeDeleteResponse {
 }
 
-message VolumeInspectRequest {
+message SdkVolumeInspectRequest {
   // Id of volume to inspect
   string volume_id = 1;
 }
 
-message VolumeInspectResponse {
+message SdkVolumeInspectResponse {
   // Information about the volume
   Volume volume = 1;
 }
 
-message VolumeEnumerateRequest {
+message SdkVolumeEnumerateRequest {
   // Volumes to match to this locator.
   // If not provided, all volumes will be returned.
   VolumeLocator locator = 1;
 }
 
-message VolumeEnumerateResponse {
+message SdkVolumeEnumerateResponse {
   // List of volumes matching label
   repeated Volume volumes = 1;
 }
 
-message VolumeSnapshotCreateRequest{
+message SdkVolumeSnapshotCreateRequest{
   // Id of volume to take the snapshot from
   string volume_id = 1;
   // Labels to apply to snapshot
   map<string, string> labels = 2;
 }
 
-message VolumeSnapshotCreateResponse {
+message SdkVolumeSnapshotCreateResponse {
   // Id of immutable snapshot
   string snapshot_id = 1;
 }
 
-message VolumeSnapshotRestoreRequest {
+message SdkVolumeSnapshotRestoreRequest {
   // Id of volume
   string volume_id = 1;
   // Snapshot id to apply to `volume_id`
   string snapshot_id = 2;
 }
 
-message VolumeSnapshotRestoreResponse {
+message SdkVolumeSnapshotRestoreResponse {
 }
 
-message VolumeSnapshotEnumerateRequest {
+message SdkVolumeSnapshotEnumerateRequest {
   // Id of volume
   string volume_id = 1;
   // Labels from snapshot
   map<string, string> labels = 2;
 }
 
-message VolumeSnapshotEnumerateResponse {
+message SdkVolumeSnapshotEnumerateResponse {
   // List of immutable snapshots
   repeated Volume snapshots = 1;
 }
 
-message ClusterEnumerateRequest {
+message SdkClusterEnumerateRequest {
 }
 
-message ClusterEnumerateResponse {
+message SdkClusterEnumerateResponse {
   // Cluster information
 	StorageCluster cluster = 1;
 }
 
-message ClusterInspectRequest {
+message SdkClusterInspectRequest {
   // Id of node to inspect (required)
 	string node_id = 1;
 }
 
-message ClusterInspectResponse {
+message SdkClusterInspectResponse {
   // Node information
 	StorageNode node = 1;
 }
 
-message ClusterAlertEnumerateRequest {
+message SdkClusterAlertEnumerateRequest {
   // Start time of alerts (required)
   google.protobuf.Timestamp time_start = 1;
   // End time of alerts (required) 
@@ -1175,27 +1175,27 @@ message ClusterAlertEnumerateRequest {
 	ResourceType resource = 3;
 }
 
-message ClusterAlertEnumerateResponse {
+message SdkClusterAlertEnumerateResponse {
   // Information on the alerts requested 
 	Alerts alerts = 1;
 }
 
-message ClusterAlertClearRequest {
+message SdkClusterAlertClearRequest {
   // Type of resource (required)
   ResourceType resource = 1;
   // Id of alert as returned by ClusterEnumerateAlertResponse (required) 
 	int64 alert_id = 2;
 }
 
-message ClusterAlertClearResponse {
+message SdkClusterAlertClearResponse {
 }
 
-message ClusterAlertEraseRequest {
+message SdkClusterAlertEraseRequest {
   // Type of resource (required)
   ResourceType resource = 1;
   // Id of alert as returned by ClusterEnumerateAlertResponse (required) 
 	int64 alert_id = 2;
 }
 
-message ClusterAlertEraseResponse {
+message SdkClusterAlertEraseResponse {
 }

--- a/api/client/sdk/js/api_grpc_pb.js
+++ b/api/client/sdk/js/api_grpc_pb.js
@@ -6,378 +6,554 @@ var api_pb = require('./api_pb.js');
 var google_protobuf_timestamp_pb = require('google-protobuf/google/protobuf/timestamp_pb.js');
 var google_api_annotations_pb = require('./google/api/annotations_pb.js');
 
-function serialize_openstorage_api_ClusterAlertClearRequest(arg) {
-  if (!(arg instanceof api_pb.ClusterAlertClearRequest)) {
-    throw new Error('Expected argument of type openstorage.api.ClusterAlertClearRequest');
+function serialize_openstorage_api_SdkClusterAlertClearRequest(arg) {
+  if (!(arg instanceof api_pb.SdkClusterAlertClearRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkClusterAlertClearRequest');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_ClusterAlertClearRequest(buffer_arg) {
-  return api_pb.ClusterAlertClearRequest.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkClusterAlertClearRequest(buffer_arg) {
+  return api_pb.SdkClusterAlertClearRequest.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_ClusterAlertClearResponse(arg) {
-  if (!(arg instanceof api_pb.ClusterAlertClearResponse)) {
-    throw new Error('Expected argument of type openstorage.api.ClusterAlertClearResponse');
+function serialize_openstorage_api_SdkClusterAlertClearResponse(arg) {
+  if (!(arg instanceof api_pb.SdkClusterAlertClearResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkClusterAlertClearResponse');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_ClusterAlertClearResponse(buffer_arg) {
-  return api_pb.ClusterAlertClearResponse.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkClusterAlertClearResponse(buffer_arg) {
+  return api_pb.SdkClusterAlertClearResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_ClusterAlertEnumerateRequest(arg) {
-  if (!(arg instanceof api_pb.ClusterAlertEnumerateRequest)) {
-    throw new Error('Expected argument of type openstorage.api.ClusterAlertEnumerateRequest');
+function serialize_openstorage_api_SdkClusterAlertEnumerateRequest(arg) {
+  if (!(arg instanceof api_pb.SdkClusterAlertEnumerateRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkClusterAlertEnumerateRequest');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_ClusterAlertEnumerateRequest(buffer_arg) {
-  return api_pb.ClusterAlertEnumerateRequest.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkClusterAlertEnumerateRequest(buffer_arg) {
+  return api_pb.SdkClusterAlertEnumerateRequest.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_ClusterAlertEnumerateResponse(arg) {
-  if (!(arg instanceof api_pb.ClusterAlertEnumerateResponse)) {
-    throw new Error('Expected argument of type openstorage.api.ClusterAlertEnumerateResponse');
+function serialize_openstorage_api_SdkClusterAlertEnumerateResponse(arg) {
+  if (!(arg instanceof api_pb.SdkClusterAlertEnumerateResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkClusterAlertEnumerateResponse');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_ClusterAlertEnumerateResponse(buffer_arg) {
-  return api_pb.ClusterAlertEnumerateResponse.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkClusterAlertEnumerateResponse(buffer_arg) {
+  return api_pb.SdkClusterAlertEnumerateResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_ClusterAlertEraseRequest(arg) {
-  if (!(arg instanceof api_pb.ClusterAlertEraseRequest)) {
-    throw new Error('Expected argument of type openstorage.api.ClusterAlertEraseRequest');
+function serialize_openstorage_api_SdkClusterAlertEraseRequest(arg) {
+  if (!(arg instanceof api_pb.SdkClusterAlertEraseRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkClusterAlertEraseRequest');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_ClusterAlertEraseRequest(buffer_arg) {
-  return api_pb.ClusterAlertEraseRequest.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkClusterAlertEraseRequest(buffer_arg) {
+  return api_pb.SdkClusterAlertEraseRequest.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_ClusterAlertEraseResponse(arg) {
-  if (!(arg instanceof api_pb.ClusterAlertEraseResponse)) {
-    throw new Error('Expected argument of type openstorage.api.ClusterAlertEraseResponse');
+function serialize_openstorage_api_SdkClusterAlertEraseResponse(arg) {
+  if (!(arg instanceof api_pb.SdkClusterAlertEraseResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkClusterAlertEraseResponse');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_ClusterAlertEraseResponse(buffer_arg) {
-  return api_pb.ClusterAlertEraseResponse.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkClusterAlertEraseResponse(buffer_arg) {
+  return api_pb.SdkClusterAlertEraseResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_ClusterEnumerateRequest(arg) {
-  if (!(arg instanceof api_pb.ClusterEnumerateRequest)) {
-    throw new Error('Expected argument of type openstorage.api.ClusterEnumerateRequest');
+function serialize_openstorage_api_SdkClusterEnumerateRequest(arg) {
+  if (!(arg instanceof api_pb.SdkClusterEnumerateRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkClusterEnumerateRequest');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_ClusterEnumerateRequest(buffer_arg) {
-  return api_pb.ClusterEnumerateRequest.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkClusterEnumerateRequest(buffer_arg) {
+  return api_pb.SdkClusterEnumerateRequest.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_ClusterEnumerateResponse(arg) {
-  if (!(arg instanceof api_pb.ClusterEnumerateResponse)) {
-    throw new Error('Expected argument of type openstorage.api.ClusterEnumerateResponse');
+function serialize_openstorage_api_SdkClusterEnumerateResponse(arg) {
+  if (!(arg instanceof api_pb.SdkClusterEnumerateResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkClusterEnumerateResponse');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_ClusterEnumerateResponse(buffer_arg) {
-  return api_pb.ClusterEnumerateResponse.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkClusterEnumerateResponse(buffer_arg) {
+  return api_pb.SdkClusterEnumerateResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_ClusterInspectRequest(arg) {
-  if (!(arg instanceof api_pb.ClusterInspectRequest)) {
-    throw new Error('Expected argument of type openstorage.api.ClusterInspectRequest');
+function serialize_openstorage_api_SdkClusterInspectRequest(arg) {
+  if (!(arg instanceof api_pb.SdkClusterInspectRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkClusterInspectRequest');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_ClusterInspectRequest(buffer_arg) {
-  return api_pb.ClusterInspectRequest.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkClusterInspectRequest(buffer_arg) {
+  return api_pb.SdkClusterInspectRequest.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_ClusterInspectResponse(arg) {
-  if (!(arg instanceof api_pb.ClusterInspectResponse)) {
-    throw new Error('Expected argument of type openstorage.api.ClusterInspectResponse');
+function serialize_openstorage_api_SdkClusterInspectResponse(arg) {
+  if (!(arg instanceof api_pb.SdkClusterInspectResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkClusterInspectResponse');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_ClusterInspectResponse(buffer_arg) {
-  return api_pb.ClusterInspectResponse.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkClusterInspectResponse(buffer_arg) {
+  return api_pb.SdkClusterInspectResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_OpenStorageVolumeCreateRequest(arg) {
-  if (!(arg instanceof api_pb.OpenStorageVolumeCreateRequest)) {
-    throw new Error('Expected argument of type openstorage.api.OpenStorageVolumeCreateRequest');
+function serialize_openstorage_api_SdkCredentialCreateAWSRequest(arg) {
+  if (!(arg instanceof api_pb.SdkCredentialCreateAWSRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkCredentialCreateAWSRequest');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_OpenStorageVolumeCreateRequest(buffer_arg) {
-  return api_pb.OpenStorageVolumeCreateRequest.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkCredentialCreateAWSRequest(buffer_arg) {
+  return api_pb.SdkCredentialCreateAWSRequest.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_OpenStorageVolumeCreateResponse(arg) {
-  if (!(arg instanceof api_pb.OpenStorageVolumeCreateResponse)) {
-    throw new Error('Expected argument of type openstorage.api.OpenStorageVolumeCreateResponse');
+function serialize_openstorage_api_SdkCredentialCreateAWSResponse(arg) {
+  if (!(arg instanceof api_pb.SdkCredentialCreateAWSResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkCredentialCreateAWSResponse');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_OpenStorageVolumeCreateResponse(buffer_arg) {
-  return api_pb.OpenStorageVolumeCreateResponse.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkCredentialCreateAWSResponse(buffer_arg) {
+  return api_pb.SdkCredentialCreateAWSResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeAttachRequest(arg) {
-  if (!(arg instanceof api_pb.VolumeAttachRequest)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeAttachRequest');
+function serialize_openstorage_api_SdkCredentialCreateAzureRequest(arg) {
+  if (!(arg instanceof api_pb.SdkCredentialCreateAzureRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkCredentialCreateAzureRequest');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeAttachRequest(buffer_arg) {
-  return api_pb.VolumeAttachRequest.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkCredentialCreateAzureRequest(buffer_arg) {
+  return api_pb.SdkCredentialCreateAzureRequest.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeAttachResponse(arg) {
-  if (!(arg instanceof api_pb.VolumeAttachResponse)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeAttachResponse');
+function serialize_openstorage_api_SdkCredentialCreateAzureResponse(arg) {
+  if (!(arg instanceof api_pb.SdkCredentialCreateAzureResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkCredentialCreateAzureResponse');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeAttachResponse(buffer_arg) {
-  return api_pb.VolumeAttachResponse.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkCredentialCreateAzureResponse(buffer_arg) {
+  return api_pb.SdkCredentialCreateAzureResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeCreateFromVolumeIDRequest(arg) {
-  if (!(arg instanceof api_pb.VolumeCreateFromVolumeIDRequest)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeCreateFromVolumeIDRequest');
+function serialize_openstorage_api_SdkCredentialCreateGoogleRequest(arg) {
+  if (!(arg instanceof api_pb.SdkCredentialCreateGoogleRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkCredentialCreateGoogleRequest');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeCreateFromVolumeIDRequest(buffer_arg) {
-  return api_pb.VolumeCreateFromVolumeIDRequest.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkCredentialCreateGoogleRequest(buffer_arg) {
+  return api_pb.SdkCredentialCreateGoogleRequest.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeCreateFromVolumeIDResponse(arg) {
-  if (!(arg instanceof api_pb.VolumeCreateFromVolumeIDResponse)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeCreateFromVolumeIDResponse');
+function serialize_openstorage_api_SdkCredentialCreateGoogleResponse(arg) {
+  if (!(arg instanceof api_pb.SdkCredentialCreateGoogleResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkCredentialCreateGoogleResponse');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeCreateFromVolumeIDResponse(buffer_arg) {
-  return api_pb.VolumeCreateFromVolumeIDResponse.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkCredentialCreateGoogleResponse(buffer_arg) {
+  return api_pb.SdkCredentialCreateGoogleResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeDeleteRequest(arg) {
-  if (!(arg instanceof api_pb.VolumeDeleteRequest)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeDeleteRequest');
+function serialize_openstorage_api_SdkCredentialDeleteRequest(arg) {
+  if (!(arg instanceof api_pb.SdkCredentialDeleteRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkCredentialDeleteRequest');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeDeleteRequest(buffer_arg) {
-  return api_pb.VolumeDeleteRequest.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkCredentialDeleteRequest(buffer_arg) {
+  return api_pb.SdkCredentialDeleteRequest.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeDeleteResponse(arg) {
-  if (!(arg instanceof api_pb.VolumeDeleteResponse)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeDeleteResponse');
+function serialize_openstorage_api_SdkCredentialDeleteResponse(arg) {
+  if (!(arg instanceof api_pb.SdkCredentialDeleteResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkCredentialDeleteResponse');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeDeleteResponse(buffer_arg) {
-  return api_pb.VolumeDeleteResponse.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkCredentialDeleteResponse(buffer_arg) {
+  return api_pb.SdkCredentialDeleteResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeDetachRequest(arg) {
-  if (!(arg instanceof api_pb.VolumeDetachRequest)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeDetachRequest');
+function serialize_openstorage_api_SdkCredentialEnumerateAWSRequest(arg) {
+  if (!(arg instanceof api_pb.SdkCredentialEnumerateAWSRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkCredentialEnumerateAWSRequest');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeDetachRequest(buffer_arg) {
-  return api_pb.VolumeDetachRequest.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkCredentialEnumerateAWSRequest(buffer_arg) {
+  return api_pb.SdkCredentialEnumerateAWSRequest.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeDetachResponse(arg) {
-  if (!(arg instanceof api_pb.VolumeDetachResponse)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeDetachResponse');
+function serialize_openstorage_api_SdkCredentialEnumerateAWSResponse(arg) {
+  if (!(arg instanceof api_pb.SdkCredentialEnumerateAWSResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkCredentialEnumerateAWSResponse');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeDetachResponse(buffer_arg) {
-  return api_pb.VolumeDetachResponse.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkCredentialEnumerateAWSResponse(buffer_arg) {
+  return api_pb.SdkCredentialEnumerateAWSResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeEnumerateRequest(arg) {
-  if (!(arg instanceof api_pb.VolumeEnumerateRequest)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeEnumerateRequest');
+function serialize_openstorage_api_SdkCredentialEnumerateAzureRequest(arg) {
+  if (!(arg instanceof api_pb.SdkCredentialEnumerateAzureRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkCredentialEnumerateAzureRequest');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeEnumerateRequest(buffer_arg) {
-  return api_pb.VolumeEnumerateRequest.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkCredentialEnumerateAzureRequest(buffer_arg) {
+  return api_pb.SdkCredentialEnumerateAzureRequest.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeEnumerateResponse(arg) {
-  if (!(arg instanceof api_pb.VolumeEnumerateResponse)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeEnumerateResponse');
+function serialize_openstorage_api_SdkCredentialEnumerateAzureResponse(arg) {
+  if (!(arg instanceof api_pb.SdkCredentialEnumerateAzureResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkCredentialEnumerateAzureResponse');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeEnumerateResponse(buffer_arg) {
-  return api_pb.VolumeEnumerateResponse.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkCredentialEnumerateAzureResponse(buffer_arg) {
+  return api_pb.SdkCredentialEnumerateAzureResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeInspectRequest(arg) {
-  if (!(arg instanceof api_pb.VolumeInspectRequest)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeInspectRequest');
+function serialize_openstorage_api_SdkCredentialEnumerateGoogleRequest(arg) {
+  if (!(arg instanceof api_pb.SdkCredentialEnumerateGoogleRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkCredentialEnumerateGoogleRequest');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeInspectRequest(buffer_arg) {
-  return api_pb.VolumeInspectRequest.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkCredentialEnumerateGoogleRequest(buffer_arg) {
+  return api_pb.SdkCredentialEnumerateGoogleRequest.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeInspectResponse(arg) {
-  if (!(arg instanceof api_pb.VolumeInspectResponse)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeInspectResponse');
+function serialize_openstorage_api_SdkCredentialEnumerateGoogleResponse(arg) {
+  if (!(arg instanceof api_pb.SdkCredentialEnumerateGoogleResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkCredentialEnumerateGoogleResponse');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeInspectResponse(buffer_arg) {
-  return api_pb.VolumeInspectResponse.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkCredentialEnumerateGoogleResponse(buffer_arg) {
+  return api_pb.SdkCredentialEnumerateGoogleResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeMountRequest(arg) {
-  if (!(arg instanceof api_pb.VolumeMountRequest)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeMountRequest');
+function serialize_openstorage_api_SdkCredentialValidateRequest(arg) {
+  if (!(arg instanceof api_pb.SdkCredentialValidateRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkCredentialValidateRequest');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeMountRequest(buffer_arg) {
-  return api_pb.VolumeMountRequest.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkCredentialValidateRequest(buffer_arg) {
+  return api_pb.SdkCredentialValidateRequest.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeMountResponse(arg) {
-  if (!(arg instanceof api_pb.VolumeMountResponse)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeMountResponse');
+function serialize_openstorage_api_SdkCredentialValidateResponse(arg) {
+  if (!(arg instanceof api_pb.SdkCredentialValidateResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkCredentialValidateResponse');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeMountResponse(buffer_arg) {
-  return api_pb.VolumeMountResponse.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkCredentialValidateResponse(buffer_arg) {
+  return api_pb.SdkCredentialValidateResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeSnapshotCreateRequest(arg) {
-  if (!(arg instanceof api_pb.VolumeSnapshotCreateRequest)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeSnapshotCreateRequest');
+function serialize_openstorage_api_SdkVolumeAttachRequest(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeAttachRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeAttachRequest');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeSnapshotCreateRequest(buffer_arg) {
-  return api_pb.VolumeSnapshotCreateRequest.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkVolumeAttachRequest(buffer_arg) {
+  return api_pb.SdkVolumeAttachRequest.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeSnapshotCreateResponse(arg) {
-  if (!(arg instanceof api_pb.VolumeSnapshotCreateResponse)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeSnapshotCreateResponse');
+function serialize_openstorage_api_SdkVolumeAttachResponse(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeAttachResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeAttachResponse');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeSnapshotCreateResponse(buffer_arg) {
-  return api_pb.VolumeSnapshotCreateResponse.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkVolumeAttachResponse(buffer_arg) {
+  return api_pb.SdkVolumeAttachResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeSnapshotEnumerateRequest(arg) {
-  if (!(arg instanceof api_pb.VolumeSnapshotEnumerateRequest)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeSnapshotEnumerateRequest');
+function serialize_openstorage_api_SdkVolumeCreateFromVolumeIdRequest(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeCreateFromVolumeIdRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeCreateFromVolumeIdRequest');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeSnapshotEnumerateRequest(buffer_arg) {
-  return api_pb.VolumeSnapshotEnumerateRequest.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkVolumeCreateFromVolumeIdRequest(buffer_arg) {
+  return api_pb.SdkVolumeCreateFromVolumeIdRequest.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeSnapshotEnumerateResponse(arg) {
-  if (!(arg instanceof api_pb.VolumeSnapshotEnumerateResponse)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeSnapshotEnumerateResponse');
+function serialize_openstorage_api_SdkVolumeCreateFromVolumeIdResponse(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeCreateFromVolumeIdResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeCreateFromVolumeIdResponse');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeSnapshotEnumerateResponse(buffer_arg) {
-  return api_pb.VolumeSnapshotEnumerateResponse.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkVolumeCreateFromVolumeIdResponse(buffer_arg) {
+  return api_pb.SdkVolumeCreateFromVolumeIdResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeSnapshotRestoreRequest(arg) {
-  if (!(arg instanceof api_pb.VolumeSnapshotRestoreRequest)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeSnapshotRestoreRequest');
+function serialize_openstorage_api_SdkVolumeCreateRequest(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeCreateRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeCreateRequest');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeSnapshotRestoreRequest(buffer_arg) {
-  return api_pb.VolumeSnapshotRestoreRequest.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkVolumeCreateRequest(buffer_arg) {
+  return api_pb.SdkVolumeCreateRequest.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeSnapshotRestoreResponse(arg) {
-  if (!(arg instanceof api_pb.VolumeSnapshotRestoreResponse)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeSnapshotRestoreResponse');
+function serialize_openstorage_api_SdkVolumeCreateResponse(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeCreateResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeCreateResponse');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeSnapshotRestoreResponse(buffer_arg) {
-  return api_pb.VolumeSnapshotRestoreResponse.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkVolumeCreateResponse(buffer_arg) {
+  return api_pb.SdkVolumeCreateResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeUnmountRequest(arg) {
-  if (!(arg instanceof api_pb.VolumeUnmountRequest)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeUnmountRequest');
+function serialize_openstorage_api_SdkVolumeDeleteRequest(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeDeleteRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeDeleteRequest');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeUnmountRequest(buffer_arg) {
-  return api_pb.VolumeUnmountRequest.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkVolumeDeleteRequest(buffer_arg) {
+  return api_pb.SdkVolumeDeleteRequest.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
-function serialize_openstorage_api_VolumeUnmountResponse(arg) {
-  if (!(arg instanceof api_pb.VolumeUnmountResponse)) {
-    throw new Error('Expected argument of type openstorage.api.VolumeUnmountResponse');
+function serialize_openstorage_api_SdkVolumeDeleteResponse(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeDeleteResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeDeleteResponse');
   }
   return new Buffer(arg.serializeBinary());
 }
 
-function deserialize_openstorage_api_VolumeUnmountResponse(buffer_arg) {
-  return api_pb.VolumeUnmountResponse.deserializeBinary(new Uint8Array(buffer_arg));
+function deserialize_openstorage_api_SdkVolumeDeleteResponse(buffer_arg) {
+  return api_pb.SdkVolumeDeleteResponse.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_openstorage_api_SdkVolumeDetachRequest(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeDetachRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeDetachRequest');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_openstorage_api_SdkVolumeDetachRequest(buffer_arg) {
+  return api_pb.SdkVolumeDetachRequest.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_openstorage_api_SdkVolumeDetachResponse(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeDetachResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeDetachResponse');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_openstorage_api_SdkVolumeDetachResponse(buffer_arg) {
+  return api_pb.SdkVolumeDetachResponse.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_openstorage_api_SdkVolumeEnumerateRequest(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeEnumerateRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeEnumerateRequest');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_openstorage_api_SdkVolumeEnumerateRequest(buffer_arg) {
+  return api_pb.SdkVolumeEnumerateRequest.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_openstorage_api_SdkVolumeEnumerateResponse(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeEnumerateResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeEnumerateResponse');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_openstorage_api_SdkVolumeEnumerateResponse(buffer_arg) {
+  return api_pb.SdkVolumeEnumerateResponse.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_openstorage_api_SdkVolumeInspectRequest(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeInspectRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeInspectRequest');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_openstorage_api_SdkVolumeInspectRequest(buffer_arg) {
+  return api_pb.SdkVolumeInspectRequest.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_openstorage_api_SdkVolumeInspectResponse(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeInspectResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeInspectResponse');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_openstorage_api_SdkVolumeInspectResponse(buffer_arg) {
+  return api_pb.SdkVolumeInspectResponse.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_openstorage_api_SdkVolumeMountRequest(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeMountRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeMountRequest');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_openstorage_api_SdkVolumeMountRequest(buffer_arg) {
+  return api_pb.SdkVolumeMountRequest.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_openstorage_api_SdkVolumeMountResponse(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeMountResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeMountResponse');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_openstorage_api_SdkVolumeMountResponse(buffer_arg) {
+  return api_pb.SdkVolumeMountResponse.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_openstorage_api_SdkVolumeSnapshotCreateRequest(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeSnapshotCreateRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeSnapshotCreateRequest');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_openstorage_api_SdkVolumeSnapshotCreateRequest(buffer_arg) {
+  return api_pb.SdkVolumeSnapshotCreateRequest.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_openstorage_api_SdkVolumeSnapshotCreateResponse(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeSnapshotCreateResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeSnapshotCreateResponse');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_openstorage_api_SdkVolumeSnapshotCreateResponse(buffer_arg) {
+  return api_pb.SdkVolumeSnapshotCreateResponse.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_openstorage_api_SdkVolumeSnapshotEnumerateRequest(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeSnapshotEnumerateRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeSnapshotEnumerateRequest');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_openstorage_api_SdkVolumeSnapshotEnumerateRequest(buffer_arg) {
+  return api_pb.SdkVolumeSnapshotEnumerateRequest.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_openstorage_api_SdkVolumeSnapshotEnumerateResponse(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeSnapshotEnumerateResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeSnapshotEnumerateResponse');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_openstorage_api_SdkVolumeSnapshotEnumerateResponse(buffer_arg) {
+  return api_pb.SdkVolumeSnapshotEnumerateResponse.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_openstorage_api_SdkVolumeSnapshotRestoreRequest(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeSnapshotRestoreRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeSnapshotRestoreRequest');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_openstorage_api_SdkVolumeSnapshotRestoreRequest(buffer_arg) {
+  return api_pb.SdkVolumeSnapshotRestoreRequest.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_openstorage_api_SdkVolumeSnapshotRestoreResponse(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeSnapshotRestoreResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeSnapshotRestoreResponse');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_openstorage_api_SdkVolumeSnapshotRestoreResponse(buffer_arg) {
+  return api_pb.SdkVolumeSnapshotRestoreResponse.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_openstorage_api_SdkVolumeUnmountRequest(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeUnmountRequest)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeUnmountRequest');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_openstorage_api_SdkVolumeUnmountRequest(buffer_arg) {
+  return api_pb.SdkVolumeUnmountRequest.deserializeBinary(new Uint8Array(buffer_arg));
+}
+
+function serialize_openstorage_api_SdkVolumeUnmountResponse(arg) {
+  if (!(arg instanceof api_pb.SdkVolumeUnmountResponse)) {
+    throw new Error('Expected argument of type openstorage.api.SdkVolumeUnmountResponse');
+  }
+  return new Buffer(arg.serializeBinary());
+}
+
+function deserialize_openstorage_api_SdkVolumeUnmountResponse(buffer_arg) {
+  return api_pb.SdkVolumeUnmountResponse.deserializeBinary(new Uint8Array(buffer_arg));
 }
 
 
@@ -387,60 +563,60 @@ var OpenStorageClusterService = exports.OpenStorageClusterService = {
     path: '/openstorage.api.OpenStorageCluster/Enumerate',
     requestStream: false,
     responseStream: false,
-    requestType: api_pb.ClusterEnumerateRequest,
-    responseType: api_pb.ClusterEnumerateResponse,
-    requestSerialize: serialize_openstorage_api_ClusterEnumerateRequest,
-    requestDeserialize: deserialize_openstorage_api_ClusterEnumerateRequest,
-    responseSerialize: serialize_openstorage_api_ClusterEnumerateResponse,
-    responseDeserialize: deserialize_openstorage_api_ClusterEnumerateResponse,
+    requestType: api_pb.SdkClusterEnumerateRequest,
+    responseType: api_pb.SdkClusterEnumerateResponse,
+    requestSerialize: serialize_openstorage_api_SdkClusterEnumerateRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkClusterEnumerateRequest,
+    responseSerialize: serialize_openstorage_api_SdkClusterEnumerateResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkClusterEnumerateResponse,
   },
   // Inspect the node given a UUID.
   inspect: {
     path: '/openstorage.api.OpenStorageCluster/Inspect',
     requestStream: false,
     responseStream: false,
-    requestType: api_pb.ClusterInspectRequest,
-    responseType: api_pb.ClusterInspectResponse,
-    requestSerialize: serialize_openstorage_api_ClusterInspectRequest,
-    requestDeserialize: deserialize_openstorage_api_ClusterInspectRequest,
-    responseSerialize: serialize_openstorage_api_ClusterInspectResponse,
-    responseDeserialize: deserialize_openstorage_api_ClusterInspectResponse,
+    requestType: api_pb.SdkClusterInspectRequest,
+    responseType: api_pb.SdkClusterInspectResponse,
+    requestSerialize: serialize_openstorage_api_SdkClusterInspectRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkClusterInspectRequest,
+    responseSerialize: serialize_openstorage_api_SdkClusterInspectResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkClusterInspectResponse,
   },
   // Get a list of alerts from the storage cluster
   alertEnumerate: {
     path: '/openstorage.api.OpenStorageCluster/AlertEnumerate',
     requestStream: false,
     responseStream: false,
-    requestType: api_pb.ClusterAlertEnumerateRequest,
-    responseType: api_pb.ClusterAlertEnumerateResponse,
-    requestSerialize: serialize_openstorage_api_ClusterAlertEnumerateRequest,
-    requestDeserialize: deserialize_openstorage_api_ClusterAlertEnumerateRequest,
-    responseSerialize: serialize_openstorage_api_ClusterAlertEnumerateResponse,
-    responseDeserialize: deserialize_openstorage_api_ClusterAlertEnumerateResponse,
+    requestType: api_pb.SdkClusterAlertEnumerateRequest,
+    responseType: api_pb.SdkClusterAlertEnumerateResponse,
+    requestSerialize: serialize_openstorage_api_SdkClusterAlertEnumerateRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkClusterAlertEnumerateRequest,
+    responseSerialize: serialize_openstorage_api_SdkClusterAlertEnumerateResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkClusterAlertEnumerateResponse,
   },
   // Clear the alert for a given resource
   alertClear: {
     path: '/openstorage.api.OpenStorageCluster/AlertClear',
     requestStream: false,
     responseStream: false,
-    requestType: api_pb.ClusterAlertClearRequest,
-    responseType: api_pb.ClusterAlertClearResponse,
-    requestSerialize: serialize_openstorage_api_ClusterAlertClearRequest,
-    requestDeserialize: deserialize_openstorage_api_ClusterAlertClearRequest,
-    responseSerialize: serialize_openstorage_api_ClusterAlertClearResponse,
-    responseDeserialize: deserialize_openstorage_api_ClusterAlertClearResponse,
+    requestType: api_pb.SdkClusterAlertClearRequest,
+    responseType: api_pb.SdkClusterAlertClearResponse,
+    requestSerialize: serialize_openstorage_api_SdkClusterAlertClearRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkClusterAlertClearRequest,
+    responseSerialize: serialize_openstorage_api_SdkClusterAlertClearResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkClusterAlertClearResponse,
   },
   // Erases an alert for a given resource
   alertErase: {
     path: '/openstorage.api.OpenStorageCluster/AlertErase',
     requestStream: false,
     responseStream: false,
-    requestType: api_pb.ClusterAlertEraseRequest,
-    responseType: api_pb.ClusterAlertEraseResponse,
-    requestSerialize: serialize_openstorage_api_ClusterAlertEraseRequest,
-    requestDeserialize: deserialize_openstorage_api_ClusterAlertEraseRequest,
-    responseSerialize: serialize_openstorage_api_ClusterAlertEraseResponse,
-    responseDeserialize: deserialize_openstorage_api_ClusterAlertEraseResponse,
+    requestType: api_pb.SdkClusterAlertEraseRequest,
+    responseType: api_pb.SdkClusterAlertEraseResponse,
+    requestSerialize: serialize_openstorage_api_SdkClusterAlertEraseRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkClusterAlertEraseRequest,
+    responseSerialize: serialize_openstorage_api_SdkClusterAlertEraseResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkClusterAlertEraseResponse,
   },
 };
 
@@ -451,60 +627,60 @@ var OpenStorageVolumeService = exports.OpenStorageVolumeService = {
     path: '/openstorage.api.OpenStorageVolume/Create',
     requestStream: false,
     responseStream: false,
-    requestType: api_pb.OpenStorageVolumeCreateRequest,
-    responseType: api_pb.OpenStorageVolumeCreateResponse,
-    requestSerialize: serialize_openstorage_api_OpenStorageVolumeCreateRequest,
-    requestDeserialize: deserialize_openstorage_api_OpenStorageVolumeCreateRequest,
-    responseSerialize: serialize_openstorage_api_OpenStorageVolumeCreateResponse,
-    responseDeserialize: deserialize_openstorage_api_OpenStorageVolumeCreateResponse,
+    requestType: api_pb.SdkVolumeCreateRequest,
+    responseType: api_pb.SdkVolumeCreateResponse,
+    requestSerialize: serialize_openstorage_api_SdkVolumeCreateRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkVolumeCreateRequest,
+    responseSerialize: serialize_openstorage_api_SdkVolumeCreateResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkVolumeCreateResponse,
   },
-  // CreateFromVolumeID creates a new volume cloned from an existing volume
-  createFromVolumeID: {
-    path: '/openstorage.api.OpenStorageVolume/CreateFromVolumeID',
+  // CreateFromVolumeId creates a new volume cloned from an existing volume
+  createFromVolumeId: {
+    path: '/openstorage.api.OpenStorageVolume/CreateFromVolumeId',
     requestStream: false,
     responseStream: false,
-    requestType: api_pb.VolumeCreateFromVolumeIDRequest,
-    responseType: api_pb.VolumeCreateFromVolumeIDResponse,
-    requestSerialize: serialize_openstorage_api_VolumeCreateFromVolumeIDRequest,
-    requestDeserialize: deserialize_openstorage_api_VolumeCreateFromVolumeIDRequest,
-    responseSerialize: serialize_openstorage_api_VolumeCreateFromVolumeIDResponse,
-    responseDeserialize: deserialize_openstorage_api_VolumeCreateFromVolumeIDResponse,
+    requestType: api_pb.SdkVolumeCreateFromVolumeIdRequest,
+    responseType: api_pb.SdkVolumeCreateFromVolumeIdResponse,
+    requestSerialize: serialize_openstorage_api_SdkVolumeCreateFromVolumeIdRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkVolumeCreateFromVolumeIdRequest,
+    responseSerialize: serialize_openstorage_api_SdkVolumeCreateFromVolumeIdResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkVolumeCreateFromVolumeIdResponse,
   },
   // Delete a volume
   delete: {
     path: '/openstorage.api.OpenStorageVolume/Delete',
     requestStream: false,
     responseStream: false,
-    requestType: api_pb.VolumeDeleteRequest,
-    responseType: api_pb.VolumeDeleteResponse,
-    requestSerialize: serialize_openstorage_api_VolumeDeleteRequest,
-    requestDeserialize: deserialize_openstorage_api_VolumeDeleteRequest,
-    responseSerialize: serialize_openstorage_api_VolumeDeleteResponse,
-    responseDeserialize: deserialize_openstorage_api_VolumeDeleteResponse,
+    requestType: api_pb.SdkVolumeDeleteRequest,
+    responseType: api_pb.SdkVolumeDeleteResponse,
+    requestSerialize: serialize_openstorage_api_SdkVolumeDeleteRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkVolumeDeleteRequest,
+    responseSerialize: serialize_openstorage_api_SdkVolumeDeleteResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkVolumeDeleteResponse,
   },
   // Get information on a volume
   inspect: {
     path: '/openstorage.api.OpenStorageVolume/Inspect',
     requestStream: false,
     responseStream: false,
-    requestType: api_pb.VolumeInspectRequest,
-    responseType: api_pb.VolumeInspectResponse,
-    requestSerialize: serialize_openstorage_api_VolumeInspectRequest,
-    requestDeserialize: deserialize_openstorage_api_VolumeInspectRequest,
-    responseSerialize: serialize_openstorage_api_VolumeInspectResponse,
-    responseDeserialize: deserialize_openstorage_api_VolumeInspectResponse,
+    requestType: api_pb.SdkVolumeInspectRequest,
+    responseType: api_pb.SdkVolumeInspectResponse,
+    requestSerialize: serialize_openstorage_api_SdkVolumeInspectRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkVolumeInspectRequest,
+    responseSerialize: serialize_openstorage_api_SdkVolumeInspectResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkVolumeInspectResponse,
   },
   // Get a list of volumes
   enumerate: {
     path: '/openstorage.api.OpenStorageVolume/Enumerate',
     requestStream: false,
     responseStream: false,
-    requestType: api_pb.VolumeEnumerateRequest,
-    responseType: api_pb.VolumeEnumerateResponse,
-    requestSerialize: serialize_openstorage_api_VolumeEnumerateRequest,
-    requestDeserialize: deserialize_openstorage_api_VolumeEnumerateRequest,
-    responseSerialize: serialize_openstorage_api_VolumeEnumerateResponse,
-    responseDeserialize: deserialize_openstorage_api_VolumeEnumerateResponse,
+    requestType: api_pb.SdkVolumeEnumerateRequest,
+    responseType: api_pb.SdkVolumeEnumerateResponse,
+    requestSerialize: serialize_openstorage_api_SdkVolumeEnumerateRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkVolumeEnumerateRequest,
+    responseSerialize: serialize_openstorage_api_SdkVolumeEnumerateResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkVolumeEnumerateResponse,
   },
   // Create a snapshot of a volume. This creates an immutable (read-only),
   // point-in-time snapshot of a volume.
@@ -512,85 +688,191 @@ var OpenStorageVolumeService = exports.OpenStorageVolumeService = {
     path: '/openstorage.api.OpenStorageVolume/SnapshotCreate',
     requestStream: false,
     responseStream: false,
-    requestType: api_pb.VolumeSnapshotCreateRequest,
-    responseType: api_pb.VolumeSnapshotCreateResponse,
-    requestSerialize: serialize_openstorage_api_VolumeSnapshotCreateRequest,
-    requestDeserialize: deserialize_openstorage_api_VolumeSnapshotCreateRequest,
-    responseSerialize: serialize_openstorage_api_VolumeSnapshotCreateResponse,
-    responseDeserialize: deserialize_openstorage_api_VolumeSnapshotCreateResponse,
+    requestType: api_pb.SdkVolumeSnapshotCreateRequest,
+    responseType: api_pb.SdkVolumeSnapshotCreateResponse,
+    requestSerialize: serialize_openstorage_api_SdkVolumeSnapshotCreateRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkVolumeSnapshotCreateRequest,
+    responseSerialize: serialize_openstorage_api_SdkVolumeSnapshotCreateResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkVolumeSnapshotCreateResponse,
   },
   // Restores a volume to a specified snapshot
   snapshotRestore: {
     path: '/openstorage.api.OpenStorageVolume/SnapshotRestore',
     requestStream: false,
     responseStream: false,
-    requestType: api_pb.VolumeSnapshotRestoreRequest,
-    responseType: api_pb.VolumeSnapshotRestoreResponse,
-    requestSerialize: serialize_openstorage_api_VolumeSnapshotRestoreRequest,
-    requestDeserialize: deserialize_openstorage_api_VolumeSnapshotRestoreRequest,
-    responseSerialize: serialize_openstorage_api_VolumeSnapshotRestoreResponse,
-    responseDeserialize: deserialize_openstorage_api_VolumeSnapshotRestoreResponse,
+    requestType: api_pb.SdkVolumeSnapshotRestoreRequest,
+    responseType: api_pb.SdkVolumeSnapshotRestoreResponse,
+    requestSerialize: serialize_openstorage_api_SdkVolumeSnapshotRestoreRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkVolumeSnapshotRestoreRequest,
+    responseSerialize: serialize_openstorage_api_SdkVolumeSnapshotRestoreResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkVolumeSnapshotRestoreResponse,
   },
   // List the number of snapshots for a specific volume
   snapshotEnumerate: {
     path: '/openstorage.api.OpenStorageVolume/SnapshotEnumerate',
     requestStream: false,
     responseStream: false,
-    requestType: api_pb.VolumeSnapshotEnumerateRequest,
-    responseType: api_pb.VolumeSnapshotEnumerateResponse,
-    requestSerialize: serialize_openstorage_api_VolumeSnapshotEnumerateRequest,
-    requestDeserialize: deserialize_openstorage_api_VolumeSnapshotEnumerateRequest,
-    responseSerialize: serialize_openstorage_api_VolumeSnapshotEnumerateResponse,
-    responseDeserialize: deserialize_openstorage_api_VolumeSnapshotEnumerateResponse,
+    requestType: api_pb.SdkVolumeSnapshotEnumerateRequest,
+    responseType: api_pb.SdkVolumeSnapshotEnumerateResponse,
+    requestSerialize: serialize_openstorage_api_SdkVolumeSnapshotEnumerateRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkVolumeSnapshotEnumerateRequest,
+    responseSerialize: serialize_openstorage_api_SdkVolumeSnapshotEnumerateResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkVolumeSnapshotEnumerateResponse,
   },
   // Attach device to host                                                      
   attach: {
     path: '/openstorage.api.OpenStorageVolume/Attach',
     requestStream: false,
     responseStream: false,
-    requestType: api_pb.VolumeAttachRequest,
-    responseType: api_pb.VolumeAttachResponse,
-    requestSerialize: serialize_openstorage_api_VolumeAttachRequest,
-    requestDeserialize: deserialize_openstorage_api_VolumeAttachRequest,
-    responseSerialize: serialize_openstorage_api_VolumeAttachResponse,
-    responseDeserialize: deserialize_openstorage_api_VolumeAttachResponse,
+    requestType: api_pb.SdkVolumeAttachRequest,
+    responseType: api_pb.SdkVolumeAttachResponse,
+    requestSerialize: serialize_openstorage_api_SdkVolumeAttachRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkVolumeAttachRequest,
+    responseSerialize: serialize_openstorage_api_SdkVolumeAttachResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkVolumeAttachResponse,
   },
   // Detaches the volume from the node.
   detach: {
     path: '/openstorage.api.OpenStorageVolume/Detach',
     requestStream: false,
     responseStream: false,
-    requestType: api_pb.VolumeDetachRequest,
-    responseType: api_pb.VolumeDetachResponse,
-    requestSerialize: serialize_openstorage_api_VolumeDetachRequest,
-    requestDeserialize: deserialize_openstorage_api_VolumeDetachRequest,
-    responseSerialize: serialize_openstorage_api_VolumeDetachResponse,
-    responseDeserialize: deserialize_openstorage_api_VolumeDetachResponse,
+    requestType: api_pb.SdkVolumeDetachRequest,
+    responseType: api_pb.SdkVolumeDetachResponse,
+    requestSerialize: serialize_openstorage_api_SdkVolumeDetachRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkVolumeDetachRequest,
+    responseSerialize: serialize_openstorage_api_SdkVolumeDetachResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkVolumeDetachResponse,
   },
   // Attaches the volume to a node.
   mount: {
     path: '/openstorage.api.OpenStorageVolume/Mount',
     requestStream: false,
     responseStream: false,
-    requestType: api_pb.VolumeMountRequest,
-    responseType: api_pb.VolumeMountResponse,
-    requestSerialize: serialize_openstorage_api_VolumeMountRequest,
-    requestDeserialize: deserialize_openstorage_api_VolumeMountRequest,
-    responseSerialize: serialize_openstorage_api_VolumeMountResponse,
-    responseDeserialize: deserialize_openstorage_api_VolumeMountResponse,
+    requestType: api_pb.SdkVolumeMountRequest,
+    responseType: api_pb.SdkVolumeMountResponse,
+    requestSerialize: serialize_openstorage_api_SdkVolumeMountRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkVolumeMountRequest,
+    responseSerialize: serialize_openstorage_api_SdkVolumeMountResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkVolumeMountResponse,
   },
   // Unmount volume at specified path                                           
   unmount: {
     path: '/openstorage.api.OpenStorageVolume/Unmount',
     requestStream: false,
     responseStream: false,
-    requestType: api_pb.VolumeUnmountRequest,
-    responseType: api_pb.VolumeUnmountResponse,
-    requestSerialize: serialize_openstorage_api_VolumeUnmountRequest,
-    requestDeserialize: deserialize_openstorage_api_VolumeUnmountRequest,
-    responseSerialize: serialize_openstorage_api_VolumeUnmountResponse,
-    responseDeserialize: deserialize_openstorage_api_VolumeUnmountResponse,
+    requestType: api_pb.SdkVolumeUnmountRequest,
+    responseType: api_pb.SdkVolumeUnmountResponse,
+    requestSerialize: serialize_openstorage_api_SdkVolumeUnmountRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkVolumeUnmountRequest,
+    responseSerialize: serialize_openstorage_api_SdkVolumeUnmountResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkVolumeUnmountResponse,
   },
 };
 
 exports.OpenStorageVolumeClient = grpc.makeGenericClientConstructor(OpenStorageVolumeService);
+var OpenStorageCredentialsService = exports.OpenStorageCredentialsService = {
+  // Provide credentials to OpenStorage and if valid,
+  // it will return an identifier to the credentials
+  //
+  // Create credential for AWS S3 and if valid ,
+  // returns a unique identifier
+  createForAWS: {
+    path: '/openstorage.api.OpenStorageCredentials/CreateForAWS',
+    requestStream: false,
+    responseStream: false,
+    requestType: api_pb.SdkCredentialCreateAWSRequest,
+    responseType: api_pb.SdkCredentialCreateAWSResponse,
+    requestSerialize: serialize_openstorage_api_SdkCredentialCreateAWSRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkCredentialCreateAWSRequest,
+    responseSerialize: serialize_openstorage_api_SdkCredentialCreateAWSResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkCredentialCreateAWSResponse,
+  },
+  // Create credential for Azure and if valid ,
+  // returns a unique identifier
+  createForAzure: {
+    path: '/openstorage.api.OpenStorageCredentials/CreateForAzure',
+    requestStream: false,
+    responseStream: false,
+    requestType: api_pb.SdkCredentialCreateAzureRequest,
+    responseType: api_pb.SdkCredentialCreateAzureResponse,
+    requestSerialize: serialize_openstorage_api_SdkCredentialCreateAzureRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkCredentialCreateAzureRequest,
+    responseSerialize: serialize_openstorage_api_SdkCredentialCreateAzureResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkCredentialCreateAzureResponse,
+  },
+  // Create credential for Google and if valid ,
+  // returns a unique identifier
+  createForGoogle: {
+    path: '/openstorage.api.OpenStorageCredentials/CreateForGoogle',
+    requestStream: false,
+    responseStream: false,
+    requestType: api_pb.SdkCredentialCreateGoogleRequest,
+    responseType: api_pb.SdkCredentialCreateGoogleResponse,
+    requestSerialize: serialize_openstorage_api_SdkCredentialCreateGoogleRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkCredentialCreateGoogleRequest,
+    responseSerialize: serialize_openstorage_api_SdkCredentialCreateGoogleResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkCredentialCreateGoogleResponse,
+  },
+  // EnumerateForAWS lists the configured AWS credentials                      
+  enumerateForAWS: {
+    path: '/openstorage.api.OpenStorageCredentials/EnumerateForAWS',
+    requestStream: false,
+    responseStream: false,
+    requestType: api_pb.SdkCredentialEnumerateAWSRequest,
+    responseType: api_pb.SdkCredentialEnumerateAWSResponse,
+    requestSerialize: serialize_openstorage_api_SdkCredentialEnumerateAWSRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkCredentialEnumerateAWSRequest,
+    responseSerialize: serialize_openstorage_api_SdkCredentialEnumerateAWSResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkCredentialEnumerateAWSResponse,
+  },
+  // EnumerateForAzure lists the configured Azure credentials                  
+  enumerateForAzure: {
+    path: '/openstorage.api.OpenStorageCredentials/EnumerateForAzure',
+    requestStream: false,
+    responseStream: false,
+    requestType: api_pb.SdkCredentialEnumerateAzureRequest,
+    responseType: api_pb.SdkCredentialEnumerateAzureResponse,
+    requestSerialize: serialize_openstorage_api_SdkCredentialEnumerateAzureRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkCredentialEnumerateAzureRequest,
+    responseSerialize: serialize_openstorage_api_SdkCredentialEnumerateAzureResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkCredentialEnumerateAzureResponse,
+  },
+  // EnumerateForGoogle lists the configured Google credentials                
+  enumerateForGoogle: {
+    path: '/openstorage.api.OpenStorageCredentials/EnumerateForGoogle',
+    requestStream: false,
+    responseStream: false,
+    requestType: api_pb.SdkCredentialEnumerateGoogleRequest,
+    responseType: api_pb.SdkCredentialEnumerateGoogleResponse,
+    requestSerialize: serialize_openstorage_api_SdkCredentialEnumerateGoogleRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkCredentialEnumerateGoogleRequest,
+    responseSerialize: serialize_openstorage_api_SdkCredentialEnumerateGoogleResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkCredentialEnumerateGoogleResponse,
+  },
+  // Delete a specified credential                                                 
+  credentialDelete: {
+    path: '/openstorage.api.OpenStorageCredentials/CredentialDelete',
+    requestStream: false,
+    responseStream: false,
+    requestType: api_pb.SdkCredentialDeleteRequest,
+    responseType: api_pb.SdkCredentialDeleteResponse,
+    requestSerialize: serialize_openstorage_api_SdkCredentialDeleteRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkCredentialDeleteRequest,
+    responseSerialize: serialize_openstorage_api_SdkCredentialDeleteResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkCredentialDeleteResponse,
+  },
+  // Validate a specified credential
+  credentialValidate: {
+    path: '/openstorage.api.OpenStorageCredentials/CredentialValidate',
+    requestStream: false,
+    responseStream: false,
+    requestType: api_pb.SdkCredentialValidateRequest,
+    responseType: api_pb.SdkCredentialValidateResponse,
+    requestSerialize: serialize_openstorage_api_SdkCredentialValidateRequest,
+    requestDeserialize: deserialize_openstorage_api_SdkCredentialValidateRequest,
+    responseSerialize: serialize_openstorage_api_SdkCredentialValidateResponse,
+    responseDeserialize: deserialize_openstorage_api_SdkCredentialValidateResponse,
+  },
+};
+
+exports.OpenStorageCredentialsClient = grpc.makeGenericClientConstructor(OpenStorageCredentialsService);

--- a/api/client/sdk/js/api_pb.js
+++ b/api/client/sdk/js/api_pb.js
@@ -19,33 +19,75 @@ goog.exportSymbol('proto.openstorage.api.Alert', null, global);
 goog.exportSymbol('proto.openstorage.api.AlertActionType', null, global);
 goog.exportSymbol('proto.openstorage.api.Alerts', null, global);
 goog.exportSymbol('proto.openstorage.api.AttachState', null, global);
-goog.exportSymbol('proto.openstorage.api.ClusterAlertClearRequest', null, global);
-goog.exportSymbol('proto.openstorage.api.ClusterAlertClearResponse', null, global);
-goog.exportSymbol('proto.openstorage.api.ClusterAlertEnumerateRequest', null, global);
-goog.exportSymbol('proto.openstorage.api.ClusterAlertEnumerateResponse', null, global);
-goog.exportSymbol('proto.openstorage.api.ClusterAlertEraseRequest', null, global);
-goog.exportSymbol('proto.openstorage.api.ClusterAlertEraseResponse', null, global);
-goog.exportSymbol('proto.openstorage.api.ClusterEnumerateRequest', null, global);
-goog.exportSymbol('proto.openstorage.api.ClusterEnumerateResponse', null, global);
-goog.exportSymbol('proto.openstorage.api.ClusterInspectRequest', null, global);
-goog.exportSymbol('proto.openstorage.api.ClusterInspectResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.AzureCredential', null, global);
 goog.exportSymbol('proto.openstorage.api.ClusterNotify', null, global);
 goog.exportSymbol('proto.openstorage.api.ClusterResponse', null, global);
 goog.exportSymbol('proto.openstorage.api.CosType', null, global);
 goog.exportSymbol('proto.openstorage.api.DriverType', null, global);
 goog.exportSymbol('proto.openstorage.api.FSType', null, global);
+goog.exportSymbol('proto.openstorage.api.GoogleCredential', null, global);
 goog.exportSymbol('proto.openstorage.api.GraphDriverChangeType', null, global);
 goog.exportSymbol('proto.openstorage.api.GraphDriverChanges', null, global);
 goog.exportSymbol('proto.openstorage.api.Group', null, global);
 goog.exportSymbol('proto.openstorage.api.GroupSnapCreateRequest', null, global);
 goog.exportSymbol('proto.openstorage.api.GroupSnapCreateResponse', null, global);
 goog.exportSymbol('proto.openstorage.api.IoProfile', null, global);
-goog.exportSymbol('proto.openstorage.api.OpenStorageVolumeCreateRequest', null, global);
-goog.exportSymbol('proto.openstorage.api.OpenStorageVolumeCreateResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.ObjectstoreInfo', null, global);
 goog.exportSymbol('proto.openstorage.api.OperationFlags', null, global);
 goog.exportSymbol('proto.openstorage.api.ReplicaSet', null, global);
 goog.exportSymbol('proto.openstorage.api.ResourceType', null, global);
 goog.exportSymbol('proto.openstorage.api.RuntimeStateMap', null, global);
+goog.exportSymbol('proto.openstorage.api.S3Credential', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkClusterAlertClearRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkClusterAlertClearResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkClusterAlertEnumerateRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkClusterAlertEnumerateResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkClusterAlertEraseRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkClusterAlertEraseResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkClusterEnumerateRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkClusterEnumerateResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkClusterInspectRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkClusterInspectResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkCredentialCreateAWSRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkCredentialCreateAWSResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkCredentialCreateAzureRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkCredentialCreateAzureResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkCredentialCreateGoogleRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkCredentialCreateGoogleResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkCredentialDeleteRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkCredentialDeleteResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkCredentialEnumerateAWSRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkCredentialEnumerateAWSResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkCredentialEnumerateAzureRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkCredentialEnumerateAzureResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkCredentialEnumerateGoogleRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkCredentialEnumerateGoogleResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkCredentialValidateRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkCredentialValidateResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeAttachRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeAttachResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeCreateRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeCreateResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeDeleteRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeDeleteResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeDetachRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeDetachResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeEnumerateRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeEnumerateResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeInspectRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeInspectResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeMountRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeMountResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeSnapshotCreateRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeSnapshotCreateResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeSnapshotRestoreRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeSnapshotRestoreResponse', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeUnmountRequest', null, global);
+goog.exportSymbol('proto.openstorage.api.SdkVolumeUnmountResponse', null, global);
 goog.exportSymbol('proto.openstorage.api.SeverityType', null, global);
 goog.exportSymbol('proto.openstorage.api.SnapCreateRequest', null, global);
 goog.exportSymbol('proto.openstorage.api.SnapCreateResponse', null, global);
@@ -59,40 +101,18 @@ goog.exportSymbol('proto.openstorage.api.StoragePool', null, global);
 goog.exportSymbol('proto.openstorage.api.StorageResource', null, global);
 goog.exportSymbol('proto.openstorage.api.Volume', null, global);
 goog.exportSymbol('proto.openstorage.api.VolumeActionParam', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeAttachRequest', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeAttachResponse', null, global);
 goog.exportSymbol('proto.openstorage.api.VolumeConsumer', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeCreateFromVolumeIDRequest', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeCreateFromVolumeIDResponse', null, global);
 goog.exportSymbol('proto.openstorage.api.VolumeCreateRequest', null, global);
 goog.exportSymbol('proto.openstorage.api.VolumeCreateResponse', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeDeleteRequest', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeDeleteResponse', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeDetachRequest', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeDetachResponse', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeEnumerateRequest', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeEnumerateResponse', null, global);
 goog.exportSymbol('proto.openstorage.api.VolumeInfo', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeInspectRequest', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeInspectResponse', null, global);
 goog.exportSymbol('proto.openstorage.api.VolumeLocator', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeMountRequest', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeMountResponse', null, global);
 goog.exportSymbol('proto.openstorage.api.VolumeResponse', null, global);
 goog.exportSymbol('proto.openstorage.api.VolumeSetRequest', null, global);
 goog.exportSymbol('proto.openstorage.api.VolumeSetResponse', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeSnapshotCreateRequest', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeSnapshotCreateResponse', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeSnapshotEnumerateRequest', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeSnapshotEnumerateResponse', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeSnapshotRestoreRequest', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeSnapshotRestoreResponse', null, global);
 goog.exportSymbol('proto.openstorage.api.VolumeSpec', null, global);
 goog.exportSymbol('proto.openstorage.api.VolumeState', null, global);
 goog.exportSymbol('proto.openstorage.api.VolumeStateAction', null, global);
 goog.exportSymbol('proto.openstorage.api.VolumeStatus', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeUnmountRequest', null, global);
-goog.exportSymbol('proto.openstorage.api.VolumeUnmountResponse', null, global);
 
 /**
  * Generated by JsPbCodeGenerator.
@@ -4355,6 +4375,441 @@ proto.openstorage.api.Alerts.prototype.clearAlertList = function() {
  * @extends {jspb.Message}
  * @constructor
  */
+proto.openstorage.api.ObjectstoreInfo = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.openstorage.api.ObjectstoreInfo.repeatedFields_, null);
+};
+goog.inherits(proto.openstorage.api.ObjectstoreInfo, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.ObjectstoreInfo.displayName = 'proto.openstorage.api.ObjectstoreInfo';
+}
+/**
+ * List of repeated fields within this message type.
+ * @private {!Array<number>}
+ * @const
+ */
+proto.openstorage.api.ObjectstoreInfo.repeatedFields_ = [8];
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.ObjectstoreInfo.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.ObjectstoreInfo.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.ObjectstoreInfo} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.ObjectstoreInfo.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    uuid: jspb.Message.getFieldWithDefault(msg, 1, ""),
+    volumeId: jspb.Message.getFieldWithDefault(msg, 2, ""),
+    enabled: jspb.Message.getFieldWithDefault(msg, 3, false),
+    status: jspb.Message.getFieldWithDefault(msg, 4, ""),
+    action: jspb.Message.getFieldWithDefault(msg, 5, 0),
+    accessKey: jspb.Message.getFieldWithDefault(msg, 6, ""),
+    secretKey: jspb.Message.getFieldWithDefault(msg, 7, ""),
+    endpointsList: jspb.Message.getRepeatedField(msg, 8),
+    currentEndpoint: jspb.Message.getFieldWithDefault(msg, 9, ""),
+    accessPort: jspb.Message.getFieldWithDefault(msg, 10, 0),
+    region: jspb.Message.getFieldWithDefault(msg, 11, "")
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.ObjectstoreInfo}
+ */
+proto.openstorage.api.ObjectstoreInfo.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.ObjectstoreInfo;
+  return proto.openstorage.api.ObjectstoreInfo.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.ObjectstoreInfo} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.ObjectstoreInfo}
+ */
+proto.openstorage.api.ObjectstoreInfo.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setUuid(value);
+      break;
+    case 2:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setVolumeId(value);
+      break;
+    case 3:
+      var value = /** @type {boolean} */ (reader.readBool());
+      msg.setEnabled(value);
+      break;
+    case 4:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setStatus(value);
+      break;
+    case 5:
+      var value = /** @type {number} */ (reader.readInt64());
+      msg.setAction(value);
+      break;
+    case 6:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setAccessKey(value);
+      break;
+    case 7:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setSecretKey(value);
+      break;
+    case 8:
+      var value = /** @type {string} */ (reader.readString());
+      msg.addEndpoints(value);
+      break;
+    case 9:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setCurrentEndpoint(value);
+      break;
+    case 10:
+      var value = /** @type {number} */ (reader.readInt64());
+      msg.setAccessPort(value);
+      break;
+    case 11:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setRegion(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.ObjectstoreInfo.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.ObjectstoreInfo.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.ObjectstoreInfo} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.ObjectstoreInfo.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getUuid();
+  if (f.length > 0) {
+    writer.writeString(
+      1,
+      f
+    );
+  }
+  f = message.getVolumeId();
+  if (f.length > 0) {
+    writer.writeString(
+      2,
+      f
+    );
+  }
+  f = message.getEnabled();
+  if (f) {
+    writer.writeBool(
+      3,
+      f
+    );
+  }
+  f = message.getStatus();
+  if (f.length > 0) {
+    writer.writeString(
+      4,
+      f
+    );
+  }
+  f = message.getAction();
+  if (f !== 0) {
+    writer.writeInt64(
+      5,
+      f
+    );
+  }
+  f = message.getAccessKey();
+  if (f.length > 0) {
+    writer.writeString(
+      6,
+      f
+    );
+  }
+  f = message.getSecretKey();
+  if (f.length > 0) {
+    writer.writeString(
+      7,
+      f
+    );
+  }
+  f = message.getEndpointsList();
+  if (f.length > 0) {
+    writer.writeRepeatedString(
+      8,
+      f
+    );
+  }
+  f = message.getCurrentEndpoint();
+  if (f.length > 0) {
+    writer.writeString(
+      9,
+      f
+    );
+  }
+  f = message.getAccessPort();
+  if (f !== 0) {
+    writer.writeInt64(
+      10,
+      f
+    );
+  }
+  f = message.getRegion();
+  if (f.length > 0) {
+    writer.writeString(
+      11,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional string uuid = 1;
+ * @return {string}
+ */
+proto.openstorage.api.ObjectstoreInfo.prototype.getUuid = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.ObjectstoreInfo.prototype.setUuid = function(value) {
+  jspb.Message.setField(this, 1, value);
+};
+
+
+/**
+ * optional string volume_id = 2;
+ * @return {string}
+ */
+proto.openstorage.api.ObjectstoreInfo.prototype.getVolumeId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.ObjectstoreInfo.prototype.setVolumeId = function(value) {
+  jspb.Message.setField(this, 2, value);
+};
+
+
+/**
+ * optional bool enabled = 3;
+ * Note that Boolean fields may be set to 0/1 when serialized from a Java server.
+ * You should avoid comparisons like {@code val === true/false} in those cases.
+ * @return {boolean}
+ */
+proto.openstorage.api.ObjectstoreInfo.prototype.getEnabled = function() {
+  return /** @type {boolean} */ (jspb.Message.getFieldWithDefault(this, 3, false));
+};
+
+
+/** @param {boolean} value */
+proto.openstorage.api.ObjectstoreInfo.prototype.setEnabled = function(value) {
+  jspb.Message.setField(this, 3, value);
+};
+
+
+/**
+ * optional string status = 4;
+ * @return {string}
+ */
+proto.openstorage.api.ObjectstoreInfo.prototype.getStatus = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 4, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.ObjectstoreInfo.prototype.setStatus = function(value) {
+  jspb.Message.setField(this, 4, value);
+};
+
+
+/**
+ * optional int64 action = 5;
+ * @return {number}
+ */
+proto.openstorage.api.ObjectstoreInfo.prototype.getAction = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 5, 0));
+};
+
+
+/** @param {number} value */
+proto.openstorage.api.ObjectstoreInfo.prototype.setAction = function(value) {
+  jspb.Message.setField(this, 5, value);
+};
+
+
+/**
+ * optional string access_key = 6;
+ * @return {string}
+ */
+proto.openstorage.api.ObjectstoreInfo.prototype.getAccessKey = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 6, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.ObjectstoreInfo.prototype.setAccessKey = function(value) {
+  jspb.Message.setField(this, 6, value);
+};
+
+
+/**
+ * optional string secret_key = 7;
+ * @return {string}
+ */
+proto.openstorage.api.ObjectstoreInfo.prototype.getSecretKey = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 7, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.ObjectstoreInfo.prototype.setSecretKey = function(value) {
+  jspb.Message.setField(this, 7, value);
+};
+
+
+/**
+ * repeated string endpoints = 8;
+ * @return {!Array.<string>}
+ */
+proto.openstorage.api.ObjectstoreInfo.prototype.getEndpointsList = function() {
+  return /** @type {!Array.<string>} */ (jspb.Message.getRepeatedField(this, 8));
+};
+
+
+/** @param {!Array.<string>} value */
+proto.openstorage.api.ObjectstoreInfo.prototype.setEndpointsList = function(value) {
+  jspb.Message.setField(this, 8, value || []);
+};
+
+
+/**
+ * @param {!string} value
+ * @param {number=} opt_index
+ */
+proto.openstorage.api.ObjectstoreInfo.prototype.addEndpoints = function(value, opt_index) {
+  jspb.Message.addToRepeatedField(this, 8, value, opt_index);
+};
+
+
+proto.openstorage.api.ObjectstoreInfo.prototype.clearEndpointsList = function() {
+  this.setEndpointsList([]);
+};
+
+
+/**
+ * optional string current_endPoint = 9;
+ * @return {string}
+ */
+proto.openstorage.api.ObjectstoreInfo.prototype.getCurrentEndpoint = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 9, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.ObjectstoreInfo.prototype.setCurrentEndpoint = function(value) {
+  jspb.Message.setField(this, 9, value);
+};
+
+
+/**
+ * optional int64 access_port = 10;
+ * @return {number}
+ */
+proto.openstorage.api.ObjectstoreInfo.prototype.getAccessPort = function() {
+  return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 10, 0));
+};
+
+
+/** @param {number} value */
+proto.openstorage.api.ObjectstoreInfo.prototype.setAccessPort = function(value) {
+  jspb.Message.setField(this, 10, value);
+};
+
+
+/**
+ * optional string region = 11;
+ * @return {string}
+ */
+proto.openstorage.api.ObjectstoreInfo.prototype.getRegion = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 11, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.ObjectstoreInfo.prototype.setRegion = function(value) {
+  jspb.Message.setField(this, 11, value);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
 proto.openstorage.api.VolumeCreateRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
@@ -8233,12 +8688,12 @@ proto.openstorage.api.StorageCluster.prototype.clearNodesList = function() {
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeMountRequest = function(opt_data) {
+proto.openstorage.api.SdkCredentialCreateAzureRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeMountRequest, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkCredentialCreateAzureRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeMountRequest.displayName = 'proto.openstorage.api.VolumeMountRequest';
+  proto.openstorage.api.SdkCredentialCreateAzureRequest.displayName = 'proto.openstorage.api.SdkCredentialCreateAzureRequest';
 }
 
 
@@ -8253,8 +8708,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeMountRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeMountRequest.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkCredentialCreateAzureRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkCredentialCreateAzureRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -8263,11 +8718,3002 @@ proto.openstorage.api.VolumeMountRequest.prototype.toObject = function(opt_inclu
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeMountRequest} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkCredentialCreateAzureRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeMountRequest.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkCredentialCreateAzureRequest.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    credential: (f = msg.getCredential()) && proto.openstorage.api.AzureCredential.toObject(includeInstance, f)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.SdkCredentialCreateAzureRequest}
+ */
+proto.openstorage.api.SdkCredentialCreateAzureRequest.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.SdkCredentialCreateAzureRequest;
+  return proto.openstorage.api.SdkCredentialCreateAzureRequest.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.SdkCredentialCreateAzureRequest} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.SdkCredentialCreateAzureRequest}
+ */
+proto.openstorage.api.SdkCredentialCreateAzureRequest.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.openstorage.api.AzureCredential;
+      reader.readMessage(value,proto.openstorage.api.AzureCredential.deserializeBinaryFromReader);
+      msg.setCredential(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.SdkCredentialCreateAzureRequest.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.SdkCredentialCreateAzureRequest.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.SdkCredentialCreateAzureRequest} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialCreateAzureRequest.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getCredential();
+  if (f != null) {
+    writer.writeMessage(
+      1,
+      f,
+      proto.openstorage.api.AzureCredential.serializeBinaryToWriter
+    );
+  }
+};
+
+
+/**
+ * optional AzureCredential credential = 1;
+ * @return {?proto.openstorage.api.AzureCredential}
+ */
+proto.openstorage.api.SdkCredentialCreateAzureRequest.prototype.getCredential = function() {
+  return /** @type{?proto.openstorage.api.AzureCredential} */ (
+    jspb.Message.getWrapperField(this, proto.openstorage.api.AzureCredential, 1));
+};
+
+
+/** @param {?proto.openstorage.api.AzureCredential|undefined} value */
+proto.openstorage.api.SdkCredentialCreateAzureRequest.prototype.setCredential = function(value) {
+  jspb.Message.setWrapperField(this, 1, value);
+};
+
+
+proto.openstorage.api.SdkCredentialCreateAzureRequest.prototype.clearCredential = function() {
+  this.setCredential(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {!boolean}
+ */
+proto.openstorage.api.SdkCredentialCreateAzureRequest.prototype.hasCredential = function() {
+  return jspb.Message.getField(this, 1) != null;
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.openstorage.api.SdkCredentialCreateAzureResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.openstorage.api.SdkCredentialCreateAzureResponse, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.SdkCredentialCreateAzureResponse.displayName = 'proto.openstorage.api.SdkCredentialCreateAzureResponse';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.SdkCredentialCreateAzureResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkCredentialCreateAzureResponse.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.SdkCredentialCreateAzureResponse} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialCreateAzureResponse.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    credentialId: jspb.Message.getFieldWithDefault(msg, 1, "")
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.SdkCredentialCreateAzureResponse}
+ */
+proto.openstorage.api.SdkCredentialCreateAzureResponse.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.SdkCredentialCreateAzureResponse;
+  return proto.openstorage.api.SdkCredentialCreateAzureResponse.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.SdkCredentialCreateAzureResponse} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.SdkCredentialCreateAzureResponse}
+ */
+proto.openstorage.api.SdkCredentialCreateAzureResponse.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setCredentialId(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.SdkCredentialCreateAzureResponse.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.SdkCredentialCreateAzureResponse.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.SdkCredentialCreateAzureResponse} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialCreateAzureResponse.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getCredentialId();
+  if (f.length > 0) {
+    writer.writeString(
+      1,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional string credential_id = 1;
+ * @return {string}
+ */
+proto.openstorage.api.SdkCredentialCreateAzureResponse.prototype.getCredentialId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.SdkCredentialCreateAzureResponse.prototype.setCredentialId = function(value) {
+  jspb.Message.setField(this, 1, value);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.openstorage.api.SdkCredentialCreateGoogleRequest = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.openstorage.api.SdkCredentialCreateGoogleRequest, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.SdkCredentialCreateGoogleRequest.displayName = 'proto.openstorage.api.SdkCredentialCreateGoogleRequest';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.SdkCredentialCreateGoogleRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkCredentialCreateGoogleRequest.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.SdkCredentialCreateGoogleRequest} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialCreateGoogleRequest.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    credential: (f = msg.getCredential()) && proto.openstorage.api.GoogleCredential.toObject(includeInstance, f)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.SdkCredentialCreateGoogleRequest}
+ */
+proto.openstorage.api.SdkCredentialCreateGoogleRequest.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.SdkCredentialCreateGoogleRequest;
+  return proto.openstorage.api.SdkCredentialCreateGoogleRequest.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.SdkCredentialCreateGoogleRequest} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.SdkCredentialCreateGoogleRequest}
+ */
+proto.openstorage.api.SdkCredentialCreateGoogleRequest.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.openstorage.api.GoogleCredential;
+      reader.readMessage(value,proto.openstorage.api.GoogleCredential.deserializeBinaryFromReader);
+      msg.setCredential(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.SdkCredentialCreateGoogleRequest.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.SdkCredentialCreateGoogleRequest.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.SdkCredentialCreateGoogleRequest} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialCreateGoogleRequest.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getCredential();
+  if (f != null) {
+    writer.writeMessage(
+      1,
+      f,
+      proto.openstorage.api.GoogleCredential.serializeBinaryToWriter
+    );
+  }
+};
+
+
+/**
+ * optional GoogleCredential credential = 1;
+ * @return {?proto.openstorage.api.GoogleCredential}
+ */
+proto.openstorage.api.SdkCredentialCreateGoogleRequest.prototype.getCredential = function() {
+  return /** @type{?proto.openstorage.api.GoogleCredential} */ (
+    jspb.Message.getWrapperField(this, proto.openstorage.api.GoogleCredential, 1));
+};
+
+
+/** @param {?proto.openstorage.api.GoogleCredential|undefined} value */
+proto.openstorage.api.SdkCredentialCreateGoogleRequest.prototype.setCredential = function(value) {
+  jspb.Message.setWrapperField(this, 1, value);
+};
+
+
+proto.openstorage.api.SdkCredentialCreateGoogleRequest.prototype.clearCredential = function() {
+  this.setCredential(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {!boolean}
+ */
+proto.openstorage.api.SdkCredentialCreateGoogleRequest.prototype.hasCredential = function() {
+  return jspb.Message.getField(this, 1) != null;
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.openstorage.api.SdkCredentialCreateGoogleResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.openstorage.api.SdkCredentialCreateGoogleResponse, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.SdkCredentialCreateGoogleResponse.displayName = 'proto.openstorage.api.SdkCredentialCreateGoogleResponse';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.SdkCredentialCreateGoogleResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkCredentialCreateGoogleResponse.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.SdkCredentialCreateGoogleResponse} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialCreateGoogleResponse.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    credentialId: jspb.Message.getFieldWithDefault(msg, 1, "")
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.SdkCredentialCreateGoogleResponse}
+ */
+proto.openstorage.api.SdkCredentialCreateGoogleResponse.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.SdkCredentialCreateGoogleResponse;
+  return proto.openstorage.api.SdkCredentialCreateGoogleResponse.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.SdkCredentialCreateGoogleResponse} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.SdkCredentialCreateGoogleResponse}
+ */
+proto.openstorage.api.SdkCredentialCreateGoogleResponse.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setCredentialId(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.SdkCredentialCreateGoogleResponse.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.SdkCredentialCreateGoogleResponse.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.SdkCredentialCreateGoogleResponse} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialCreateGoogleResponse.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getCredentialId();
+  if (f.length > 0) {
+    writer.writeString(
+      1,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional string credential_id = 1;
+ * @return {string}
+ */
+proto.openstorage.api.SdkCredentialCreateGoogleResponse.prototype.getCredentialId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.SdkCredentialCreateGoogleResponse.prototype.setCredentialId = function(value) {
+  jspb.Message.setField(this, 1, value);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.openstorage.api.SdkCredentialCreateAWSRequest = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.openstorage.api.SdkCredentialCreateAWSRequest, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.SdkCredentialCreateAWSRequest.displayName = 'proto.openstorage.api.SdkCredentialCreateAWSRequest';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.SdkCredentialCreateAWSRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkCredentialCreateAWSRequest.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.SdkCredentialCreateAWSRequest} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialCreateAWSRequest.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    credential: (f = msg.getCredential()) && proto.openstorage.api.S3Credential.toObject(includeInstance, f)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.SdkCredentialCreateAWSRequest}
+ */
+proto.openstorage.api.SdkCredentialCreateAWSRequest.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.SdkCredentialCreateAWSRequest;
+  return proto.openstorage.api.SdkCredentialCreateAWSRequest.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.SdkCredentialCreateAWSRequest} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.SdkCredentialCreateAWSRequest}
+ */
+proto.openstorage.api.SdkCredentialCreateAWSRequest.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.openstorage.api.S3Credential;
+      reader.readMessage(value,proto.openstorage.api.S3Credential.deserializeBinaryFromReader);
+      msg.setCredential(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.SdkCredentialCreateAWSRequest.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.SdkCredentialCreateAWSRequest.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.SdkCredentialCreateAWSRequest} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialCreateAWSRequest.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getCredential();
+  if (f != null) {
+    writer.writeMessage(
+      1,
+      f,
+      proto.openstorage.api.S3Credential.serializeBinaryToWriter
+    );
+  }
+};
+
+
+/**
+ * optional S3Credential credential = 1;
+ * @return {?proto.openstorage.api.S3Credential}
+ */
+proto.openstorage.api.SdkCredentialCreateAWSRequest.prototype.getCredential = function() {
+  return /** @type{?proto.openstorage.api.S3Credential} */ (
+    jspb.Message.getWrapperField(this, proto.openstorage.api.S3Credential, 1));
+};
+
+
+/** @param {?proto.openstorage.api.S3Credential|undefined} value */
+proto.openstorage.api.SdkCredentialCreateAWSRequest.prototype.setCredential = function(value) {
+  jspb.Message.setWrapperField(this, 1, value);
+};
+
+
+proto.openstorage.api.SdkCredentialCreateAWSRequest.prototype.clearCredential = function() {
+  this.setCredential(undefined);
+};
+
+
+/**
+ * Returns whether this field is set.
+ * @return {!boolean}
+ */
+proto.openstorage.api.SdkCredentialCreateAWSRequest.prototype.hasCredential = function() {
+  return jspb.Message.getField(this, 1) != null;
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.openstorage.api.SdkCredentialCreateAWSResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.openstorage.api.SdkCredentialCreateAWSResponse, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.SdkCredentialCreateAWSResponse.displayName = 'proto.openstorage.api.SdkCredentialCreateAWSResponse';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.SdkCredentialCreateAWSResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkCredentialCreateAWSResponse.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.SdkCredentialCreateAWSResponse} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialCreateAWSResponse.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    credentialId: jspb.Message.getFieldWithDefault(msg, 1, "")
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.SdkCredentialCreateAWSResponse}
+ */
+proto.openstorage.api.SdkCredentialCreateAWSResponse.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.SdkCredentialCreateAWSResponse;
+  return proto.openstorage.api.SdkCredentialCreateAWSResponse.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.SdkCredentialCreateAWSResponse} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.SdkCredentialCreateAWSResponse}
+ */
+proto.openstorage.api.SdkCredentialCreateAWSResponse.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setCredentialId(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.SdkCredentialCreateAWSResponse.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.SdkCredentialCreateAWSResponse.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.SdkCredentialCreateAWSResponse} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialCreateAWSResponse.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getCredentialId();
+  if (f.length > 0) {
+    writer.writeString(
+      1,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional string credential_id = 1;
+ * @return {string}
+ */
+proto.openstorage.api.SdkCredentialCreateAWSResponse.prototype.getCredentialId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.SdkCredentialCreateAWSResponse.prototype.setCredentialId = function(value) {
+  jspb.Message.setField(this, 1, value);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.openstorage.api.S3Credential = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.openstorage.api.S3Credential, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.S3Credential.displayName = 'proto.openstorage.api.S3Credential';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.S3Credential.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.S3Credential.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.S3Credential} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.S3Credential.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    credentialId: jspb.Message.getFieldWithDefault(msg, 1, ""),
+    accessKey: jspb.Message.getFieldWithDefault(msg, 2, ""),
+    secretKey: jspb.Message.getFieldWithDefault(msg, 3, ""),
+    endpoint: jspb.Message.getFieldWithDefault(msg, 4, ""),
+    region: jspb.Message.getFieldWithDefault(msg, 5, "")
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.S3Credential}
+ */
+proto.openstorage.api.S3Credential.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.S3Credential;
+  return proto.openstorage.api.S3Credential.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.S3Credential} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.S3Credential}
+ */
+proto.openstorage.api.S3Credential.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setCredentialId(value);
+      break;
+    case 2:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setAccessKey(value);
+      break;
+    case 3:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setSecretKey(value);
+      break;
+    case 4:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setEndpoint(value);
+      break;
+    case 5:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setRegion(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.S3Credential.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.S3Credential.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.S3Credential} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.S3Credential.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getCredentialId();
+  if (f.length > 0) {
+    writer.writeString(
+      1,
+      f
+    );
+  }
+  f = message.getAccessKey();
+  if (f.length > 0) {
+    writer.writeString(
+      2,
+      f
+    );
+  }
+  f = message.getSecretKey();
+  if (f.length > 0) {
+    writer.writeString(
+      3,
+      f
+    );
+  }
+  f = message.getEndpoint();
+  if (f.length > 0) {
+    writer.writeString(
+      4,
+      f
+    );
+  }
+  f = message.getRegion();
+  if (f.length > 0) {
+    writer.writeString(
+      5,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional string credential_id = 1;
+ * @return {string}
+ */
+proto.openstorage.api.S3Credential.prototype.getCredentialId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.S3Credential.prototype.setCredentialId = function(value) {
+  jspb.Message.setField(this, 1, value);
+};
+
+
+/**
+ * optional string access_key = 2;
+ * @return {string}
+ */
+proto.openstorage.api.S3Credential.prototype.getAccessKey = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.S3Credential.prototype.setAccessKey = function(value) {
+  jspb.Message.setField(this, 2, value);
+};
+
+
+/**
+ * optional string secret_key = 3;
+ * @return {string}
+ */
+proto.openstorage.api.S3Credential.prototype.getSecretKey = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.S3Credential.prototype.setSecretKey = function(value) {
+  jspb.Message.setField(this, 3, value);
+};
+
+
+/**
+ * optional string endpoint = 4;
+ * @return {string}
+ */
+proto.openstorage.api.S3Credential.prototype.getEndpoint = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 4, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.S3Credential.prototype.setEndpoint = function(value) {
+  jspb.Message.setField(this, 4, value);
+};
+
+
+/**
+ * optional string region = 5;
+ * @return {string}
+ */
+proto.openstorage.api.S3Credential.prototype.getRegion = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 5, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.S3Credential.prototype.setRegion = function(value) {
+  jspb.Message.setField(this, 5, value);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.openstorage.api.AzureCredential = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.openstorage.api.AzureCredential, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.AzureCredential.displayName = 'proto.openstorage.api.AzureCredential';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.AzureCredential.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.AzureCredential.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.AzureCredential} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.AzureCredential.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    credentialId: jspb.Message.getFieldWithDefault(msg, 1, ""),
+    accountName: jspb.Message.getFieldWithDefault(msg, 2, ""),
+    accountKey: jspb.Message.getFieldWithDefault(msg, 3, "")
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.AzureCredential}
+ */
+proto.openstorage.api.AzureCredential.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.AzureCredential;
+  return proto.openstorage.api.AzureCredential.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.AzureCredential} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.AzureCredential}
+ */
+proto.openstorage.api.AzureCredential.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setCredentialId(value);
+      break;
+    case 2:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setAccountName(value);
+      break;
+    case 3:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setAccountKey(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.AzureCredential.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.AzureCredential.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.AzureCredential} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.AzureCredential.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getCredentialId();
+  if (f.length > 0) {
+    writer.writeString(
+      1,
+      f
+    );
+  }
+  f = message.getAccountName();
+  if (f.length > 0) {
+    writer.writeString(
+      2,
+      f
+    );
+  }
+  f = message.getAccountKey();
+  if (f.length > 0) {
+    writer.writeString(
+      3,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional string credential_id = 1;
+ * @return {string}
+ */
+proto.openstorage.api.AzureCredential.prototype.getCredentialId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.AzureCredential.prototype.setCredentialId = function(value) {
+  jspb.Message.setField(this, 1, value);
+};
+
+
+/**
+ * optional string account_name = 2;
+ * @return {string}
+ */
+proto.openstorage.api.AzureCredential.prototype.getAccountName = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.AzureCredential.prototype.setAccountName = function(value) {
+  jspb.Message.setField(this, 2, value);
+};
+
+
+/**
+ * optional string account_key = 3;
+ * @return {string}
+ */
+proto.openstorage.api.AzureCredential.prototype.getAccountKey = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.AzureCredential.prototype.setAccountKey = function(value) {
+  jspb.Message.setField(this, 3, value);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.openstorage.api.GoogleCredential = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.openstorage.api.GoogleCredential, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.GoogleCredential.displayName = 'proto.openstorage.api.GoogleCredential';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.GoogleCredential.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.GoogleCredential.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.GoogleCredential} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.GoogleCredential.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    credentialId: jspb.Message.getFieldWithDefault(msg, 1, ""),
+    projectId: jspb.Message.getFieldWithDefault(msg, 2, ""),
+    jsonKey: jspb.Message.getFieldWithDefault(msg, 3, "")
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.GoogleCredential}
+ */
+proto.openstorage.api.GoogleCredential.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.GoogleCredential;
+  return proto.openstorage.api.GoogleCredential.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.GoogleCredential} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.GoogleCredential}
+ */
+proto.openstorage.api.GoogleCredential.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setCredentialId(value);
+      break;
+    case 2:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setProjectId(value);
+      break;
+    case 3:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setJsonKey(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.GoogleCredential.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.GoogleCredential.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.GoogleCredential} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.GoogleCredential.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getCredentialId();
+  if (f.length > 0) {
+    writer.writeString(
+      1,
+      f
+    );
+  }
+  f = message.getProjectId();
+  if (f.length > 0) {
+    writer.writeString(
+      2,
+      f
+    );
+  }
+  f = message.getJsonKey();
+  if (f.length > 0) {
+    writer.writeString(
+      3,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional string credential_id = 1;
+ * @return {string}
+ */
+proto.openstorage.api.GoogleCredential.prototype.getCredentialId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.GoogleCredential.prototype.setCredentialId = function(value) {
+  jspb.Message.setField(this, 1, value);
+};
+
+
+/**
+ * optional string project_id = 2;
+ * @return {string}
+ */
+proto.openstorage.api.GoogleCredential.prototype.getProjectId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.GoogleCredential.prototype.setProjectId = function(value) {
+  jspb.Message.setField(this, 2, value);
+};
+
+
+/**
+ * optional string json_key = 3;
+ * @return {string}
+ */
+proto.openstorage.api.GoogleCredential.prototype.getJsonKey = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 3, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.GoogleCredential.prototype.setJsonKey = function(value) {
+  jspb.Message.setField(this, 3, value);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.openstorage.api.SdkCredentialEnumerateAWSRequest = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.openstorage.api.SdkCredentialEnumerateAWSRequest, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.SdkCredentialEnumerateAWSRequest.displayName = 'proto.openstorage.api.SdkCredentialEnumerateAWSRequest';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAWSRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkCredentialEnumerateAWSRequest.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.SdkCredentialEnumerateAWSRequest} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialEnumerateAWSRequest.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    credentialId: jspb.Message.getFieldWithDefault(msg, 1, "")
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.SdkCredentialEnumerateAWSRequest}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAWSRequest.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.SdkCredentialEnumerateAWSRequest;
+  return proto.openstorage.api.SdkCredentialEnumerateAWSRequest.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.SdkCredentialEnumerateAWSRequest} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.SdkCredentialEnumerateAWSRequest}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAWSRequest.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setCredentialId(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAWSRequest.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.SdkCredentialEnumerateAWSRequest.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.SdkCredentialEnumerateAWSRequest} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialEnumerateAWSRequest.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getCredentialId();
+  if (f.length > 0) {
+    writer.writeString(
+      1,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional string credential_id = 1;
+ * @return {string}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAWSRequest.prototype.getCredentialId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.SdkCredentialEnumerateAWSRequest.prototype.setCredentialId = function(value) {
+  jspb.Message.setField(this, 1, value);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.openstorage.api.SdkCredentialEnumerateAWSResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.openstorage.api.SdkCredentialEnumerateAWSResponse.repeatedFields_, null);
+};
+goog.inherits(proto.openstorage.api.SdkCredentialEnumerateAWSResponse, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.SdkCredentialEnumerateAWSResponse.displayName = 'proto.openstorage.api.SdkCredentialEnumerateAWSResponse';
+}
+/**
+ * List of repeated fields within this message type.
+ * @private {!Array<number>}
+ * @const
+ */
+proto.openstorage.api.SdkCredentialEnumerateAWSResponse.repeatedFields_ = [1];
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAWSResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkCredentialEnumerateAWSResponse.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.SdkCredentialEnumerateAWSResponse} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialEnumerateAWSResponse.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    credentialList: jspb.Message.toObjectList(msg.getCredentialList(),
+    proto.openstorage.api.S3Credential.toObject, includeInstance)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.SdkCredentialEnumerateAWSResponse}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAWSResponse.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.SdkCredentialEnumerateAWSResponse;
+  return proto.openstorage.api.SdkCredentialEnumerateAWSResponse.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.SdkCredentialEnumerateAWSResponse} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.SdkCredentialEnumerateAWSResponse}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAWSResponse.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.openstorage.api.S3Credential;
+      reader.readMessage(value,proto.openstorage.api.S3Credential.deserializeBinaryFromReader);
+      msg.addCredential(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAWSResponse.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.SdkCredentialEnumerateAWSResponse.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.SdkCredentialEnumerateAWSResponse} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialEnumerateAWSResponse.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getCredentialList();
+  if (f.length > 0) {
+    writer.writeRepeatedMessage(
+      1,
+      f,
+      proto.openstorage.api.S3Credential.serializeBinaryToWriter
+    );
+  }
+};
+
+
+/**
+ * repeated S3Credential credential = 1;
+ * @return {!Array.<!proto.openstorage.api.S3Credential>}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAWSResponse.prototype.getCredentialList = function() {
+  return /** @type{!Array.<!proto.openstorage.api.S3Credential>} */ (
+    jspb.Message.getRepeatedWrapperField(this, proto.openstorage.api.S3Credential, 1));
+};
+
+
+/** @param {!Array.<!proto.openstorage.api.S3Credential>} value */
+proto.openstorage.api.SdkCredentialEnumerateAWSResponse.prototype.setCredentialList = function(value) {
+  jspb.Message.setRepeatedWrapperField(this, 1, value);
+};
+
+
+/**
+ * @param {!proto.openstorage.api.S3Credential=} opt_value
+ * @param {number=} opt_index
+ * @return {!proto.openstorage.api.S3Credential}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAWSResponse.prototype.addCredential = function(opt_value, opt_index) {
+  return jspb.Message.addToRepeatedWrapperField(this, 1, opt_value, proto.openstorage.api.S3Credential, opt_index);
+};
+
+
+proto.openstorage.api.SdkCredentialEnumerateAWSResponse.prototype.clearCredentialList = function() {
+  this.setCredentialList([]);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.openstorage.api.SdkCredentialEnumerateAzureRequest = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.openstorage.api.SdkCredentialEnumerateAzureRequest, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.SdkCredentialEnumerateAzureRequest.displayName = 'proto.openstorage.api.SdkCredentialEnumerateAzureRequest';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAzureRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkCredentialEnumerateAzureRequest.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.SdkCredentialEnumerateAzureRequest} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialEnumerateAzureRequest.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    credentialId: jspb.Message.getFieldWithDefault(msg, 1, "")
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.SdkCredentialEnumerateAzureRequest}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAzureRequest.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.SdkCredentialEnumerateAzureRequest;
+  return proto.openstorage.api.SdkCredentialEnumerateAzureRequest.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.SdkCredentialEnumerateAzureRequest} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.SdkCredentialEnumerateAzureRequest}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAzureRequest.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setCredentialId(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAzureRequest.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.SdkCredentialEnumerateAzureRequest.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.SdkCredentialEnumerateAzureRequest} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialEnumerateAzureRequest.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getCredentialId();
+  if (f.length > 0) {
+    writer.writeString(
+      1,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional string credential_id = 1;
+ * @return {string}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAzureRequest.prototype.getCredentialId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.SdkCredentialEnumerateAzureRequest.prototype.setCredentialId = function(value) {
+  jspb.Message.setField(this, 1, value);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.openstorage.api.SdkCredentialEnumerateAzureResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.openstorage.api.SdkCredentialEnumerateAzureResponse.repeatedFields_, null);
+};
+goog.inherits(proto.openstorage.api.SdkCredentialEnumerateAzureResponse, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.SdkCredentialEnumerateAzureResponse.displayName = 'proto.openstorage.api.SdkCredentialEnumerateAzureResponse';
+}
+/**
+ * List of repeated fields within this message type.
+ * @private {!Array<number>}
+ * @const
+ */
+proto.openstorage.api.SdkCredentialEnumerateAzureResponse.repeatedFields_ = [1];
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAzureResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkCredentialEnumerateAzureResponse.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.SdkCredentialEnumerateAzureResponse} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialEnumerateAzureResponse.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    credentialList: jspb.Message.toObjectList(msg.getCredentialList(),
+    proto.openstorage.api.AzureCredential.toObject, includeInstance)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.SdkCredentialEnumerateAzureResponse}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAzureResponse.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.SdkCredentialEnumerateAzureResponse;
+  return proto.openstorage.api.SdkCredentialEnumerateAzureResponse.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.SdkCredentialEnumerateAzureResponse} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.SdkCredentialEnumerateAzureResponse}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAzureResponse.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.openstorage.api.AzureCredential;
+      reader.readMessage(value,proto.openstorage.api.AzureCredential.deserializeBinaryFromReader);
+      msg.addCredential(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAzureResponse.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.SdkCredentialEnumerateAzureResponse.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.SdkCredentialEnumerateAzureResponse} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialEnumerateAzureResponse.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getCredentialList();
+  if (f.length > 0) {
+    writer.writeRepeatedMessage(
+      1,
+      f,
+      proto.openstorage.api.AzureCredential.serializeBinaryToWriter
+    );
+  }
+};
+
+
+/**
+ * repeated AzureCredential credential = 1;
+ * @return {!Array.<!proto.openstorage.api.AzureCredential>}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAzureResponse.prototype.getCredentialList = function() {
+  return /** @type{!Array.<!proto.openstorage.api.AzureCredential>} */ (
+    jspb.Message.getRepeatedWrapperField(this, proto.openstorage.api.AzureCredential, 1));
+};
+
+
+/** @param {!Array.<!proto.openstorage.api.AzureCredential>} value */
+proto.openstorage.api.SdkCredentialEnumerateAzureResponse.prototype.setCredentialList = function(value) {
+  jspb.Message.setRepeatedWrapperField(this, 1, value);
+};
+
+
+/**
+ * @param {!proto.openstorage.api.AzureCredential=} opt_value
+ * @param {number=} opt_index
+ * @return {!proto.openstorage.api.AzureCredential}
+ */
+proto.openstorage.api.SdkCredentialEnumerateAzureResponse.prototype.addCredential = function(opt_value, opt_index) {
+  return jspb.Message.addToRepeatedWrapperField(this, 1, opt_value, proto.openstorage.api.AzureCredential, opt_index);
+};
+
+
+proto.openstorage.api.SdkCredentialEnumerateAzureResponse.prototype.clearCredentialList = function() {
+  this.setCredentialList([]);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.openstorage.api.SdkCredentialEnumerateGoogleRequest = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.openstorage.api.SdkCredentialEnumerateGoogleRequest, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.SdkCredentialEnumerateGoogleRequest.displayName = 'proto.openstorage.api.SdkCredentialEnumerateGoogleRequest';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.SdkCredentialEnumerateGoogleRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkCredentialEnumerateGoogleRequest.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.SdkCredentialEnumerateGoogleRequest} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialEnumerateGoogleRequest.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    credentialId: jspb.Message.getFieldWithDefault(msg, 1, "")
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.SdkCredentialEnumerateGoogleRequest}
+ */
+proto.openstorage.api.SdkCredentialEnumerateGoogleRequest.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.SdkCredentialEnumerateGoogleRequest;
+  return proto.openstorage.api.SdkCredentialEnumerateGoogleRequest.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.SdkCredentialEnumerateGoogleRequest} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.SdkCredentialEnumerateGoogleRequest}
+ */
+proto.openstorage.api.SdkCredentialEnumerateGoogleRequest.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setCredentialId(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.SdkCredentialEnumerateGoogleRequest.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.SdkCredentialEnumerateGoogleRequest.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.SdkCredentialEnumerateGoogleRequest} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialEnumerateGoogleRequest.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getCredentialId();
+  if (f.length > 0) {
+    writer.writeString(
+      1,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional string credential_id = 1;
+ * @return {string}
+ */
+proto.openstorage.api.SdkCredentialEnumerateGoogleRequest.prototype.getCredentialId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.SdkCredentialEnumerateGoogleRequest.prototype.setCredentialId = function(value) {
+  jspb.Message.setField(this, 1, value);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.openstorage.api.SdkCredentialEnumerateGoogleResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.openstorage.api.SdkCredentialEnumerateGoogleResponse.repeatedFields_, null);
+};
+goog.inherits(proto.openstorage.api.SdkCredentialEnumerateGoogleResponse, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.SdkCredentialEnumerateGoogleResponse.displayName = 'proto.openstorage.api.SdkCredentialEnumerateGoogleResponse';
+}
+/**
+ * List of repeated fields within this message type.
+ * @private {!Array<number>}
+ * @const
+ */
+proto.openstorage.api.SdkCredentialEnumerateGoogleResponse.repeatedFields_ = [1];
+
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.SdkCredentialEnumerateGoogleResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkCredentialEnumerateGoogleResponse.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.SdkCredentialEnumerateGoogleResponse} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialEnumerateGoogleResponse.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    credentialList: jspb.Message.toObjectList(msg.getCredentialList(),
+    proto.openstorage.api.GoogleCredential.toObject, includeInstance)
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.SdkCredentialEnumerateGoogleResponse}
+ */
+proto.openstorage.api.SdkCredentialEnumerateGoogleResponse.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.SdkCredentialEnumerateGoogleResponse;
+  return proto.openstorage.api.SdkCredentialEnumerateGoogleResponse.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.SdkCredentialEnumerateGoogleResponse} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.SdkCredentialEnumerateGoogleResponse}
+ */
+proto.openstorage.api.SdkCredentialEnumerateGoogleResponse.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = new proto.openstorage.api.GoogleCredential;
+      reader.readMessage(value,proto.openstorage.api.GoogleCredential.deserializeBinaryFromReader);
+      msg.addCredential(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.SdkCredentialEnumerateGoogleResponse.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.SdkCredentialEnumerateGoogleResponse.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.SdkCredentialEnumerateGoogleResponse} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialEnumerateGoogleResponse.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getCredentialList();
+  if (f.length > 0) {
+    writer.writeRepeatedMessage(
+      1,
+      f,
+      proto.openstorage.api.GoogleCredential.serializeBinaryToWriter
+    );
+  }
+};
+
+
+/**
+ * repeated GoogleCredential credential = 1;
+ * @return {!Array.<!proto.openstorage.api.GoogleCredential>}
+ */
+proto.openstorage.api.SdkCredentialEnumerateGoogleResponse.prototype.getCredentialList = function() {
+  return /** @type{!Array.<!proto.openstorage.api.GoogleCredential>} */ (
+    jspb.Message.getRepeatedWrapperField(this, proto.openstorage.api.GoogleCredential, 1));
+};
+
+
+/** @param {!Array.<!proto.openstorage.api.GoogleCredential>} value */
+proto.openstorage.api.SdkCredentialEnumerateGoogleResponse.prototype.setCredentialList = function(value) {
+  jspb.Message.setRepeatedWrapperField(this, 1, value);
+};
+
+
+/**
+ * @param {!proto.openstorage.api.GoogleCredential=} opt_value
+ * @param {number=} opt_index
+ * @return {!proto.openstorage.api.GoogleCredential}
+ */
+proto.openstorage.api.SdkCredentialEnumerateGoogleResponse.prototype.addCredential = function(opt_value, opt_index) {
+  return jspb.Message.addToRepeatedWrapperField(this, 1, opt_value, proto.openstorage.api.GoogleCredential, opt_index);
+};
+
+
+proto.openstorage.api.SdkCredentialEnumerateGoogleResponse.prototype.clearCredentialList = function() {
+  this.setCredentialList([]);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.openstorage.api.SdkCredentialDeleteRequest = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.openstorage.api.SdkCredentialDeleteRequest, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.SdkCredentialDeleteRequest.displayName = 'proto.openstorage.api.SdkCredentialDeleteRequest';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.SdkCredentialDeleteRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkCredentialDeleteRequest.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.SdkCredentialDeleteRequest} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialDeleteRequest.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    credentialId: jspb.Message.getFieldWithDefault(msg, 1, "")
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.SdkCredentialDeleteRequest}
+ */
+proto.openstorage.api.SdkCredentialDeleteRequest.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.SdkCredentialDeleteRequest;
+  return proto.openstorage.api.SdkCredentialDeleteRequest.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.SdkCredentialDeleteRequest} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.SdkCredentialDeleteRequest}
+ */
+proto.openstorage.api.SdkCredentialDeleteRequest.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setCredentialId(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.SdkCredentialDeleteRequest.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.SdkCredentialDeleteRequest.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.SdkCredentialDeleteRequest} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialDeleteRequest.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getCredentialId();
+  if (f.length > 0) {
+    writer.writeString(
+      1,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional string credential_id = 1;
+ * @return {string}
+ */
+proto.openstorage.api.SdkCredentialDeleteRequest.prototype.getCredentialId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.SdkCredentialDeleteRequest.prototype.setCredentialId = function(value) {
+  jspb.Message.setField(this, 1, value);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.openstorage.api.SdkCredentialDeleteResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.openstorage.api.SdkCredentialDeleteResponse, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.SdkCredentialDeleteResponse.displayName = 'proto.openstorage.api.SdkCredentialDeleteResponse';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.SdkCredentialDeleteResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkCredentialDeleteResponse.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.SdkCredentialDeleteResponse} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialDeleteResponse.toObject = function(includeInstance, msg) {
+  var f, obj = {
+
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.SdkCredentialDeleteResponse}
+ */
+proto.openstorage.api.SdkCredentialDeleteResponse.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.SdkCredentialDeleteResponse;
+  return proto.openstorage.api.SdkCredentialDeleteResponse.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.SdkCredentialDeleteResponse} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.SdkCredentialDeleteResponse}
+ */
+proto.openstorage.api.SdkCredentialDeleteResponse.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.SdkCredentialDeleteResponse.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.SdkCredentialDeleteResponse.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.SdkCredentialDeleteResponse} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialDeleteResponse.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.openstorage.api.SdkCredentialValidateRequest = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.openstorage.api.SdkCredentialValidateRequest, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.SdkCredentialValidateRequest.displayName = 'proto.openstorage.api.SdkCredentialValidateRequest';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.SdkCredentialValidateRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkCredentialValidateRequest.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.SdkCredentialValidateRequest} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialValidateRequest.toObject = function(includeInstance, msg) {
+  var f, obj = {
+    credentialId: jspb.Message.getFieldWithDefault(msg, 1, "")
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.SdkCredentialValidateRequest}
+ */
+proto.openstorage.api.SdkCredentialValidateRequest.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.SdkCredentialValidateRequest;
+  return proto.openstorage.api.SdkCredentialValidateRequest.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.SdkCredentialValidateRequest} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.SdkCredentialValidateRequest}
+ */
+proto.openstorage.api.SdkCredentialValidateRequest.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    case 1:
+      var value = /** @type {string} */ (reader.readString());
+      msg.setCredentialId(value);
+      break;
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.SdkCredentialValidateRequest.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.SdkCredentialValidateRequest.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.SdkCredentialValidateRequest} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialValidateRequest.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+  f = message.getCredentialId();
+  if (f.length > 0) {
+    writer.writeString(
+      1,
+      f
+    );
+  }
+};
+
+
+/**
+ * optional string credential_id = 1;
+ * @return {string}
+ */
+proto.openstorage.api.SdkCredentialValidateRequest.prototype.getCredentialId = function() {
+  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
+};
+
+
+/** @param {string} value */
+proto.openstorage.api.SdkCredentialValidateRequest.prototype.setCredentialId = function(value) {
+  jspb.Message.setField(this, 1, value);
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.openstorage.api.SdkCredentialValidateResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.openstorage.api.SdkCredentialValidateResponse, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.SdkCredentialValidateResponse.displayName = 'proto.openstorage.api.SdkCredentialValidateResponse';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.SdkCredentialValidateResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkCredentialValidateResponse.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.SdkCredentialValidateResponse} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialValidateResponse.toObject = function(includeInstance, msg) {
+  var f, obj = {
+
+  };
+
+  if (includeInstance) {
+    obj.$jspbMessageInstance = msg;
+  }
+  return obj;
+};
+}
+
+
+/**
+ * Deserializes binary data (in protobuf wire format).
+ * @param {jspb.ByteSource} bytes The bytes to deserialize.
+ * @return {!proto.openstorage.api.SdkCredentialValidateResponse}
+ */
+proto.openstorage.api.SdkCredentialValidateResponse.deserializeBinary = function(bytes) {
+  var reader = new jspb.BinaryReader(bytes);
+  var msg = new proto.openstorage.api.SdkCredentialValidateResponse;
+  return proto.openstorage.api.SdkCredentialValidateResponse.deserializeBinaryFromReader(msg, reader);
+};
+
+
+/**
+ * Deserializes binary data (in protobuf wire format) from the
+ * given reader into the given message object.
+ * @param {!proto.openstorage.api.SdkCredentialValidateResponse} msg The message object to deserialize into.
+ * @param {!jspb.BinaryReader} reader The BinaryReader to use.
+ * @return {!proto.openstorage.api.SdkCredentialValidateResponse}
+ */
+proto.openstorage.api.SdkCredentialValidateResponse.deserializeBinaryFromReader = function(msg, reader) {
+  while (reader.nextField()) {
+    if (reader.isEndGroup()) {
+      break;
+    }
+    var field = reader.getFieldNumber();
+    switch (field) {
+    default:
+      reader.skipField();
+      break;
+    }
+  }
+  return msg;
+};
+
+
+/**
+ * Serializes the message to binary data (in protobuf wire format).
+ * @return {!Uint8Array}
+ */
+proto.openstorage.api.SdkCredentialValidateResponse.prototype.serializeBinary = function() {
+  var writer = new jspb.BinaryWriter();
+  proto.openstorage.api.SdkCredentialValidateResponse.serializeBinaryToWriter(this, writer);
+  return writer.getResultBuffer();
+};
+
+
+/**
+ * Serializes the given message to binary data (in protobuf wire
+ * format), writing to the given BinaryWriter.
+ * @param {!proto.openstorage.api.SdkCredentialValidateResponse} message
+ * @param {!jspb.BinaryWriter} writer
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkCredentialValidateResponse.serializeBinaryToWriter = function(message, writer) {
+  var f = undefined;
+};
+
+
+
+/**
+ * Generated by JsPbCodeGenerator.
+ * @param {Array=} opt_data Optional initial data array, typically from a
+ * server response, or constructed directly in Javascript. The array is used
+ * in place and becomes part of the constructed object. It is not cloned.
+ * If no data is provided, the constructed object will be empty, but still
+ * valid.
+ * @extends {jspb.Message}
+ * @constructor
+ */
+proto.openstorage.api.SdkVolumeMountRequest = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, null, null);
+};
+goog.inherits(proto.openstorage.api.SdkVolumeMountRequest, jspb.Message);
+if (goog.DEBUG && !COMPILED) {
+  proto.openstorage.api.SdkVolumeMountRequest.displayName = 'proto.openstorage.api.SdkVolumeMountRequest';
+}
+
+
+if (jspb.Message.GENERATE_TO_OBJECT) {
+/**
+ * Creates an object representation of this proto suitable for use in Soy templates.
+ * Field names that are reserved in JavaScript and will be renamed to pb_name.
+ * To access a reserved field use, foo.pb_<name>, eg, foo.pb_default.
+ * For the list of reserved names please see:
+ *     com.google.apps.jspb.JsClassTemplate.JS_RESERVED_WORDS.
+ * @param {boolean=} opt_includeInstance Whether to include the JSPB instance
+ *     for transitional soy proto support: http://goto/soy-param-migration
+ * @return {!Object}
+ */
+proto.openstorage.api.SdkVolumeMountRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeMountRequest.toObject(opt_includeInstance, this);
+};
+
+
+/**
+ * Static version of the {@see toObject} method.
+ * @param {boolean|undefined} includeInstance Whether to include the JSPB
+ *     instance for transitional soy proto support:
+ *     http://goto/soy-param-migration
+ * @param {!proto.openstorage.api.SdkVolumeMountRequest} msg The msg instance to transform.
+ * @return {!Object}
+ * @suppress {unusedLocalVariables} f is only used for nested messages
+ */
+proto.openstorage.api.SdkVolumeMountRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     volumeId: jspb.Message.getFieldWithDefault(msg, 1, ""),
     mountPath: jspb.Message.getFieldWithDefault(msg, 2, ""),
@@ -8285,23 +11731,23 @@ proto.openstorage.api.VolumeMountRequest.toObject = function(includeInstance, ms
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeMountRequest}
+ * @return {!proto.openstorage.api.SdkVolumeMountRequest}
  */
-proto.openstorage.api.VolumeMountRequest.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeMountRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeMountRequest;
-  return proto.openstorage.api.VolumeMountRequest.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeMountRequest;
+  return proto.openstorage.api.SdkVolumeMountRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeMountRequest} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeMountRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeMountRequest}
+ * @return {!proto.openstorage.api.SdkVolumeMountRequest}
  */
-proto.openstorage.api.VolumeMountRequest.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeMountRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -8335,9 +11781,9 @@ proto.openstorage.api.VolumeMountRequest.deserializeBinaryFromReader = function(
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeMountRequest.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeMountRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeMountRequest.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeMountRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -8345,11 +11791,11 @@ proto.openstorage.api.VolumeMountRequest.prototype.serializeBinary = function() 
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeMountRequest} message
+ * @param {!proto.openstorage.api.SdkVolumeMountRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeMountRequest.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeMountRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getVolumeId();
   if (f.length > 0) {
@@ -8376,13 +11822,13 @@ proto.openstorage.api.VolumeMountRequest.serializeBinaryToWriter = function(mess
  * optional string volume_id = 1;
  * @return {string}
  */
-proto.openstorage.api.VolumeMountRequest.prototype.getVolumeId = function() {
+proto.openstorage.api.SdkVolumeMountRequest.prototype.getVolumeId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.VolumeMountRequest.prototype.setVolumeId = function(value) {
+proto.openstorage.api.SdkVolumeMountRequest.prototype.setVolumeId = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -8391,13 +11837,13 @@ proto.openstorage.api.VolumeMountRequest.prototype.setVolumeId = function(value)
  * optional string mount_path = 2;
  * @return {string}
  */
-proto.openstorage.api.VolumeMountRequest.prototype.getMountPath = function() {
+proto.openstorage.api.SdkVolumeMountRequest.prototype.getMountPath = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.VolumeMountRequest.prototype.setMountPath = function(value) {
+proto.openstorage.api.SdkVolumeMountRequest.prototype.setMountPath = function(value) {
   jspb.Message.setField(this, 2, value);
 };
 
@@ -8408,14 +11854,14 @@ proto.openstorage.api.VolumeMountRequest.prototype.setMountPath = function(value
  * empty, instead returning `undefined`
  * @return {!jspb.Map<string,string>}
  */
-proto.openstorage.api.VolumeMountRequest.prototype.getOptionsMap = function(opt_noLazyCreate) {
+proto.openstorage.api.SdkVolumeMountRequest.prototype.getOptionsMap = function(opt_noLazyCreate) {
   return /** @type {!jspb.Map<string,string>} */ (
       jspb.Message.getMapField(this, 3, opt_noLazyCreate,
       null));
 };
 
 
-proto.openstorage.api.VolumeMountRequest.prototype.clearOptionsMap = function() {
+proto.openstorage.api.SdkVolumeMountRequest.prototype.clearOptionsMap = function() {
   this.getOptionsMap().clear();
 };
 
@@ -8431,12 +11877,12 @@ proto.openstorage.api.VolumeMountRequest.prototype.clearOptionsMap = function() 
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeMountResponse = function(opt_data) {
+proto.openstorage.api.SdkVolumeMountResponse = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeMountResponse, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeMountResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeMountResponse.displayName = 'proto.openstorage.api.VolumeMountResponse';
+  proto.openstorage.api.SdkVolumeMountResponse.displayName = 'proto.openstorage.api.SdkVolumeMountResponse';
 }
 
 
@@ -8451,8 +11897,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeMountResponse.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeMountResponse.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeMountResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeMountResponse.toObject(opt_includeInstance, this);
 };
 
 
@@ -8461,11 +11907,11 @@ proto.openstorage.api.VolumeMountResponse.prototype.toObject = function(opt_incl
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeMountResponse} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeMountResponse} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeMountResponse.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeMountResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
 
   };
@@ -8481,23 +11927,23 @@ proto.openstorage.api.VolumeMountResponse.toObject = function(includeInstance, m
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeMountResponse}
+ * @return {!proto.openstorage.api.SdkVolumeMountResponse}
  */
-proto.openstorage.api.VolumeMountResponse.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeMountResponse.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeMountResponse;
-  return proto.openstorage.api.VolumeMountResponse.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeMountResponse;
+  return proto.openstorage.api.SdkVolumeMountResponse.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeMountResponse} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeMountResponse} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeMountResponse}
+ * @return {!proto.openstorage.api.SdkVolumeMountResponse}
  */
-proto.openstorage.api.VolumeMountResponse.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeMountResponse.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -8517,9 +11963,9 @@ proto.openstorage.api.VolumeMountResponse.deserializeBinaryFromReader = function
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeMountResponse.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeMountResponse.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeMountResponse.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeMountResponse.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -8527,11 +11973,11 @@ proto.openstorage.api.VolumeMountResponse.prototype.serializeBinary = function()
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeMountResponse} message
+ * @param {!proto.openstorage.api.SdkVolumeMountResponse} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeMountResponse.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeMountResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
 };
 
@@ -8547,12 +11993,12 @@ proto.openstorage.api.VolumeMountResponse.serializeBinaryToWriter = function(mes
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeUnmountRequest = function(opt_data) {
+proto.openstorage.api.SdkVolumeUnmountRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeUnmountRequest, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeUnmountRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeUnmountRequest.displayName = 'proto.openstorage.api.VolumeUnmountRequest';
+  proto.openstorage.api.SdkVolumeUnmountRequest.displayName = 'proto.openstorage.api.SdkVolumeUnmountRequest';
 }
 
 
@@ -8567,8 +12013,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeUnmountRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeUnmountRequest.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeUnmountRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeUnmountRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -8577,11 +12023,11 @@ proto.openstorage.api.VolumeUnmountRequest.prototype.toObject = function(opt_inc
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeUnmountRequest} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeUnmountRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeUnmountRequest.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeUnmountRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     volumeId: jspb.Message.getFieldWithDefault(msg, 1, ""),
     mountPath: jspb.Message.getFieldWithDefault(msg, 2, ""),
@@ -8599,23 +12045,23 @@ proto.openstorage.api.VolumeUnmountRequest.toObject = function(includeInstance, 
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeUnmountRequest}
+ * @return {!proto.openstorage.api.SdkVolumeUnmountRequest}
  */
-proto.openstorage.api.VolumeUnmountRequest.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeUnmountRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeUnmountRequest;
-  return proto.openstorage.api.VolumeUnmountRequest.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeUnmountRequest;
+  return proto.openstorage.api.SdkVolumeUnmountRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeUnmountRequest} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeUnmountRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeUnmountRequest}
+ * @return {!proto.openstorage.api.SdkVolumeUnmountRequest}
  */
-proto.openstorage.api.VolumeUnmountRequest.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeUnmountRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -8649,9 +12095,9 @@ proto.openstorage.api.VolumeUnmountRequest.deserializeBinaryFromReader = functio
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeUnmountRequest.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeUnmountRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeUnmountRequest.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeUnmountRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -8659,11 +12105,11 @@ proto.openstorage.api.VolumeUnmountRequest.prototype.serializeBinary = function(
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeUnmountRequest} message
+ * @param {!proto.openstorage.api.SdkVolumeUnmountRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeUnmountRequest.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeUnmountRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getVolumeId();
   if (f.length > 0) {
@@ -8690,13 +12136,13 @@ proto.openstorage.api.VolumeUnmountRequest.serializeBinaryToWriter = function(me
  * optional string volume_id = 1;
  * @return {string}
  */
-proto.openstorage.api.VolumeUnmountRequest.prototype.getVolumeId = function() {
+proto.openstorage.api.SdkVolumeUnmountRequest.prototype.getVolumeId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.VolumeUnmountRequest.prototype.setVolumeId = function(value) {
+proto.openstorage.api.SdkVolumeUnmountRequest.prototype.setVolumeId = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -8705,13 +12151,13 @@ proto.openstorage.api.VolumeUnmountRequest.prototype.setVolumeId = function(valu
  * optional string mount_path = 2;
  * @return {string}
  */
-proto.openstorage.api.VolumeUnmountRequest.prototype.getMountPath = function() {
+proto.openstorage.api.SdkVolumeUnmountRequest.prototype.getMountPath = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.VolumeUnmountRequest.prototype.setMountPath = function(value) {
+proto.openstorage.api.SdkVolumeUnmountRequest.prototype.setMountPath = function(value) {
   jspb.Message.setField(this, 2, value);
 };
 
@@ -8722,14 +12168,14 @@ proto.openstorage.api.VolumeUnmountRequest.prototype.setMountPath = function(val
  * empty, instead returning `undefined`
  * @return {!jspb.Map<string,string>}
  */
-proto.openstorage.api.VolumeUnmountRequest.prototype.getOptionsMap = function(opt_noLazyCreate) {
+proto.openstorage.api.SdkVolumeUnmountRequest.prototype.getOptionsMap = function(opt_noLazyCreate) {
   return /** @type {!jspb.Map<string,string>} */ (
       jspb.Message.getMapField(this, 3, opt_noLazyCreate,
       null));
 };
 
 
-proto.openstorage.api.VolumeUnmountRequest.prototype.clearOptionsMap = function() {
+proto.openstorage.api.SdkVolumeUnmountRequest.prototype.clearOptionsMap = function() {
   this.getOptionsMap().clear();
 };
 
@@ -8745,12 +12191,12 @@ proto.openstorage.api.VolumeUnmountRequest.prototype.clearOptionsMap = function(
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeUnmountResponse = function(opt_data) {
+proto.openstorage.api.SdkVolumeUnmountResponse = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeUnmountResponse, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeUnmountResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeUnmountResponse.displayName = 'proto.openstorage.api.VolumeUnmountResponse';
+  proto.openstorage.api.SdkVolumeUnmountResponse.displayName = 'proto.openstorage.api.SdkVolumeUnmountResponse';
 }
 
 
@@ -8765,8 +12211,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeUnmountResponse.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeUnmountResponse.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeUnmountResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeUnmountResponse.toObject(opt_includeInstance, this);
 };
 
 
@@ -8775,11 +12221,11 @@ proto.openstorage.api.VolumeUnmountResponse.prototype.toObject = function(opt_in
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeUnmountResponse} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeUnmountResponse} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeUnmountResponse.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeUnmountResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
 
   };
@@ -8795,23 +12241,23 @@ proto.openstorage.api.VolumeUnmountResponse.toObject = function(includeInstance,
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeUnmountResponse}
+ * @return {!proto.openstorage.api.SdkVolumeUnmountResponse}
  */
-proto.openstorage.api.VolumeUnmountResponse.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeUnmountResponse.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeUnmountResponse;
-  return proto.openstorage.api.VolumeUnmountResponse.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeUnmountResponse;
+  return proto.openstorage.api.SdkVolumeUnmountResponse.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeUnmountResponse} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeUnmountResponse} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeUnmountResponse}
+ * @return {!proto.openstorage.api.SdkVolumeUnmountResponse}
  */
-proto.openstorage.api.VolumeUnmountResponse.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeUnmountResponse.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -8831,9 +12277,9 @@ proto.openstorage.api.VolumeUnmountResponse.deserializeBinaryFromReader = functi
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeUnmountResponse.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeUnmountResponse.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeUnmountResponse.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeUnmountResponse.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -8841,11 +12287,11 @@ proto.openstorage.api.VolumeUnmountResponse.prototype.serializeBinary = function
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeUnmountResponse} message
+ * @param {!proto.openstorage.api.SdkVolumeUnmountResponse} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeUnmountResponse.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeUnmountResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
 };
 
@@ -8861,12 +12307,12 @@ proto.openstorage.api.VolumeUnmountResponse.serializeBinaryToWriter = function(m
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeAttachRequest = function(opt_data) {
+proto.openstorage.api.SdkVolumeAttachRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeAttachRequest, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeAttachRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeAttachRequest.displayName = 'proto.openstorage.api.VolumeAttachRequest';
+  proto.openstorage.api.SdkVolumeAttachRequest.displayName = 'proto.openstorage.api.SdkVolumeAttachRequest';
 }
 
 
@@ -8881,8 +12327,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeAttachRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeAttachRequest.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeAttachRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeAttachRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -8891,11 +12337,11 @@ proto.openstorage.api.VolumeAttachRequest.prototype.toObject = function(opt_incl
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeAttachRequest} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeAttachRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeAttachRequest.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeAttachRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     volumeId: jspb.Message.getFieldWithDefault(msg, 1, ""),
     optionsMap: (f = msg.getOptionsMap()) ? f.toObject(includeInstance, undefined) : []
@@ -8912,23 +12358,23 @@ proto.openstorage.api.VolumeAttachRequest.toObject = function(includeInstance, m
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeAttachRequest}
+ * @return {!proto.openstorage.api.SdkVolumeAttachRequest}
  */
-proto.openstorage.api.VolumeAttachRequest.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeAttachRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeAttachRequest;
-  return proto.openstorage.api.VolumeAttachRequest.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeAttachRequest;
+  return proto.openstorage.api.SdkVolumeAttachRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeAttachRequest} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeAttachRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeAttachRequest}
+ * @return {!proto.openstorage.api.SdkVolumeAttachRequest}
  */
-proto.openstorage.api.VolumeAttachRequest.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeAttachRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -8958,9 +12404,9 @@ proto.openstorage.api.VolumeAttachRequest.deserializeBinaryFromReader = function
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeAttachRequest.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeAttachRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeAttachRequest.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeAttachRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -8968,11 +12414,11 @@ proto.openstorage.api.VolumeAttachRequest.prototype.serializeBinary = function()
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeAttachRequest} message
+ * @param {!proto.openstorage.api.SdkVolumeAttachRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeAttachRequest.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeAttachRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getVolumeId();
   if (f.length > 0) {
@@ -8992,13 +12438,13 @@ proto.openstorage.api.VolumeAttachRequest.serializeBinaryToWriter = function(mes
  * optional string volume_id = 1;
  * @return {string}
  */
-proto.openstorage.api.VolumeAttachRequest.prototype.getVolumeId = function() {
+proto.openstorage.api.SdkVolumeAttachRequest.prototype.getVolumeId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.VolumeAttachRequest.prototype.setVolumeId = function(value) {
+proto.openstorage.api.SdkVolumeAttachRequest.prototype.setVolumeId = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -9009,14 +12455,14 @@ proto.openstorage.api.VolumeAttachRequest.prototype.setVolumeId = function(value
  * empty, instead returning `undefined`
  * @return {!jspb.Map<string,string>}
  */
-proto.openstorage.api.VolumeAttachRequest.prototype.getOptionsMap = function(opt_noLazyCreate) {
+proto.openstorage.api.SdkVolumeAttachRequest.prototype.getOptionsMap = function(opt_noLazyCreate) {
   return /** @type {!jspb.Map<string,string>} */ (
       jspb.Message.getMapField(this, 2, opt_noLazyCreate,
       null));
 };
 
 
-proto.openstorage.api.VolumeAttachRequest.prototype.clearOptionsMap = function() {
+proto.openstorage.api.SdkVolumeAttachRequest.prototype.clearOptionsMap = function() {
   this.getOptionsMap().clear();
 };
 
@@ -9032,12 +12478,12 @@ proto.openstorage.api.VolumeAttachRequest.prototype.clearOptionsMap = function()
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeAttachResponse = function(opt_data) {
+proto.openstorage.api.SdkVolumeAttachResponse = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeAttachResponse, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeAttachResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeAttachResponse.displayName = 'proto.openstorage.api.VolumeAttachResponse';
+  proto.openstorage.api.SdkVolumeAttachResponse.displayName = 'proto.openstorage.api.SdkVolumeAttachResponse';
 }
 
 
@@ -9052,8 +12498,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeAttachResponse.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeAttachResponse.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeAttachResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeAttachResponse.toObject(opt_includeInstance, this);
 };
 
 
@@ -9062,11 +12508,11 @@ proto.openstorage.api.VolumeAttachResponse.prototype.toObject = function(opt_inc
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeAttachResponse} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeAttachResponse} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeAttachResponse.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeAttachResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
     devicePath: jspb.Message.getFieldWithDefault(msg, 1, "")
   };
@@ -9082,23 +12528,23 @@ proto.openstorage.api.VolumeAttachResponse.toObject = function(includeInstance, 
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeAttachResponse}
+ * @return {!proto.openstorage.api.SdkVolumeAttachResponse}
  */
-proto.openstorage.api.VolumeAttachResponse.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeAttachResponse.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeAttachResponse;
-  return proto.openstorage.api.VolumeAttachResponse.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeAttachResponse;
+  return proto.openstorage.api.SdkVolumeAttachResponse.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeAttachResponse} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeAttachResponse} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeAttachResponse}
+ * @return {!proto.openstorage.api.SdkVolumeAttachResponse}
  */
-proto.openstorage.api.VolumeAttachResponse.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeAttachResponse.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -9122,9 +12568,9 @@ proto.openstorage.api.VolumeAttachResponse.deserializeBinaryFromReader = functio
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeAttachResponse.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeAttachResponse.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeAttachResponse.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeAttachResponse.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -9132,11 +12578,11 @@ proto.openstorage.api.VolumeAttachResponse.prototype.serializeBinary = function(
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeAttachResponse} message
+ * @param {!proto.openstorage.api.SdkVolumeAttachResponse} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeAttachResponse.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeAttachResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getDevicePath();
   if (f.length > 0) {
@@ -9152,13 +12598,13 @@ proto.openstorage.api.VolumeAttachResponse.serializeBinaryToWriter = function(me
  * optional string device_path = 1;
  * @return {string}
  */
-proto.openstorage.api.VolumeAttachResponse.prototype.getDevicePath = function() {
+proto.openstorage.api.SdkVolumeAttachResponse.prototype.getDevicePath = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.VolumeAttachResponse.prototype.setDevicePath = function(value) {
+proto.openstorage.api.SdkVolumeAttachResponse.prototype.setDevicePath = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -9174,12 +12620,12 @@ proto.openstorage.api.VolumeAttachResponse.prototype.setDevicePath = function(va
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeDetachRequest = function(opt_data) {
+proto.openstorage.api.SdkVolumeDetachRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeDetachRequest, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeDetachRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeDetachRequest.displayName = 'proto.openstorage.api.VolumeDetachRequest';
+  proto.openstorage.api.SdkVolumeDetachRequest.displayName = 'proto.openstorage.api.SdkVolumeDetachRequest';
 }
 
 
@@ -9194,8 +12640,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeDetachRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeDetachRequest.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeDetachRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeDetachRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -9204,11 +12650,11 @@ proto.openstorage.api.VolumeDetachRequest.prototype.toObject = function(opt_incl
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeDetachRequest} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeDetachRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeDetachRequest.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeDetachRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     volumeId: jspb.Message.getFieldWithDefault(msg, 1, "")
   };
@@ -9224,23 +12670,23 @@ proto.openstorage.api.VolumeDetachRequest.toObject = function(includeInstance, m
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeDetachRequest}
+ * @return {!proto.openstorage.api.SdkVolumeDetachRequest}
  */
-proto.openstorage.api.VolumeDetachRequest.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeDetachRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeDetachRequest;
-  return proto.openstorage.api.VolumeDetachRequest.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeDetachRequest;
+  return proto.openstorage.api.SdkVolumeDetachRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeDetachRequest} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeDetachRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeDetachRequest}
+ * @return {!proto.openstorage.api.SdkVolumeDetachRequest}
  */
-proto.openstorage.api.VolumeDetachRequest.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeDetachRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -9264,9 +12710,9 @@ proto.openstorage.api.VolumeDetachRequest.deserializeBinaryFromReader = function
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeDetachRequest.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeDetachRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeDetachRequest.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeDetachRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -9274,11 +12720,11 @@ proto.openstorage.api.VolumeDetachRequest.prototype.serializeBinary = function()
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeDetachRequest} message
+ * @param {!proto.openstorage.api.SdkVolumeDetachRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeDetachRequest.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeDetachRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getVolumeId();
   if (f.length > 0) {
@@ -9294,13 +12740,13 @@ proto.openstorage.api.VolumeDetachRequest.serializeBinaryToWriter = function(mes
  * optional string volume_id = 1;
  * @return {string}
  */
-proto.openstorage.api.VolumeDetachRequest.prototype.getVolumeId = function() {
+proto.openstorage.api.SdkVolumeDetachRequest.prototype.getVolumeId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.VolumeDetachRequest.prototype.setVolumeId = function(value) {
+proto.openstorage.api.SdkVolumeDetachRequest.prototype.setVolumeId = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -9316,12 +12762,12 @@ proto.openstorage.api.VolumeDetachRequest.prototype.setVolumeId = function(value
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeDetachResponse = function(opt_data) {
+proto.openstorage.api.SdkVolumeDetachResponse = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeDetachResponse, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeDetachResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeDetachResponse.displayName = 'proto.openstorage.api.VolumeDetachResponse';
+  proto.openstorage.api.SdkVolumeDetachResponse.displayName = 'proto.openstorage.api.SdkVolumeDetachResponse';
 }
 
 
@@ -9336,8 +12782,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeDetachResponse.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeDetachResponse.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeDetachResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeDetachResponse.toObject(opt_includeInstance, this);
 };
 
 
@@ -9346,11 +12792,11 @@ proto.openstorage.api.VolumeDetachResponse.prototype.toObject = function(opt_inc
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeDetachResponse} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeDetachResponse} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeDetachResponse.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeDetachResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
 
   };
@@ -9366,23 +12812,23 @@ proto.openstorage.api.VolumeDetachResponse.toObject = function(includeInstance, 
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeDetachResponse}
+ * @return {!proto.openstorage.api.SdkVolumeDetachResponse}
  */
-proto.openstorage.api.VolumeDetachResponse.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeDetachResponse.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeDetachResponse;
-  return proto.openstorage.api.VolumeDetachResponse.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeDetachResponse;
+  return proto.openstorage.api.SdkVolumeDetachResponse.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeDetachResponse} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeDetachResponse} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeDetachResponse}
+ * @return {!proto.openstorage.api.SdkVolumeDetachResponse}
  */
-proto.openstorage.api.VolumeDetachResponse.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeDetachResponse.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -9402,9 +12848,9 @@ proto.openstorage.api.VolumeDetachResponse.deserializeBinaryFromReader = functio
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeDetachResponse.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeDetachResponse.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeDetachResponse.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeDetachResponse.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -9412,11 +12858,11 @@ proto.openstorage.api.VolumeDetachResponse.prototype.serializeBinary = function(
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeDetachResponse} message
+ * @param {!proto.openstorage.api.SdkVolumeDetachResponse} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeDetachResponse.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeDetachResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
 };
 
@@ -9432,12 +12878,12 @@ proto.openstorage.api.VolumeDetachResponse.serializeBinaryToWriter = function(me
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.OpenStorageVolumeCreateRequest = function(opt_data) {
+proto.openstorage.api.SdkVolumeCreateRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.OpenStorageVolumeCreateRequest, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeCreateRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.OpenStorageVolumeCreateRequest.displayName = 'proto.openstorage.api.OpenStorageVolumeCreateRequest';
+  proto.openstorage.api.SdkVolumeCreateRequest.displayName = 'proto.openstorage.api.SdkVolumeCreateRequest';
 }
 
 
@@ -9452,8 +12898,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.OpenStorageVolumeCreateRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.OpenStorageVolumeCreateRequest.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeCreateRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeCreateRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -9462,11 +12908,11 @@ proto.openstorage.api.OpenStorageVolumeCreateRequest.prototype.toObject = functi
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.OpenStorageVolumeCreateRequest} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeCreateRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.OpenStorageVolumeCreateRequest.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeCreateRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     name: jspb.Message.getFieldWithDefault(msg, 1, ""),
     spec: (f = msg.getSpec()) && proto.openstorage.api.VolumeSpec.toObject(includeInstance, f)
@@ -9483,23 +12929,23 @@ proto.openstorage.api.OpenStorageVolumeCreateRequest.toObject = function(include
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.OpenStorageVolumeCreateRequest}
+ * @return {!proto.openstorage.api.SdkVolumeCreateRequest}
  */
-proto.openstorage.api.OpenStorageVolumeCreateRequest.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeCreateRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.OpenStorageVolumeCreateRequest;
-  return proto.openstorage.api.OpenStorageVolumeCreateRequest.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeCreateRequest;
+  return proto.openstorage.api.SdkVolumeCreateRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.OpenStorageVolumeCreateRequest} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeCreateRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.OpenStorageVolumeCreateRequest}
+ * @return {!proto.openstorage.api.SdkVolumeCreateRequest}
  */
-proto.openstorage.api.OpenStorageVolumeCreateRequest.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeCreateRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -9528,9 +12974,9 @@ proto.openstorage.api.OpenStorageVolumeCreateRequest.deserializeBinaryFromReader
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.OpenStorageVolumeCreateRequest.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeCreateRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.OpenStorageVolumeCreateRequest.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeCreateRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -9538,11 +12984,11 @@ proto.openstorage.api.OpenStorageVolumeCreateRequest.prototype.serializeBinary =
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.OpenStorageVolumeCreateRequest} message
+ * @param {!proto.openstorage.api.SdkVolumeCreateRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.OpenStorageVolumeCreateRequest.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeCreateRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getName();
   if (f.length > 0) {
@@ -9566,13 +13012,13 @@ proto.openstorage.api.OpenStorageVolumeCreateRequest.serializeBinaryToWriter = f
  * optional string name = 1;
  * @return {string}
  */
-proto.openstorage.api.OpenStorageVolumeCreateRequest.prototype.getName = function() {
+proto.openstorage.api.SdkVolumeCreateRequest.prototype.getName = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.OpenStorageVolumeCreateRequest.prototype.setName = function(value) {
+proto.openstorage.api.SdkVolumeCreateRequest.prototype.setName = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -9581,19 +13027,19 @@ proto.openstorage.api.OpenStorageVolumeCreateRequest.prototype.setName = functio
  * optional VolumeSpec spec = 2;
  * @return {?proto.openstorage.api.VolumeSpec}
  */
-proto.openstorage.api.OpenStorageVolumeCreateRequest.prototype.getSpec = function() {
+proto.openstorage.api.SdkVolumeCreateRequest.prototype.getSpec = function() {
   return /** @type{?proto.openstorage.api.VolumeSpec} */ (
     jspb.Message.getWrapperField(this, proto.openstorage.api.VolumeSpec, 2));
 };
 
 
 /** @param {?proto.openstorage.api.VolumeSpec|undefined} value */
-proto.openstorage.api.OpenStorageVolumeCreateRequest.prototype.setSpec = function(value) {
+proto.openstorage.api.SdkVolumeCreateRequest.prototype.setSpec = function(value) {
   jspb.Message.setWrapperField(this, 2, value);
 };
 
 
-proto.openstorage.api.OpenStorageVolumeCreateRequest.prototype.clearSpec = function() {
+proto.openstorage.api.SdkVolumeCreateRequest.prototype.clearSpec = function() {
   this.setSpec(undefined);
 };
 
@@ -9602,7 +13048,7 @@ proto.openstorage.api.OpenStorageVolumeCreateRequest.prototype.clearSpec = funct
  * Returns whether this field is set.
  * @return {!boolean}
  */
-proto.openstorage.api.OpenStorageVolumeCreateRequest.prototype.hasSpec = function() {
+proto.openstorage.api.SdkVolumeCreateRequest.prototype.hasSpec = function() {
   return jspb.Message.getField(this, 2) != null;
 };
 
@@ -9618,12 +13064,12 @@ proto.openstorage.api.OpenStorageVolumeCreateRequest.prototype.hasSpec = functio
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.OpenStorageVolumeCreateResponse = function(opt_data) {
+proto.openstorage.api.SdkVolumeCreateResponse = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.OpenStorageVolumeCreateResponse, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeCreateResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.OpenStorageVolumeCreateResponse.displayName = 'proto.openstorage.api.OpenStorageVolumeCreateResponse';
+  proto.openstorage.api.SdkVolumeCreateResponse.displayName = 'proto.openstorage.api.SdkVolumeCreateResponse';
 }
 
 
@@ -9638,8 +13084,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.OpenStorageVolumeCreateResponse.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.OpenStorageVolumeCreateResponse.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeCreateResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeCreateResponse.toObject(opt_includeInstance, this);
 };
 
 
@@ -9648,11 +13094,11 @@ proto.openstorage.api.OpenStorageVolumeCreateResponse.prototype.toObject = funct
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.OpenStorageVolumeCreateResponse} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeCreateResponse} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.OpenStorageVolumeCreateResponse.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeCreateResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
     volumeId: jspb.Message.getFieldWithDefault(msg, 1, "")
   };
@@ -9668,23 +13114,23 @@ proto.openstorage.api.OpenStorageVolumeCreateResponse.toObject = function(includ
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.OpenStorageVolumeCreateResponse}
+ * @return {!proto.openstorage.api.SdkVolumeCreateResponse}
  */
-proto.openstorage.api.OpenStorageVolumeCreateResponse.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeCreateResponse.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.OpenStorageVolumeCreateResponse;
-  return proto.openstorage.api.OpenStorageVolumeCreateResponse.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeCreateResponse;
+  return proto.openstorage.api.SdkVolumeCreateResponse.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.OpenStorageVolumeCreateResponse} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeCreateResponse} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.OpenStorageVolumeCreateResponse}
+ * @return {!proto.openstorage.api.SdkVolumeCreateResponse}
  */
-proto.openstorage.api.OpenStorageVolumeCreateResponse.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeCreateResponse.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -9708,9 +13154,9 @@ proto.openstorage.api.OpenStorageVolumeCreateResponse.deserializeBinaryFromReade
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.OpenStorageVolumeCreateResponse.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeCreateResponse.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.OpenStorageVolumeCreateResponse.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeCreateResponse.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -9718,11 +13164,11 @@ proto.openstorage.api.OpenStorageVolumeCreateResponse.prototype.serializeBinary 
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.OpenStorageVolumeCreateResponse} message
+ * @param {!proto.openstorage.api.SdkVolumeCreateResponse} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.OpenStorageVolumeCreateResponse.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeCreateResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getVolumeId();
   if (f.length > 0) {
@@ -9738,13 +13184,13 @@ proto.openstorage.api.OpenStorageVolumeCreateResponse.serializeBinaryToWriter = 
  * optional string volume_id = 1;
  * @return {string}
  */
-proto.openstorage.api.OpenStorageVolumeCreateResponse.prototype.getVolumeId = function() {
+proto.openstorage.api.SdkVolumeCreateResponse.prototype.getVolumeId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.OpenStorageVolumeCreateResponse.prototype.setVolumeId = function(value) {
+proto.openstorage.api.SdkVolumeCreateResponse.prototype.setVolumeId = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -9760,12 +13206,12 @@ proto.openstorage.api.OpenStorageVolumeCreateResponse.prototype.setVolumeId = fu
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeCreateFromVolumeIDRequest = function(opt_data) {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeCreateFromVolumeIDRequest, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeCreateFromVolumeIDRequest.displayName = 'proto.openstorage.api.VolumeCreateFromVolumeIDRequest';
+  proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest.displayName = 'proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest';
 }
 
 
@@ -9780,8 +13226,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeCreateFromVolumeIDRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeCreateFromVolumeIDRequest.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -9790,11 +13236,11 @@ proto.openstorage.api.VolumeCreateFromVolumeIDRequest.prototype.toObject = funct
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeCreateFromVolumeIDRequest} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeCreateFromVolumeIDRequest.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     name: jspb.Message.getFieldWithDefault(msg, 1, ""),
     parentId: jspb.Message.getFieldWithDefault(msg, 2, ""),
@@ -9812,23 +13258,23 @@ proto.openstorage.api.VolumeCreateFromVolumeIDRequest.toObject = function(includ
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeCreateFromVolumeIDRequest}
+ * @return {!proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest}
  */
-proto.openstorage.api.VolumeCreateFromVolumeIDRequest.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeCreateFromVolumeIDRequest;
-  return proto.openstorage.api.VolumeCreateFromVolumeIDRequest.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest;
+  return proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeCreateFromVolumeIDRequest} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeCreateFromVolumeIDRequest}
+ * @return {!proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest}
  */
-proto.openstorage.api.VolumeCreateFromVolumeIDRequest.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -9861,9 +13307,9 @@ proto.openstorage.api.VolumeCreateFromVolumeIDRequest.deserializeBinaryFromReade
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeCreateFromVolumeIDRequest.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeCreateFromVolumeIDRequest.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -9871,11 +13317,11 @@ proto.openstorage.api.VolumeCreateFromVolumeIDRequest.prototype.serializeBinary 
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeCreateFromVolumeIDRequest} message
+ * @param {!proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeCreateFromVolumeIDRequest.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getName();
   if (f.length > 0) {
@@ -9906,13 +13352,13 @@ proto.openstorage.api.VolumeCreateFromVolumeIDRequest.serializeBinaryToWriter = 
  * optional string name = 1;
  * @return {string}
  */
-proto.openstorage.api.VolumeCreateFromVolumeIDRequest.prototype.getName = function() {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest.prototype.getName = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.VolumeCreateFromVolumeIDRequest.prototype.setName = function(value) {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest.prototype.setName = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -9921,13 +13367,13 @@ proto.openstorage.api.VolumeCreateFromVolumeIDRequest.prototype.setName = functi
  * optional string parent_id = 2;
  * @return {string}
  */
-proto.openstorage.api.VolumeCreateFromVolumeIDRequest.prototype.getParentId = function() {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest.prototype.getParentId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.VolumeCreateFromVolumeIDRequest.prototype.setParentId = function(value) {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest.prototype.setParentId = function(value) {
   jspb.Message.setField(this, 2, value);
 };
 
@@ -9936,19 +13382,19 @@ proto.openstorage.api.VolumeCreateFromVolumeIDRequest.prototype.setParentId = fu
  * optional VolumeSpec spec = 3;
  * @return {?proto.openstorage.api.VolumeSpec}
  */
-proto.openstorage.api.VolumeCreateFromVolumeIDRequest.prototype.getSpec = function() {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest.prototype.getSpec = function() {
   return /** @type{?proto.openstorage.api.VolumeSpec} */ (
     jspb.Message.getWrapperField(this, proto.openstorage.api.VolumeSpec, 3));
 };
 
 
 /** @param {?proto.openstorage.api.VolumeSpec|undefined} value */
-proto.openstorage.api.VolumeCreateFromVolumeIDRequest.prototype.setSpec = function(value) {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest.prototype.setSpec = function(value) {
   jspb.Message.setWrapperField(this, 3, value);
 };
 
 
-proto.openstorage.api.VolumeCreateFromVolumeIDRequest.prototype.clearSpec = function() {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest.prototype.clearSpec = function() {
   this.setSpec(undefined);
 };
 
@@ -9957,7 +13403,7 @@ proto.openstorage.api.VolumeCreateFromVolumeIDRequest.prototype.clearSpec = func
  * Returns whether this field is set.
  * @return {!boolean}
  */
-proto.openstorage.api.VolumeCreateFromVolumeIDRequest.prototype.hasSpec = function() {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdRequest.prototype.hasSpec = function() {
   return jspb.Message.getField(this, 3) != null;
 };
 
@@ -9973,12 +13419,12 @@ proto.openstorage.api.VolumeCreateFromVolumeIDRequest.prototype.hasSpec = functi
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeCreateFromVolumeIDResponse = function(opt_data) {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeCreateFromVolumeIDResponse, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeCreateFromVolumeIDResponse.displayName = 'proto.openstorage.api.VolumeCreateFromVolumeIDResponse';
+  proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse.displayName = 'proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse';
 }
 
 
@@ -9993,8 +13439,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeCreateFromVolumeIDResponse.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeCreateFromVolumeIDResponse.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse.toObject(opt_includeInstance, this);
 };
 
 
@@ -10003,11 +13449,11 @@ proto.openstorage.api.VolumeCreateFromVolumeIDResponse.prototype.toObject = func
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeCreateFromVolumeIDResponse} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeCreateFromVolumeIDResponse.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
     volumeId: jspb.Message.getFieldWithDefault(msg, 1, "")
   };
@@ -10023,23 +13469,23 @@ proto.openstorage.api.VolumeCreateFromVolumeIDResponse.toObject = function(inclu
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeCreateFromVolumeIDResponse}
+ * @return {!proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse}
  */
-proto.openstorage.api.VolumeCreateFromVolumeIDResponse.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeCreateFromVolumeIDResponse;
-  return proto.openstorage.api.VolumeCreateFromVolumeIDResponse.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse;
+  return proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeCreateFromVolumeIDResponse} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeCreateFromVolumeIDResponse}
+ * @return {!proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse}
  */
-proto.openstorage.api.VolumeCreateFromVolumeIDResponse.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -10063,9 +13509,9 @@ proto.openstorage.api.VolumeCreateFromVolumeIDResponse.deserializeBinaryFromRead
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeCreateFromVolumeIDResponse.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeCreateFromVolumeIDResponse.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -10073,11 +13519,11 @@ proto.openstorage.api.VolumeCreateFromVolumeIDResponse.prototype.serializeBinary
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeCreateFromVolumeIDResponse} message
+ * @param {!proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeCreateFromVolumeIDResponse.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getVolumeId();
   if (f.length > 0) {
@@ -10093,13 +13539,13 @@ proto.openstorage.api.VolumeCreateFromVolumeIDResponse.serializeBinaryToWriter =
  * optional string volume_id = 1;
  * @return {string}
  */
-proto.openstorage.api.VolumeCreateFromVolumeIDResponse.prototype.getVolumeId = function() {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse.prototype.getVolumeId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.VolumeCreateFromVolumeIDResponse.prototype.setVolumeId = function(value) {
+proto.openstorage.api.SdkVolumeCreateFromVolumeIdResponse.prototype.setVolumeId = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -10115,12 +13561,12 @@ proto.openstorage.api.VolumeCreateFromVolumeIDResponse.prototype.setVolumeId = f
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeDeleteRequest = function(opt_data) {
+proto.openstorage.api.SdkVolumeDeleteRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeDeleteRequest, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeDeleteRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeDeleteRequest.displayName = 'proto.openstorage.api.VolumeDeleteRequest';
+  proto.openstorage.api.SdkVolumeDeleteRequest.displayName = 'proto.openstorage.api.SdkVolumeDeleteRequest';
 }
 
 
@@ -10135,8 +13581,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeDeleteRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeDeleteRequest.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeDeleteRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeDeleteRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -10145,11 +13591,11 @@ proto.openstorage.api.VolumeDeleteRequest.prototype.toObject = function(opt_incl
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeDeleteRequest} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeDeleteRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeDeleteRequest.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeDeleteRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     volumeId: jspb.Message.getFieldWithDefault(msg, 1, "")
   };
@@ -10165,23 +13611,23 @@ proto.openstorage.api.VolumeDeleteRequest.toObject = function(includeInstance, m
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeDeleteRequest}
+ * @return {!proto.openstorage.api.SdkVolumeDeleteRequest}
  */
-proto.openstorage.api.VolumeDeleteRequest.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeDeleteRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeDeleteRequest;
-  return proto.openstorage.api.VolumeDeleteRequest.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeDeleteRequest;
+  return proto.openstorage.api.SdkVolumeDeleteRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeDeleteRequest} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeDeleteRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeDeleteRequest}
+ * @return {!proto.openstorage.api.SdkVolumeDeleteRequest}
  */
-proto.openstorage.api.VolumeDeleteRequest.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeDeleteRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -10205,9 +13651,9 @@ proto.openstorage.api.VolumeDeleteRequest.deserializeBinaryFromReader = function
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeDeleteRequest.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeDeleteRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeDeleteRequest.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeDeleteRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -10215,11 +13661,11 @@ proto.openstorage.api.VolumeDeleteRequest.prototype.serializeBinary = function()
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeDeleteRequest} message
+ * @param {!proto.openstorage.api.SdkVolumeDeleteRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeDeleteRequest.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeDeleteRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getVolumeId();
   if (f.length > 0) {
@@ -10235,13 +13681,13 @@ proto.openstorage.api.VolumeDeleteRequest.serializeBinaryToWriter = function(mes
  * optional string volume_id = 1;
  * @return {string}
  */
-proto.openstorage.api.VolumeDeleteRequest.prototype.getVolumeId = function() {
+proto.openstorage.api.SdkVolumeDeleteRequest.prototype.getVolumeId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.VolumeDeleteRequest.prototype.setVolumeId = function(value) {
+proto.openstorage.api.SdkVolumeDeleteRequest.prototype.setVolumeId = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -10257,12 +13703,12 @@ proto.openstorage.api.VolumeDeleteRequest.prototype.setVolumeId = function(value
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeDeleteResponse = function(opt_data) {
+proto.openstorage.api.SdkVolumeDeleteResponse = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeDeleteResponse, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeDeleteResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeDeleteResponse.displayName = 'proto.openstorage.api.VolumeDeleteResponse';
+  proto.openstorage.api.SdkVolumeDeleteResponse.displayName = 'proto.openstorage.api.SdkVolumeDeleteResponse';
 }
 
 
@@ -10277,8 +13723,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeDeleteResponse.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeDeleteResponse.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeDeleteResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeDeleteResponse.toObject(opt_includeInstance, this);
 };
 
 
@@ -10287,11 +13733,11 @@ proto.openstorage.api.VolumeDeleteResponse.prototype.toObject = function(opt_inc
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeDeleteResponse} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeDeleteResponse} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeDeleteResponse.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeDeleteResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
 
   };
@@ -10307,23 +13753,23 @@ proto.openstorage.api.VolumeDeleteResponse.toObject = function(includeInstance, 
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeDeleteResponse}
+ * @return {!proto.openstorage.api.SdkVolumeDeleteResponse}
  */
-proto.openstorage.api.VolumeDeleteResponse.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeDeleteResponse.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeDeleteResponse;
-  return proto.openstorage.api.VolumeDeleteResponse.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeDeleteResponse;
+  return proto.openstorage.api.SdkVolumeDeleteResponse.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeDeleteResponse} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeDeleteResponse} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeDeleteResponse}
+ * @return {!proto.openstorage.api.SdkVolumeDeleteResponse}
  */
-proto.openstorage.api.VolumeDeleteResponse.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeDeleteResponse.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -10343,9 +13789,9 @@ proto.openstorage.api.VolumeDeleteResponse.deserializeBinaryFromReader = functio
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeDeleteResponse.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeDeleteResponse.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeDeleteResponse.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeDeleteResponse.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -10353,11 +13799,11 @@ proto.openstorage.api.VolumeDeleteResponse.prototype.serializeBinary = function(
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeDeleteResponse} message
+ * @param {!proto.openstorage.api.SdkVolumeDeleteResponse} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeDeleteResponse.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeDeleteResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
 };
 
@@ -10373,12 +13819,12 @@ proto.openstorage.api.VolumeDeleteResponse.serializeBinaryToWriter = function(me
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeInspectRequest = function(opt_data) {
+proto.openstorage.api.SdkVolumeInspectRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeInspectRequest, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeInspectRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeInspectRequest.displayName = 'proto.openstorage.api.VolumeInspectRequest';
+  proto.openstorage.api.SdkVolumeInspectRequest.displayName = 'proto.openstorage.api.SdkVolumeInspectRequest';
 }
 
 
@@ -10393,8 +13839,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeInspectRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeInspectRequest.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeInspectRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeInspectRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -10403,11 +13849,11 @@ proto.openstorage.api.VolumeInspectRequest.prototype.toObject = function(opt_inc
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeInspectRequest} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeInspectRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeInspectRequest.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeInspectRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     volumeId: jspb.Message.getFieldWithDefault(msg, 1, "")
   };
@@ -10423,23 +13869,23 @@ proto.openstorage.api.VolumeInspectRequest.toObject = function(includeInstance, 
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeInspectRequest}
+ * @return {!proto.openstorage.api.SdkVolumeInspectRequest}
  */
-proto.openstorage.api.VolumeInspectRequest.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeInspectRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeInspectRequest;
-  return proto.openstorage.api.VolumeInspectRequest.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeInspectRequest;
+  return proto.openstorage.api.SdkVolumeInspectRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeInspectRequest} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeInspectRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeInspectRequest}
+ * @return {!proto.openstorage.api.SdkVolumeInspectRequest}
  */
-proto.openstorage.api.VolumeInspectRequest.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeInspectRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -10463,9 +13909,9 @@ proto.openstorage.api.VolumeInspectRequest.deserializeBinaryFromReader = functio
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeInspectRequest.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeInspectRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeInspectRequest.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeInspectRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -10473,11 +13919,11 @@ proto.openstorage.api.VolumeInspectRequest.prototype.serializeBinary = function(
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeInspectRequest} message
+ * @param {!proto.openstorage.api.SdkVolumeInspectRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeInspectRequest.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeInspectRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getVolumeId();
   if (f.length > 0) {
@@ -10493,13 +13939,13 @@ proto.openstorage.api.VolumeInspectRequest.serializeBinaryToWriter = function(me
  * optional string volume_id = 1;
  * @return {string}
  */
-proto.openstorage.api.VolumeInspectRequest.prototype.getVolumeId = function() {
+proto.openstorage.api.SdkVolumeInspectRequest.prototype.getVolumeId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.VolumeInspectRequest.prototype.setVolumeId = function(value) {
+proto.openstorage.api.SdkVolumeInspectRequest.prototype.setVolumeId = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -10515,12 +13961,12 @@ proto.openstorage.api.VolumeInspectRequest.prototype.setVolumeId = function(valu
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeInspectResponse = function(opt_data) {
+proto.openstorage.api.SdkVolumeInspectResponse = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeInspectResponse, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeInspectResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeInspectResponse.displayName = 'proto.openstorage.api.VolumeInspectResponse';
+  proto.openstorage.api.SdkVolumeInspectResponse.displayName = 'proto.openstorage.api.SdkVolumeInspectResponse';
 }
 
 
@@ -10535,8 +13981,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeInspectResponse.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeInspectResponse.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeInspectResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeInspectResponse.toObject(opt_includeInstance, this);
 };
 
 
@@ -10545,11 +13991,11 @@ proto.openstorage.api.VolumeInspectResponse.prototype.toObject = function(opt_in
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeInspectResponse} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeInspectResponse} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeInspectResponse.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeInspectResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
     volume: (f = msg.getVolume()) && proto.openstorage.api.Volume.toObject(includeInstance, f)
   };
@@ -10565,23 +14011,23 @@ proto.openstorage.api.VolumeInspectResponse.toObject = function(includeInstance,
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeInspectResponse}
+ * @return {!proto.openstorage.api.SdkVolumeInspectResponse}
  */
-proto.openstorage.api.VolumeInspectResponse.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeInspectResponse.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeInspectResponse;
-  return proto.openstorage.api.VolumeInspectResponse.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeInspectResponse;
+  return proto.openstorage.api.SdkVolumeInspectResponse.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeInspectResponse} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeInspectResponse} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeInspectResponse}
+ * @return {!proto.openstorage.api.SdkVolumeInspectResponse}
  */
-proto.openstorage.api.VolumeInspectResponse.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeInspectResponse.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -10606,9 +14052,9 @@ proto.openstorage.api.VolumeInspectResponse.deserializeBinaryFromReader = functi
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeInspectResponse.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeInspectResponse.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeInspectResponse.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeInspectResponse.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -10616,11 +14062,11 @@ proto.openstorage.api.VolumeInspectResponse.prototype.serializeBinary = function
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeInspectResponse} message
+ * @param {!proto.openstorage.api.SdkVolumeInspectResponse} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeInspectResponse.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeInspectResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getVolume();
   if (f != null) {
@@ -10637,19 +14083,19 @@ proto.openstorage.api.VolumeInspectResponse.serializeBinaryToWriter = function(m
  * optional Volume volume = 1;
  * @return {?proto.openstorage.api.Volume}
  */
-proto.openstorage.api.VolumeInspectResponse.prototype.getVolume = function() {
+proto.openstorage.api.SdkVolumeInspectResponse.prototype.getVolume = function() {
   return /** @type{?proto.openstorage.api.Volume} */ (
     jspb.Message.getWrapperField(this, proto.openstorage.api.Volume, 1));
 };
 
 
 /** @param {?proto.openstorage.api.Volume|undefined} value */
-proto.openstorage.api.VolumeInspectResponse.prototype.setVolume = function(value) {
+proto.openstorage.api.SdkVolumeInspectResponse.prototype.setVolume = function(value) {
   jspb.Message.setWrapperField(this, 1, value);
 };
 
 
-proto.openstorage.api.VolumeInspectResponse.prototype.clearVolume = function() {
+proto.openstorage.api.SdkVolumeInspectResponse.prototype.clearVolume = function() {
   this.setVolume(undefined);
 };
 
@@ -10658,7 +14104,7 @@ proto.openstorage.api.VolumeInspectResponse.prototype.clearVolume = function() {
  * Returns whether this field is set.
  * @return {!boolean}
  */
-proto.openstorage.api.VolumeInspectResponse.prototype.hasVolume = function() {
+proto.openstorage.api.SdkVolumeInspectResponse.prototype.hasVolume = function() {
   return jspb.Message.getField(this, 1) != null;
 };
 
@@ -10674,12 +14120,12 @@ proto.openstorage.api.VolumeInspectResponse.prototype.hasVolume = function() {
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeEnumerateRequest = function(opt_data) {
+proto.openstorage.api.SdkVolumeEnumerateRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeEnumerateRequest, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeEnumerateRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeEnumerateRequest.displayName = 'proto.openstorage.api.VolumeEnumerateRequest';
+  proto.openstorage.api.SdkVolumeEnumerateRequest.displayName = 'proto.openstorage.api.SdkVolumeEnumerateRequest';
 }
 
 
@@ -10694,8 +14140,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeEnumerateRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeEnumerateRequest.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeEnumerateRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeEnumerateRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -10704,11 +14150,11 @@ proto.openstorage.api.VolumeEnumerateRequest.prototype.toObject = function(opt_i
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeEnumerateRequest} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeEnumerateRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeEnumerateRequest.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeEnumerateRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     locator: (f = msg.getLocator()) && proto.openstorage.api.VolumeLocator.toObject(includeInstance, f)
   };
@@ -10724,23 +14170,23 @@ proto.openstorage.api.VolumeEnumerateRequest.toObject = function(includeInstance
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeEnumerateRequest}
+ * @return {!proto.openstorage.api.SdkVolumeEnumerateRequest}
  */
-proto.openstorage.api.VolumeEnumerateRequest.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeEnumerateRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeEnumerateRequest;
-  return proto.openstorage.api.VolumeEnumerateRequest.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeEnumerateRequest;
+  return proto.openstorage.api.SdkVolumeEnumerateRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeEnumerateRequest} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeEnumerateRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeEnumerateRequest}
+ * @return {!proto.openstorage.api.SdkVolumeEnumerateRequest}
  */
-proto.openstorage.api.VolumeEnumerateRequest.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeEnumerateRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -10765,9 +14211,9 @@ proto.openstorage.api.VolumeEnumerateRequest.deserializeBinaryFromReader = funct
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeEnumerateRequest.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeEnumerateRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeEnumerateRequest.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeEnumerateRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -10775,11 +14221,11 @@ proto.openstorage.api.VolumeEnumerateRequest.prototype.serializeBinary = functio
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeEnumerateRequest} message
+ * @param {!proto.openstorage.api.SdkVolumeEnumerateRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeEnumerateRequest.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeEnumerateRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getLocator();
   if (f != null) {
@@ -10796,19 +14242,19 @@ proto.openstorage.api.VolumeEnumerateRequest.serializeBinaryToWriter = function(
  * optional VolumeLocator locator = 1;
  * @return {?proto.openstorage.api.VolumeLocator}
  */
-proto.openstorage.api.VolumeEnumerateRequest.prototype.getLocator = function() {
+proto.openstorage.api.SdkVolumeEnumerateRequest.prototype.getLocator = function() {
   return /** @type{?proto.openstorage.api.VolumeLocator} */ (
     jspb.Message.getWrapperField(this, proto.openstorage.api.VolumeLocator, 1));
 };
 
 
 /** @param {?proto.openstorage.api.VolumeLocator|undefined} value */
-proto.openstorage.api.VolumeEnumerateRequest.prototype.setLocator = function(value) {
+proto.openstorage.api.SdkVolumeEnumerateRequest.prototype.setLocator = function(value) {
   jspb.Message.setWrapperField(this, 1, value);
 };
 
 
-proto.openstorage.api.VolumeEnumerateRequest.prototype.clearLocator = function() {
+proto.openstorage.api.SdkVolumeEnumerateRequest.prototype.clearLocator = function() {
   this.setLocator(undefined);
 };
 
@@ -10817,7 +14263,7 @@ proto.openstorage.api.VolumeEnumerateRequest.prototype.clearLocator = function()
  * Returns whether this field is set.
  * @return {!boolean}
  */
-proto.openstorage.api.VolumeEnumerateRequest.prototype.hasLocator = function() {
+proto.openstorage.api.SdkVolumeEnumerateRequest.prototype.hasLocator = function() {
   return jspb.Message.getField(this, 1) != null;
 };
 
@@ -10833,19 +14279,19 @@ proto.openstorage.api.VolumeEnumerateRequest.prototype.hasLocator = function() {
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeEnumerateResponse = function(opt_data) {
-  jspb.Message.initialize(this, opt_data, 0, -1, proto.openstorage.api.VolumeEnumerateResponse.repeatedFields_, null);
+proto.openstorage.api.SdkVolumeEnumerateResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.openstorage.api.SdkVolumeEnumerateResponse.repeatedFields_, null);
 };
-goog.inherits(proto.openstorage.api.VolumeEnumerateResponse, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeEnumerateResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeEnumerateResponse.displayName = 'proto.openstorage.api.VolumeEnumerateResponse';
+  proto.openstorage.api.SdkVolumeEnumerateResponse.displayName = 'proto.openstorage.api.SdkVolumeEnumerateResponse';
 }
 /**
  * List of repeated fields within this message type.
  * @private {!Array<number>}
  * @const
  */
-proto.openstorage.api.VolumeEnumerateResponse.repeatedFields_ = [1];
+proto.openstorage.api.SdkVolumeEnumerateResponse.repeatedFields_ = [1];
 
 
 
@@ -10860,8 +14306,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeEnumerateResponse.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeEnumerateResponse.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeEnumerateResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeEnumerateResponse.toObject(opt_includeInstance, this);
 };
 
 
@@ -10870,11 +14316,11 @@ proto.openstorage.api.VolumeEnumerateResponse.prototype.toObject = function(opt_
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeEnumerateResponse} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeEnumerateResponse} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeEnumerateResponse.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeEnumerateResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
     volumesList: jspb.Message.toObjectList(msg.getVolumesList(),
     proto.openstorage.api.Volume.toObject, includeInstance)
@@ -10891,23 +14337,23 @@ proto.openstorage.api.VolumeEnumerateResponse.toObject = function(includeInstanc
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeEnumerateResponse}
+ * @return {!proto.openstorage.api.SdkVolumeEnumerateResponse}
  */
-proto.openstorage.api.VolumeEnumerateResponse.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeEnumerateResponse.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeEnumerateResponse;
-  return proto.openstorage.api.VolumeEnumerateResponse.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeEnumerateResponse;
+  return proto.openstorage.api.SdkVolumeEnumerateResponse.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeEnumerateResponse} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeEnumerateResponse} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeEnumerateResponse}
+ * @return {!proto.openstorage.api.SdkVolumeEnumerateResponse}
  */
-proto.openstorage.api.VolumeEnumerateResponse.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeEnumerateResponse.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -10932,9 +14378,9 @@ proto.openstorage.api.VolumeEnumerateResponse.deserializeBinaryFromReader = func
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeEnumerateResponse.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeEnumerateResponse.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeEnumerateResponse.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeEnumerateResponse.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -10942,11 +14388,11 @@ proto.openstorage.api.VolumeEnumerateResponse.prototype.serializeBinary = functi
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeEnumerateResponse} message
+ * @param {!proto.openstorage.api.SdkVolumeEnumerateResponse} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeEnumerateResponse.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeEnumerateResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getVolumesList();
   if (f.length > 0) {
@@ -10963,14 +14409,14 @@ proto.openstorage.api.VolumeEnumerateResponse.serializeBinaryToWriter = function
  * repeated Volume volumes = 1;
  * @return {!Array.<!proto.openstorage.api.Volume>}
  */
-proto.openstorage.api.VolumeEnumerateResponse.prototype.getVolumesList = function() {
+proto.openstorage.api.SdkVolumeEnumerateResponse.prototype.getVolumesList = function() {
   return /** @type{!Array.<!proto.openstorage.api.Volume>} */ (
     jspb.Message.getRepeatedWrapperField(this, proto.openstorage.api.Volume, 1));
 };
 
 
 /** @param {!Array.<!proto.openstorage.api.Volume>} value */
-proto.openstorage.api.VolumeEnumerateResponse.prototype.setVolumesList = function(value) {
+proto.openstorage.api.SdkVolumeEnumerateResponse.prototype.setVolumesList = function(value) {
   jspb.Message.setRepeatedWrapperField(this, 1, value);
 };
 
@@ -10980,12 +14426,12 @@ proto.openstorage.api.VolumeEnumerateResponse.prototype.setVolumesList = functio
  * @param {number=} opt_index
  * @return {!proto.openstorage.api.Volume}
  */
-proto.openstorage.api.VolumeEnumerateResponse.prototype.addVolumes = function(opt_value, opt_index) {
+proto.openstorage.api.SdkVolumeEnumerateResponse.prototype.addVolumes = function(opt_value, opt_index) {
   return jspb.Message.addToRepeatedWrapperField(this, 1, opt_value, proto.openstorage.api.Volume, opt_index);
 };
 
 
-proto.openstorage.api.VolumeEnumerateResponse.prototype.clearVolumesList = function() {
+proto.openstorage.api.SdkVolumeEnumerateResponse.prototype.clearVolumesList = function() {
   this.setVolumesList([]);
 };
 
@@ -11001,12 +14447,12 @@ proto.openstorage.api.VolumeEnumerateResponse.prototype.clearVolumesList = funct
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeSnapshotCreateRequest = function(opt_data) {
+proto.openstorage.api.SdkVolumeSnapshotCreateRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeSnapshotCreateRequest, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeSnapshotCreateRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeSnapshotCreateRequest.displayName = 'proto.openstorage.api.VolumeSnapshotCreateRequest';
+  proto.openstorage.api.SdkVolumeSnapshotCreateRequest.displayName = 'proto.openstorage.api.SdkVolumeSnapshotCreateRequest';
 }
 
 
@@ -11021,8 +14467,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeSnapshotCreateRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeSnapshotCreateRequest.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeSnapshotCreateRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeSnapshotCreateRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -11031,11 +14477,11 @@ proto.openstorage.api.VolumeSnapshotCreateRequest.prototype.toObject = function(
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeSnapshotCreateRequest} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeSnapshotCreateRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeSnapshotCreateRequest.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeSnapshotCreateRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     volumeId: jspb.Message.getFieldWithDefault(msg, 1, ""),
     labelsMap: (f = msg.getLabelsMap()) ? f.toObject(includeInstance, undefined) : []
@@ -11052,23 +14498,23 @@ proto.openstorage.api.VolumeSnapshotCreateRequest.toObject = function(includeIns
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeSnapshotCreateRequest}
+ * @return {!proto.openstorage.api.SdkVolumeSnapshotCreateRequest}
  */
-proto.openstorage.api.VolumeSnapshotCreateRequest.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeSnapshotCreateRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeSnapshotCreateRequest;
-  return proto.openstorage.api.VolumeSnapshotCreateRequest.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeSnapshotCreateRequest;
+  return proto.openstorage.api.SdkVolumeSnapshotCreateRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeSnapshotCreateRequest} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeSnapshotCreateRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeSnapshotCreateRequest}
+ * @return {!proto.openstorage.api.SdkVolumeSnapshotCreateRequest}
  */
-proto.openstorage.api.VolumeSnapshotCreateRequest.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeSnapshotCreateRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -11098,9 +14544,9 @@ proto.openstorage.api.VolumeSnapshotCreateRequest.deserializeBinaryFromReader = 
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeSnapshotCreateRequest.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeSnapshotCreateRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeSnapshotCreateRequest.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeSnapshotCreateRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -11108,11 +14554,11 @@ proto.openstorage.api.VolumeSnapshotCreateRequest.prototype.serializeBinary = fu
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeSnapshotCreateRequest} message
+ * @param {!proto.openstorage.api.SdkVolumeSnapshotCreateRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeSnapshotCreateRequest.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeSnapshotCreateRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getVolumeId();
   if (f.length > 0) {
@@ -11132,13 +14578,13 @@ proto.openstorage.api.VolumeSnapshotCreateRequest.serializeBinaryToWriter = func
  * optional string volume_id = 1;
  * @return {string}
  */
-proto.openstorage.api.VolumeSnapshotCreateRequest.prototype.getVolumeId = function() {
+proto.openstorage.api.SdkVolumeSnapshotCreateRequest.prototype.getVolumeId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.VolumeSnapshotCreateRequest.prototype.setVolumeId = function(value) {
+proto.openstorage.api.SdkVolumeSnapshotCreateRequest.prototype.setVolumeId = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -11149,14 +14595,14 @@ proto.openstorage.api.VolumeSnapshotCreateRequest.prototype.setVolumeId = functi
  * empty, instead returning `undefined`
  * @return {!jspb.Map<string,string>}
  */
-proto.openstorage.api.VolumeSnapshotCreateRequest.prototype.getLabelsMap = function(opt_noLazyCreate) {
+proto.openstorage.api.SdkVolumeSnapshotCreateRequest.prototype.getLabelsMap = function(opt_noLazyCreate) {
   return /** @type {!jspb.Map<string,string>} */ (
       jspb.Message.getMapField(this, 2, opt_noLazyCreate,
       null));
 };
 
 
-proto.openstorage.api.VolumeSnapshotCreateRequest.prototype.clearLabelsMap = function() {
+proto.openstorage.api.SdkVolumeSnapshotCreateRequest.prototype.clearLabelsMap = function() {
   this.getLabelsMap().clear();
 };
 
@@ -11172,12 +14618,12 @@ proto.openstorage.api.VolumeSnapshotCreateRequest.prototype.clearLabelsMap = fun
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeSnapshotCreateResponse = function(opt_data) {
+proto.openstorage.api.SdkVolumeSnapshotCreateResponse = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeSnapshotCreateResponse, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeSnapshotCreateResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeSnapshotCreateResponse.displayName = 'proto.openstorage.api.VolumeSnapshotCreateResponse';
+  proto.openstorage.api.SdkVolumeSnapshotCreateResponse.displayName = 'proto.openstorage.api.SdkVolumeSnapshotCreateResponse';
 }
 
 
@@ -11192,8 +14638,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeSnapshotCreateResponse.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeSnapshotCreateResponse.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeSnapshotCreateResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeSnapshotCreateResponse.toObject(opt_includeInstance, this);
 };
 
 
@@ -11202,11 +14648,11 @@ proto.openstorage.api.VolumeSnapshotCreateResponse.prototype.toObject = function
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeSnapshotCreateResponse} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeSnapshotCreateResponse} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeSnapshotCreateResponse.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeSnapshotCreateResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
     snapshotId: jspb.Message.getFieldWithDefault(msg, 1, "")
   };
@@ -11222,23 +14668,23 @@ proto.openstorage.api.VolumeSnapshotCreateResponse.toObject = function(includeIn
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeSnapshotCreateResponse}
+ * @return {!proto.openstorage.api.SdkVolumeSnapshotCreateResponse}
  */
-proto.openstorage.api.VolumeSnapshotCreateResponse.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeSnapshotCreateResponse.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeSnapshotCreateResponse;
-  return proto.openstorage.api.VolumeSnapshotCreateResponse.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeSnapshotCreateResponse;
+  return proto.openstorage.api.SdkVolumeSnapshotCreateResponse.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeSnapshotCreateResponse} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeSnapshotCreateResponse} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeSnapshotCreateResponse}
+ * @return {!proto.openstorage.api.SdkVolumeSnapshotCreateResponse}
  */
-proto.openstorage.api.VolumeSnapshotCreateResponse.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeSnapshotCreateResponse.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -11262,9 +14708,9 @@ proto.openstorage.api.VolumeSnapshotCreateResponse.deserializeBinaryFromReader =
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeSnapshotCreateResponse.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeSnapshotCreateResponse.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeSnapshotCreateResponse.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeSnapshotCreateResponse.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -11272,11 +14718,11 @@ proto.openstorage.api.VolumeSnapshotCreateResponse.prototype.serializeBinary = f
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeSnapshotCreateResponse} message
+ * @param {!proto.openstorage.api.SdkVolumeSnapshotCreateResponse} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeSnapshotCreateResponse.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeSnapshotCreateResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getSnapshotId();
   if (f.length > 0) {
@@ -11292,13 +14738,13 @@ proto.openstorage.api.VolumeSnapshotCreateResponse.serializeBinaryToWriter = fun
  * optional string snapshot_id = 1;
  * @return {string}
  */
-proto.openstorage.api.VolumeSnapshotCreateResponse.prototype.getSnapshotId = function() {
+proto.openstorage.api.SdkVolumeSnapshotCreateResponse.prototype.getSnapshotId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.VolumeSnapshotCreateResponse.prototype.setSnapshotId = function(value) {
+proto.openstorage.api.SdkVolumeSnapshotCreateResponse.prototype.setSnapshotId = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -11314,12 +14760,12 @@ proto.openstorage.api.VolumeSnapshotCreateResponse.prototype.setSnapshotId = fun
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeSnapshotRestoreRequest = function(opt_data) {
+proto.openstorage.api.SdkVolumeSnapshotRestoreRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeSnapshotRestoreRequest, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeSnapshotRestoreRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeSnapshotRestoreRequest.displayName = 'proto.openstorage.api.VolumeSnapshotRestoreRequest';
+  proto.openstorage.api.SdkVolumeSnapshotRestoreRequest.displayName = 'proto.openstorage.api.SdkVolumeSnapshotRestoreRequest';
 }
 
 
@@ -11334,8 +14780,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeSnapshotRestoreRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeSnapshotRestoreRequest.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeSnapshotRestoreRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeSnapshotRestoreRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -11344,11 +14790,11 @@ proto.openstorage.api.VolumeSnapshotRestoreRequest.prototype.toObject = function
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeSnapshotRestoreRequest} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeSnapshotRestoreRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeSnapshotRestoreRequest.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeSnapshotRestoreRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     volumeId: jspb.Message.getFieldWithDefault(msg, 1, ""),
     snapshotId: jspb.Message.getFieldWithDefault(msg, 2, "")
@@ -11365,23 +14811,23 @@ proto.openstorage.api.VolumeSnapshotRestoreRequest.toObject = function(includeIn
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeSnapshotRestoreRequest}
+ * @return {!proto.openstorage.api.SdkVolumeSnapshotRestoreRequest}
  */
-proto.openstorage.api.VolumeSnapshotRestoreRequest.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeSnapshotRestoreRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeSnapshotRestoreRequest;
-  return proto.openstorage.api.VolumeSnapshotRestoreRequest.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeSnapshotRestoreRequest;
+  return proto.openstorage.api.SdkVolumeSnapshotRestoreRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeSnapshotRestoreRequest} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeSnapshotRestoreRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeSnapshotRestoreRequest}
+ * @return {!proto.openstorage.api.SdkVolumeSnapshotRestoreRequest}
  */
-proto.openstorage.api.VolumeSnapshotRestoreRequest.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeSnapshotRestoreRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -11409,9 +14855,9 @@ proto.openstorage.api.VolumeSnapshotRestoreRequest.deserializeBinaryFromReader =
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeSnapshotRestoreRequest.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeSnapshotRestoreRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeSnapshotRestoreRequest.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeSnapshotRestoreRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -11419,11 +14865,11 @@ proto.openstorage.api.VolumeSnapshotRestoreRequest.prototype.serializeBinary = f
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeSnapshotRestoreRequest} message
+ * @param {!proto.openstorage.api.SdkVolumeSnapshotRestoreRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeSnapshotRestoreRequest.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeSnapshotRestoreRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getVolumeId();
   if (f.length > 0) {
@@ -11446,13 +14892,13 @@ proto.openstorage.api.VolumeSnapshotRestoreRequest.serializeBinaryToWriter = fun
  * optional string volume_id = 1;
  * @return {string}
  */
-proto.openstorage.api.VolumeSnapshotRestoreRequest.prototype.getVolumeId = function() {
+proto.openstorage.api.SdkVolumeSnapshotRestoreRequest.prototype.getVolumeId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.VolumeSnapshotRestoreRequest.prototype.setVolumeId = function(value) {
+proto.openstorage.api.SdkVolumeSnapshotRestoreRequest.prototype.setVolumeId = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -11461,13 +14907,13 @@ proto.openstorage.api.VolumeSnapshotRestoreRequest.prototype.setVolumeId = funct
  * optional string snapshot_id = 2;
  * @return {string}
  */
-proto.openstorage.api.VolumeSnapshotRestoreRequest.prototype.getSnapshotId = function() {
+proto.openstorage.api.SdkVolumeSnapshotRestoreRequest.prototype.getSnapshotId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 2, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.VolumeSnapshotRestoreRequest.prototype.setSnapshotId = function(value) {
+proto.openstorage.api.SdkVolumeSnapshotRestoreRequest.prototype.setSnapshotId = function(value) {
   jspb.Message.setField(this, 2, value);
 };
 
@@ -11483,12 +14929,12 @@ proto.openstorage.api.VolumeSnapshotRestoreRequest.prototype.setSnapshotId = fun
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeSnapshotRestoreResponse = function(opt_data) {
+proto.openstorage.api.SdkVolumeSnapshotRestoreResponse = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeSnapshotRestoreResponse, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeSnapshotRestoreResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeSnapshotRestoreResponse.displayName = 'proto.openstorage.api.VolumeSnapshotRestoreResponse';
+  proto.openstorage.api.SdkVolumeSnapshotRestoreResponse.displayName = 'proto.openstorage.api.SdkVolumeSnapshotRestoreResponse';
 }
 
 
@@ -11503,8 +14949,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeSnapshotRestoreResponse.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeSnapshotRestoreResponse.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeSnapshotRestoreResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeSnapshotRestoreResponse.toObject(opt_includeInstance, this);
 };
 
 
@@ -11513,11 +14959,11 @@ proto.openstorage.api.VolumeSnapshotRestoreResponse.prototype.toObject = functio
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeSnapshotRestoreResponse} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeSnapshotRestoreResponse} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeSnapshotRestoreResponse.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeSnapshotRestoreResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
 
   };
@@ -11533,23 +14979,23 @@ proto.openstorage.api.VolumeSnapshotRestoreResponse.toObject = function(includeI
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeSnapshotRestoreResponse}
+ * @return {!proto.openstorage.api.SdkVolumeSnapshotRestoreResponse}
  */
-proto.openstorage.api.VolumeSnapshotRestoreResponse.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeSnapshotRestoreResponse.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeSnapshotRestoreResponse;
-  return proto.openstorage.api.VolumeSnapshotRestoreResponse.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeSnapshotRestoreResponse;
+  return proto.openstorage.api.SdkVolumeSnapshotRestoreResponse.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeSnapshotRestoreResponse} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeSnapshotRestoreResponse} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeSnapshotRestoreResponse}
+ * @return {!proto.openstorage.api.SdkVolumeSnapshotRestoreResponse}
  */
-proto.openstorage.api.VolumeSnapshotRestoreResponse.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeSnapshotRestoreResponse.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -11569,9 +15015,9 @@ proto.openstorage.api.VolumeSnapshotRestoreResponse.deserializeBinaryFromReader 
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeSnapshotRestoreResponse.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeSnapshotRestoreResponse.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeSnapshotRestoreResponse.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeSnapshotRestoreResponse.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -11579,11 +15025,11 @@ proto.openstorage.api.VolumeSnapshotRestoreResponse.prototype.serializeBinary = 
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeSnapshotRestoreResponse} message
+ * @param {!proto.openstorage.api.SdkVolumeSnapshotRestoreResponse} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeSnapshotRestoreResponse.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeSnapshotRestoreResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
 };
 
@@ -11599,12 +15045,12 @@ proto.openstorage.api.VolumeSnapshotRestoreResponse.serializeBinaryToWriter = fu
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeSnapshotEnumerateRequest = function(opt_data) {
+proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.VolumeSnapshotEnumerateRequest, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeSnapshotEnumerateRequest.displayName = 'proto.openstorage.api.VolumeSnapshotEnumerateRequest';
+  proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest.displayName = 'proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest';
 }
 
 
@@ -11619,8 +15065,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeSnapshotEnumerateRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeSnapshotEnumerateRequest.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -11629,11 +15075,11 @@ proto.openstorage.api.VolumeSnapshotEnumerateRequest.prototype.toObject = functi
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeSnapshotEnumerateRequest} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeSnapshotEnumerateRequest.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     volumeId: jspb.Message.getFieldWithDefault(msg, 1, ""),
     labelsMap: (f = msg.getLabelsMap()) ? f.toObject(includeInstance, undefined) : []
@@ -11650,23 +15096,23 @@ proto.openstorage.api.VolumeSnapshotEnumerateRequest.toObject = function(include
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeSnapshotEnumerateRequest}
+ * @return {!proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest}
  */
-proto.openstorage.api.VolumeSnapshotEnumerateRequest.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeSnapshotEnumerateRequest;
-  return proto.openstorage.api.VolumeSnapshotEnumerateRequest.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest;
+  return proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeSnapshotEnumerateRequest} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeSnapshotEnumerateRequest}
+ * @return {!proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest}
  */
-proto.openstorage.api.VolumeSnapshotEnumerateRequest.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -11696,9 +15142,9 @@ proto.openstorage.api.VolumeSnapshotEnumerateRequest.deserializeBinaryFromReader
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeSnapshotEnumerateRequest.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeSnapshotEnumerateRequest.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -11706,11 +15152,11 @@ proto.openstorage.api.VolumeSnapshotEnumerateRequest.prototype.serializeBinary =
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeSnapshotEnumerateRequest} message
+ * @param {!proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeSnapshotEnumerateRequest.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getVolumeId();
   if (f.length > 0) {
@@ -11730,13 +15176,13 @@ proto.openstorage.api.VolumeSnapshotEnumerateRequest.serializeBinaryToWriter = f
  * optional string volume_id = 1;
  * @return {string}
  */
-proto.openstorage.api.VolumeSnapshotEnumerateRequest.prototype.getVolumeId = function() {
+proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest.prototype.getVolumeId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.VolumeSnapshotEnumerateRequest.prototype.setVolumeId = function(value) {
+proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest.prototype.setVolumeId = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -11747,14 +15193,14 @@ proto.openstorage.api.VolumeSnapshotEnumerateRequest.prototype.setVolumeId = fun
  * empty, instead returning `undefined`
  * @return {!jspb.Map<string,string>}
  */
-proto.openstorage.api.VolumeSnapshotEnumerateRequest.prototype.getLabelsMap = function(opt_noLazyCreate) {
+proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest.prototype.getLabelsMap = function(opt_noLazyCreate) {
   return /** @type {!jspb.Map<string,string>} */ (
       jspb.Message.getMapField(this, 2, opt_noLazyCreate,
       null));
 };
 
 
-proto.openstorage.api.VolumeSnapshotEnumerateRequest.prototype.clearLabelsMap = function() {
+proto.openstorage.api.SdkVolumeSnapshotEnumerateRequest.prototype.clearLabelsMap = function() {
   this.getLabelsMap().clear();
 };
 
@@ -11770,19 +15216,19 @@ proto.openstorage.api.VolumeSnapshotEnumerateRequest.prototype.clearLabelsMap = 
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.VolumeSnapshotEnumerateResponse = function(opt_data) {
-  jspb.Message.initialize(this, opt_data, 0, -1, proto.openstorage.api.VolumeSnapshotEnumerateResponse.repeatedFields_, null);
+proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse = function(opt_data) {
+  jspb.Message.initialize(this, opt_data, 0, -1, proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse.repeatedFields_, null);
 };
-goog.inherits(proto.openstorage.api.VolumeSnapshotEnumerateResponse, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.VolumeSnapshotEnumerateResponse.displayName = 'proto.openstorage.api.VolumeSnapshotEnumerateResponse';
+  proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse.displayName = 'proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse';
 }
 /**
  * List of repeated fields within this message type.
  * @private {!Array<number>}
  * @const
  */
-proto.openstorage.api.VolumeSnapshotEnumerateResponse.repeatedFields_ = [1];
+proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse.repeatedFields_ = [1];
 
 
 
@@ -11797,8 +15243,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.VolumeSnapshotEnumerateResponse.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.VolumeSnapshotEnumerateResponse.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse.toObject(opt_includeInstance, this);
 };
 
 
@@ -11807,11 +15253,11 @@ proto.openstorage.api.VolumeSnapshotEnumerateResponse.prototype.toObject = funct
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.VolumeSnapshotEnumerateResponse} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeSnapshotEnumerateResponse.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
     snapshotsList: jspb.Message.toObjectList(msg.getSnapshotsList(),
     proto.openstorage.api.Volume.toObject, includeInstance)
@@ -11828,23 +15274,23 @@ proto.openstorage.api.VolumeSnapshotEnumerateResponse.toObject = function(includ
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.VolumeSnapshotEnumerateResponse}
+ * @return {!proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse}
  */
-proto.openstorage.api.VolumeSnapshotEnumerateResponse.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.VolumeSnapshotEnumerateResponse;
-  return proto.openstorage.api.VolumeSnapshotEnumerateResponse.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse;
+  return proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.VolumeSnapshotEnumerateResponse} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.VolumeSnapshotEnumerateResponse}
+ * @return {!proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse}
  */
-proto.openstorage.api.VolumeSnapshotEnumerateResponse.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -11869,9 +15315,9 @@ proto.openstorage.api.VolumeSnapshotEnumerateResponse.deserializeBinaryFromReade
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.VolumeSnapshotEnumerateResponse.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.VolumeSnapshotEnumerateResponse.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -11879,11 +15325,11 @@ proto.openstorage.api.VolumeSnapshotEnumerateResponse.prototype.serializeBinary 
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.VolumeSnapshotEnumerateResponse} message
+ * @param {!proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.VolumeSnapshotEnumerateResponse.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getSnapshotsList();
   if (f.length > 0) {
@@ -11900,14 +15346,14 @@ proto.openstorage.api.VolumeSnapshotEnumerateResponse.serializeBinaryToWriter = 
  * repeated Volume snapshots = 1;
  * @return {!Array.<!proto.openstorage.api.Volume>}
  */
-proto.openstorage.api.VolumeSnapshotEnumerateResponse.prototype.getSnapshotsList = function() {
+proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse.prototype.getSnapshotsList = function() {
   return /** @type{!Array.<!proto.openstorage.api.Volume>} */ (
     jspb.Message.getRepeatedWrapperField(this, proto.openstorage.api.Volume, 1));
 };
 
 
 /** @param {!Array.<!proto.openstorage.api.Volume>} value */
-proto.openstorage.api.VolumeSnapshotEnumerateResponse.prototype.setSnapshotsList = function(value) {
+proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse.prototype.setSnapshotsList = function(value) {
   jspb.Message.setRepeatedWrapperField(this, 1, value);
 };
 
@@ -11917,12 +15363,12 @@ proto.openstorage.api.VolumeSnapshotEnumerateResponse.prototype.setSnapshotsList
  * @param {number=} opt_index
  * @return {!proto.openstorage.api.Volume}
  */
-proto.openstorage.api.VolumeSnapshotEnumerateResponse.prototype.addSnapshots = function(opt_value, opt_index) {
+proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse.prototype.addSnapshots = function(opt_value, opt_index) {
   return jspb.Message.addToRepeatedWrapperField(this, 1, opt_value, proto.openstorage.api.Volume, opt_index);
 };
 
 
-proto.openstorage.api.VolumeSnapshotEnumerateResponse.prototype.clearSnapshotsList = function() {
+proto.openstorage.api.SdkVolumeSnapshotEnumerateResponse.prototype.clearSnapshotsList = function() {
   this.setSnapshotsList([]);
 };
 
@@ -11938,12 +15384,12 @@ proto.openstorage.api.VolumeSnapshotEnumerateResponse.prototype.clearSnapshotsLi
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.ClusterEnumerateRequest = function(opt_data) {
+proto.openstorage.api.SdkClusterEnumerateRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.ClusterEnumerateRequest, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkClusterEnumerateRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.ClusterEnumerateRequest.displayName = 'proto.openstorage.api.ClusterEnumerateRequest';
+  proto.openstorage.api.SdkClusterEnumerateRequest.displayName = 'proto.openstorage.api.SdkClusterEnumerateRequest';
 }
 
 
@@ -11958,8 +15404,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.ClusterEnumerateRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.ClusterEnumerateRequest.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkClusterEnumerateRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkClusterEnumerateRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -11968,11 +15414,11 @@ proto.openstorage.api.ClusterEnumerateRequest.prototype.toObject = function(opt_
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.ClusterEnumerateRequest} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkClusterEnumerateRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterEnumerateRequest.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkClusterEnumerateRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
 
   };
@@ -11988,23 +15434,23 @@ proto.openstorage.api.ClusterEnumerateRequest.toObject = function(includeInstanc
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.ClusterEnumerateRequest}
+ * @return {!proto.openstorage.api.SdkClusterEnumerateRequest}
  */
-proto.openstorage.api.ClusterEnumerateRequest.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkClusterEnumerateRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.ClusterEnumerateRequest;
-  return proto.openstorage.api.ClusterEnumerateRequest.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkClusterEnumerateRequest;
+  return proto.openstorage.api.SdkClusterEnumerateRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.ClusterEnumerateRequest} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkClusterEnumerateRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.ClusterEnumerateRequest}
+ * @return {!proto.openstorage.api.SdkClusterEnumerateRequest}
  */
-proto.openstorage.api.ClusterEnumerateRequest.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkClusterEnumerateRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -12024,9 +15470,9 @@ proto.openstorage.api.ClusterEnumerateRequest.deserializeBinaryFromReader = func
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.ClusterEnumerateRequest.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkClusterEnumerateRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.ClusterEnumerateRequest.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkClusterEnumerateRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -12034,11 +15480,11 @@ proto.openstorage.api.ClusterEnumerateRequest.prototype.serializeBinary = functi
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.ClusterEnumerateRequest} message
+ * @param {!proto.openstorage.api.SdkClusterEnumerateRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterEnumerateRequest.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkClusterEnumerateRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
 };
 
@@ -12054,12 +15500,12 @@ proto.openstorage.api.ClusterEnumerateRequest.serializeBinaryToWriter = function
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.ClusterEnumerateResponse = function(opt_data) {
+proto.openstorage.api.SdkClusterEnumerateResponse = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.ClusterEnumerateResponse, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkClusterEnumerateResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.ClusterEnumerateResponse.displayName = 'proto.openstorage.api.ClusterEnumerateResponse';
+  proto.openstorage.api.SdkClusterEnumerateResponse.displayName = 'proto.openstorage.api.SdkClusterEnumerateResponse';
 }
 
 
@@ -12074,8 +15520,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.ClusterEnumerateResponse.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.ClusterEnumerateResponse.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkClusterEnumerateResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkClusterEnumerateResponse.toObject(opt_includeInstance, this);
 };
 
 
@@ -12084,11 +15530,11 @@ proto.openstorage.api.ClusterEnumerateResponse.prototype.toObject = function(opt
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.ClusterEnumerateResponse} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkClusterEnumerateResponse} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterEnumerateResponse.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkClusterEnumerateResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
     cluster: (f = msg.getCluster()) && proto.openstorage.api.StorageCluster.toObject(includeInstance, f)
   };
@@ -12104,23 +15550,23 @@ proto.openstorage.api.ClusterEnumerateResponse.toObject = function(includeInstan
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.ClusterEnumerateResponse}
+ * @return {!proto.openstorage.api.SdkClusterEnumerateResponse}
  */
-proto.openstorage.api.ClusterEnumerateResponse.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkClusterEnumerateResponse.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.ClusterEnumerateResponse;
-  return proto.openstorage.api.ClusterEnumerateResponse.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkClusterEnumerateResponse;
+  return proto.openstorage.api.SdkClusterEnumerateResponse.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.ClusterEnumerateResponse} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkClusterEnumerateResponse} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.ClusterEnumerateResponse}
+ * @return {!proto.openstorage.api.SdkClusterEnumerateResponse}
  */
-proto.openstorage.api.ClusterEnumerateResponse.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkClusterEnumerateResponse.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -12145,9 +15591,9 @@ proto.openstorage.api.ClusterEnumerateResponse.deserializeBinaryFromReader = fun
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.ClusterEnumerateResponse.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkClusterEnumerateResponse.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.ClusterEnumerateResponse.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkClusterEnumerateResponse.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -12155,11 +15601,11 @@ proto.openstorage.api.ClusterEnumerateResponse.prototype.serializeBinary = funct
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.ClusterEnumerateResponse} message
+ * @param {!proto.openstorage.api.SdkClusterEnumerateResponse} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterEnumerateResponse.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkClusterEnumerateResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getCluster();
   if (f != null) {
@@ -12176,19 +15622,19 @@ proto.openstorage.api.ClusterEnumerateResponse.serializeBinaryToWriter = functio
  * optional StorageCluster cluster = 1;
  * @return {?proto.openstorage.api.StorageCluster}
  */
-proto.openstorage.api.ClusterEnumerateResponse.prototype.getCluster = function() {
+proto.openstorage.api.SdkClusterEnumerateResponse.prototype.getCluster = function() {
   return /** @type{?proto.openstorage.api.StorageCluster} */ (
     jspb.Message.getWrapperField(this, proto.openstorage.api.StorageCluster, 1));
 };
 
 
 /** @param {?proto.openstorage.api.StorageCluster|undefined} value */
-proto.openstorage.api.ClusterEnumerateResponse.prototype.setCluster = function(value) {
+proto.openstorage.api.SdkClusterEnumerateResponse.prototype.setCluster = function(value) {
   jspb.Message.setWrapperField(this, 1, value);
 };
 
 
-proto.openstorage.api.ClusterEnumerateResponse.prototype.clearCluster = function() {
+proto.openstorage.api.SdkClusterEnumerateResponse.prototype.clearCluster = function() {
   this.setCluster(undefined);
 };
 
@@ -12197,7 +15643,7 @@ proto.openstorage.api.ClusterEnumerateResponse.prototype.clearCluster = function
  * Returns whether this field is set.
  * @return {!boolean}
  */
-proto.openstorage.api.ClusterEnumerateResponse.prototype.hasCluster = function() {
+proto.openstorage.api.SdkClusterEnumerateResponse.prototype.hasCluster = function() {
   return jspb.Message.getField(this, 1) != null;
 };
 
@@ -12213,12 +15659,12 @@ proto.openstorage.api.ClusterEnumerateResponse.prototype.hasCluster = function()
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.ClusterInspectRequest = function(opt_data) {
+proto.openstorage.api.SdkClusterInspectRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.ClusterInspectRequest, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkClusterInspectRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.ClusterInspectRequest.displayName = 'proto.openstorage.api.ClusterInspectRequest';
+  proto.openstorage.api.SdkClusterInspectRequest.displayName = 'proto.openstorage.api.SdkClusterInspectRequest';
 }
 
 
@@ -12233,8 +15679,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.ClusterInspectRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.ClusterInspectRequest.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkClusterInspectRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkClusterInspectRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -12243,11 +15689,11 @@ proto.openstorage.api.ClusterInspectRequest.prototype.toObject = function(opt_in
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.ClusterInspectRequest} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkClusterInspectRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterInspectRequest.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkClusterInspectRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     nodeId: jspb.Message.getFieldWithDefault(msg, 1, "")
   };
@@ -12263,23 +15709,23 @@ proto.openstorage.api.ClusterInspectRequest.toObject = function(includeInstance,
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.ClusterInspectRequest}
+ * @return {!proto.openstorage.api.SdkClusterInspectRequest}
  */
-proto.openstorage.api.ClusterInspectRequest.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkClusterInspectRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.ClusterInspectRequest;
-  return proto.openstorage.api.ClusterInspectRequest.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkClusterInspectRequest;
+  return proto.openstorage.api.SdkClusterInspectRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.ClusterInspectRequest} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkClusterInspectRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.ClusterInspectRequest}
+ * @return {!proto.openstorage.api.SdkClusterInspectRequest}
  */
-proto.openstorage.api.ClusterInspectRequest.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkClusterInspectRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -12303,9 +15749,9 @@ proto.openstorage.api.ClusterInspectRequest.deserializeBinaryFromReader = functi
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.ClusterInspectRequest.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkClusterInspectRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.ClusterInspectRequest.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkClusterInspectRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -12313,11 +15759,11 @@ proto.openstorage.api.ClusterInspectRequest.prototype.serializeBinary = function
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.ClusterInspectRequest} message
+ * @param {!proto.openstorage.api.SdkClusterInspectRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterInspectRequest.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkClusterInspectRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getNodeId();
   if (f.length > 0) {
@@ -12333,13 +15779,13 @@ proto.openstorage.api.ClusterInspectRequest.serializeBinaryToWriter = function(m
  * optional string node_id = 1;
  * @return {string}
  */
-proto.openstorage.api.ClusterInspectRequest.prototype.getNodeId = function() {
+proto.openstorage.api.SdkClusterInspectRequest.prototype.getNodeId = function() {
   return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 1, ""));
 };
 
 
 /** @param {string} value */
-proto.openstorage.api.ClusterInspectRequest.prototype.setNodeId = function(value) {
+proto.openstorage.api.SdkClusterInspectRequest.prototype.setNodeId = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -12355,12 +15801,12 @@ proto.openstorage.api.ClusterInspectRequest.prototype.setNodeId = function(value
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.ClusterInspectResponse = function(opt_data) {
+proto.openstorage.api.SdkClusterInspectResponse = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.ClusterInspectResponse, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkClusterInspectResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.ClusterInspectResponse.displayName = 'proto.openstorage.api.ClusterInspectResponse';
+  proto.openstorage.api.SdkClusterInspectResponse.displayName = 'proto.openstorage.api.SdkClusterInspectResponse';
 }
 
 
@@ -12375,8 +15821,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.ClusterInspectResponse.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.ClusterInspectResponse.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkClusterInspectResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkClusterInspectResponse.toObject(opt_includeInstance, this);
 };
 
 
@@ -12385,11 +15831,11 @@ proto.openstorage.api.ClusterInspectResponse.prototype.toObject = function(opt_i
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.ClusterInspectResponse} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkClusterInspectResponse} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterInspectResponse.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkClusterInspectResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
     node: (f = msg.getNode()) && proto.openstorage.api.StorageNode.toObject(includeInstance, f)
   };
@@ -12405,23 +15851,23 @@ proto.openstorage.api.ClusterInspectResponse.toObject = function(includeInstance
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.ClusterInspectResponse}
+ * @return {!proto.openstorage.api.SdkClusterInspectResponse}
  */
-proto.openstorage.api.ClusterInspectResponse.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkClusterInspectResponse.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.ClusterInspectResponse;
-  return proto.openstorage.api.ClusterInspectResponse.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkClusterInspectResponse;
+  return proto.openstorage.api.SdkClusterInspectResponse.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.ClusterInspectResponse} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkClusterInspectResponse} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.ClusterInspectResponse}
+ * @return {!proto.openstorage.api.SdkClusterInspectResponse}
  */
-proto.openstorage.api.ClusterInspectResponse.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkClusterInspectResponse.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -12446,9 +15892,9 @@ proto.openstorage.api.ClusterInspectResponse.deserializeBinaryFromReader = funct
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.ClusterInspectResponse.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkClusterInspectResponse.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.ClusterInspectResponse.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkClusterInspectResponse.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -12456,11 +15902,11 @@ proto.openstorage.api.ClusterInspectResponse.prototype.serializeBinary = functio
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.ClusterInspectResponse} message
+ * @param {!proto.openstorage.api.SdkClusterInspectResponse} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterInspectResponse.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkClusterInspectResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getNode();
   if (f != null) {
@@ -12477,19 +15923,19 @@ proto.openstorage.api.ClusterInspectResponse.serializeBinaryToWriter = function(
  * optional StorageNode node = 1;
  * @return {?proto.openstorage.api.StorageNode}
  */
-proto.openstorage.api.ClusterInspectResponse.prototype.getNode = function() {
+proto.openstorage.api.SdkClusterInspectResponse.prototype.getNode = function() {
   return /** @type{?proto.openstorage.api.StorageNode} */ (
     jspb.Message.getWrapperField(this, proto.openstorage.api.StorageNode, 1));
 };
 
 
 /** @param {?proto.openstorage.api.StorageNode|undefined} value */
-proto.openstorage.api.ClusterInspectResponse.prototype.setNode = function(value) {
+proto.openstorage.api.SdkClusterInspectResponse.prototype.setNode = function(value) {
   jspb.Message.setWrapperField(this, 1, value);
 };
 
 
-proto.openstorage.api.ClusterInspectResponse.prototype.clearNode = function() {
+proto.openstorage.api.SdkClusterInspectResponse.prototype.clearNode = function() {
   this.setNode(undefined);
 };
 
@@ -12498,7 +15944,7 @@ proto.openstorage.api.ClusterInspectResponse.prototype.clearNode = function() {
  * Returns whether this field is set.
  * @return {!boolean}
  */
-proto.openstorage.api.ClusterInspectResponse.prototype.hasNode = function() {
+proto.openstorage.api.SdkClusterInspectResponse.prototype.hasNode = function() {
   return jspb.Message.getField(this, 1) != null;
 };
 
@@ -12514,12 +15960,12 @@ proto.openstorage.api.ClusterInspectResponse.prototype.hasNode = function() {
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.ClusterAlertEnumerateRequest = function(opt_data) {
+proto.openstorage.api.SdkClusterAlertEnumerateRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.ClusterAlertEnumerateRequest, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkClusterAlertEnumerateRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.ClusterAlertEnumerateRequest.displayName = 'proto.openstorage.api.ClusterAlertEnumerateRequest';
+  proto.openstorage.api.SdkClusterAlertEnumerateRequest.displayName = 'proto.openstorage.api.SdkClusterAlertEnumerateRequest';
 }
 
 
@@ -12534,8 +15980,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.ClusterAlertEnumerateRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.ClusterAlertEnumerateRequest.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkClusterAlertEnumerateRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkClusterAlertEnumerateRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -12544,11 +15990,11 @@ proto.openstorage.api.ClusterAlertEnumerateRequest.prototype.toObject = function
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.ClusterAlertEnumerateRequest} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkClusterAlertEnumerateRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterAlertEnumerateRequest.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkClusterAlertEnumerateRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     timeStart: (f = msg.getTimeStart()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
     timeEnd: (f = msg.getTimeEnd()) && google_protobuf_timestamp_pb.Timestamp.toObject(includeInstance, f),
@@ -12566,23 +16012,23 @@ proto.openstorage.api.ClusterAlertEnumerateRequest.toObject = function(includeIn
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.ClusterAlertEnumerateRequest}
+ * @return {!proto.openstorage.api.SdkClusterAlertEnumerateRequest}
  */
-proto.openstorage.api.ClusterAlertEnumerateRequest.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkClusterAlertEnumerateRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.ClusterAlertEnumerateRequest;
-  return proto.openstorage.api.ClusterAlertEnumerateRequest.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkClusterAlertEnumerateRequest;
+  return proto.openstorage.api.SdkClusterAlertEnumerateRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.ClusterAlertEnumerateRequest} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkClusterAlertEnumerateRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.ClusterAlertEnumerateRequest}
+ * @return {!proto.openstorage.api.SdkClusterAlertEnumerateRequest}
  */
-proto.openstorage.api.ClusterAlertEnumerateRequest.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkClusterAlertEnumerateRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -12616,9 +16062,9 @@ proto.openstorage.api.ClusterAlertEnumerateRequest.deserializeBinaryFromReader =
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.ClusterAlertEnumerateRequest.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkClusterAlertEnumerateRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.ClusterAlertEnumerateRequest.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkClusterAlertEnumerateRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -12626,11 +16072,11 @@ proto.openstorage.api.ClusterAlertEnumerateRequest.prototype.serializeBinary = f
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.ClusterAlertEnumerateRequest} message
+ * @param {!proto.openstorage.api.SdkClusterAlertEnumerateRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterAlertEnumerateRequest.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkClusterAlertEnumerateRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getTimeStart();
   if (f != null) {
@@ -12662,19 +16108,19 @@ proto.openstorage.api.ClusterAlertEnumerateRequest.serializeBinaryToWriter = fun
  * optional google.protobuf.Timestamp time_start = 1;
  * @return {?proto.google.protobuf.Timestamp}
  */
-proto.openstorage.api.ClusterAlertEnumerateRequest.prototype.getTimeStart = function() {
+proto.openstorage.api.SdkClusterAlertEnumerateRequest.prototype.getTimeStart = function() {
   return /** @type{?proto.google.protobuf.Timestamp} */ (
     jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 1));
 };
 
 
 /** @param {?proto.google.protobuf.Timestamp|undefined} value */
-proto.openstorage.api.ClusterAlertEnumerateRequest.prototype.setTimeStart = function(value) {
+proto.openstorage.api.SdkClusterAlertEnumerateRequest.prototype.setTimeStart = function(value) {
   jspb.Message.setWrapperField(this, 1, value);
 };
 
 
-proto.openstorage.api.ClusterAlertEnumerateRequest.prototype.clearTimeStart = function() {
+proto.openstorage.api.SdkClusterAlertEnumerateRequest.prototype.clearTimeStart = function() {
   this.setTimeStart(undefined);
 };
 
@@ -12683,7 +16129,7 @@ proto.openstorage.api.ClusterAlertEnumerateRequest.prototype.clearTimeStart = fu
  * Returns whether this field is set.
  * @return {!boolean}
  */
-proto.openstorage.api.ClusterAlertEnumerateRequest.prototype.hasTimeStart = function() {
+proto.openstorage.api.SdkClusterAlertEnumerateRequest.prototype.hasTimeStart = function() {
   return jspb.Message.getField(this, 1) != null;
 };
 
@@ -12692,19 +16138,19 @@ proto.openstorage.api.ClusterAlertEnumerateRequest.prototype.hasTimeStart = func
  * optional google.protobuf.Timestamp time_end = 2;
  * @return {?proto.google.protobuf.Timestamp}
  */
-proto.openstorage.api.ClusterAlertEnumerateRequest.prototype.getTimeEnd = function() {
+proto.openstorage.api.SdkClusterAlertEnumerateRequest.prototype.getTimeEnd = function() {
   return /** @type{?proto.google.protobuf.Timestamp} */ (
     jspb.Message.getWrapperField(this, google_protobuf_timestamp_pb.Timestamp, 2));
 };
 
 
 /** @param {?proto.google.protobuf.Timestamp|undefined} value */
-proto.openstorage.api.ClusterAlertEnumerateRequest.prototype.setTimeEnd = function(value) {
+proto.openstorage.api.SdkClusterAlertEnumerateRequest.prototype.setTimeEnd = function(value) {
   jspb.Message.setWrapperField(this, 2, value);
 };
 
 
-proto.openstorage.api.ClusterAlertEnumerateRequest.prototype.clearTimeEnd = function() {
+proto.openstorage.api.SdkClusterAlertEnumerateRequest.prototype.clearTimeEnd = function() {
   this.setTimeEnd(undefined);
 };
 
@@ -12713,7 +16159,7 @@ proto.openstorage.api.ClusterAlertEnumerateRequest.prototype.clearTimeEnd = func
  * Returns whether this field is set.
  * @return {!boolean}
  */
-proto.openstorage.api.ClusterAlertEnumerateRequest.prototype.hasTimeEnd = function() {
+proto.openstorage.api.SdkClusterAlertEnumerateRequest.prototype.hasTimeEnd = function() {
   return jspb.Message.getField(this, 2) != null;
 };
 
@@ -12722,13 +16168,13 @@ proto.openstorage.api.ClusterAlertEnumerateRequest.prototype.hasTimeEnd = functi
  * optional ResourceType resource = 3;
  * @return {!proto.openstorage.api.ResourceType}
  */
-proto.openstorage.api.ClusterAlertEnumerateRequest.prototype.getResource = function() {
+proto.openstorage.api.SdkClusterAlertEnumerateRequest.prototype.getResource = function() {
   return /** @type {!proto.openstorage.api.ResourceType} */ (jspb.Message.getFieldWithDefault(this, 3, 0));
 };
 
 
 /** @param {!proto.openstorage.api.ResourceType} value */
-proto.openstorage.api.ClusterAlertEnumerateRequest.prototype.setResource = function(value) {
+proto.openstorage.api.SdkClusterAlertEnumerateRequest.prototype.setResource = function(value) {
   jspb.Message.setField(this, 3, value);
 };
 
@@ -12744,12 +16190,12 @@ proto.openstorage.api.ClusterAlertEnumerateRequest.prototype.setResource = funct
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.ClusterAlertEnumerateResponse = function(opt_data) {
+proto.openstorage.api.SdkClusterAlertEnumerateResponse = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.ClusterAlertEnumerateResponse, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkClusterAlertEnumerateResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.ClusterAlertEnumerateResponse.displayName = 'proto.openstorage.api.ClusterAlertEnumerateResponse';
+  proto.openstorage.api.SdkClusterAlertEnumerateResponse.displayName = 'proto.openstorage.api.SdkClusterAlertEnumerateResponse';
 }
 
 
@@ -12764,8 +16210,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.ClusterAlertEnumerateResponse.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.ClusterAlertEnumerateResponse.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkClusterAlertEnumerateResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkClusterAlertEnumerateResponse.toObject(opt_includeInstance, this);
 };
 
 
@@ -12774,11 +16220,11 @@ proto.openstorage.api.ClusterAlertEnumerateResponse.prototype.toObject = functio
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.ClusterAlertEnumerateResponse} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkClusterAlertEnumerateResponse} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterAlertEnumerateResponse.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkClusterAlertEnumerateResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
     alerts: (f = msg.getAlerts()) && proto.openstorage.api.Alerts.toObject(includeInstance, f)
   };
@@ -12794,23 +16240,23 @@ proto.openstorage.api.ClusterAlertEnumerateResponse.toObject = function(includeI
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.ClusterAlertEnumerateResponse}
+ * @return {!proto.openstorage.api.SdkClusterAlertEnumerateResponse}
  */
-proto.openstorage.api.ClusterAlertEnumerateResponse.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkClusterAlertEnumerateResponse.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.ClusterAlertEnumerateResponse;
-  return proto.openstorage.api.ClusterAlertEnumerateResponse.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkClusterAlertEnumerateResponse;
+  return proto.openstorage.api.SdkClusterAlertEnumerateResponse.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.ClusterAlertEnumerateResponse} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkClusterAlertEnumerateResponse} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.ClusterAlertEnumerateResponse}
+ * @return {!proto.openstorage.api.SdkClusterAlertEnumerateResponse}
  */
-proto.openstorage.api.ClusterAlertEnumerateResponse.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkClusterAlertEnumerateResponse.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -12835,9 +16281,9 @@ proto.openstorage.api.ClusterAlertEnumerateResponse.deserializeBinaryFromReader 
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.ClusterAlertEnumerateResponse.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkClusterAlertEnumerateResponse.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.ClusterAlertEnumerateResponse.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkClusterAlertEnumerateResponse.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -12845,11 +16291,11 @@ proto.openstorage.api.ClusterAlertEnumerateResponse.prototype.serializeBinary = 
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.ClusterAlertEnumerateResponse} message
+ * @param {!proto.openstorage.api.SdkClusterAlertEnumerateResponse} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterAlertEnumerateResponse.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkClusterAlertEnumerateResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getAlerts();
   if (f != null) {
@@ -12866,19 +16312,19 @@ proto.openstorage.api.ClusterAlertEnumerateResponse.serializeBinaryToWriter = fu
  * optional Alerts alerts = 1;
  * @return {?proto.openstorage.api.Alerts}
  */
-proto.openstorage.api.ClusterAlertEnumerateResponse.prototype.getAlerts = function() {
+proto.openstorage.api.SdkClusterAlertEnumerateResponse.prototype.getAlerts = function() {
   return /** @type{?proto.openstorage.api.Alerts} */ (
     jspb.Message.getWrapperField(this, proto.openstorage.api.Alerts, 1));
 };
 
 
 /** @param {?proto.openstorage.api.Alerts|undefined} value */
-proto.openstorage.api.ClusterAlertEnumerateResponse.prototype.setAlerts = function(value) {
+proto.openstorage.api.SdkClusterAlertEnumerateResponse.prototype.setAlerts = function(value) {
   jspb.Message.setWrapperField(this, 1, value);
 };
 
 
-proto.openstorage.api.ClusterAlertEnumerateResponse.prototype.clearAlerts = function() {
+proto.openstorage.api.SdkClusterAlertEnumerateResponse.prototype.clearAlerts = function() {
   this.setAlerts(undefined);
 };
 
@@ -12887,7 +16333,7 @@ proto.openstorage.api.ClusterAlertEnumerateResponse.prototype.clearAlerts = func
  * Returns whether this field is set.
  * @return {!boolean}
  */
-proto.openstorage.api.ClusterAlertEnumerateResponse.prototype.hasAlerts = function() {
+proto.openstorage.api.SdkClusterAlertEnumerateResponse.prototype.hasAlerts = function() {
   return jspb.Message.getField(this, 1) != null;
 };
 
@@ -12903,12 +16349,12 @@ proto.openstorage.api.ClusterAlertEnumerateResponse.prototype.hasAlerts = functi
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.ClusterAlertClearRequest = function(opt_data) {
+proto.openstorage.api.SdkClusterAlertClearRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.ClusterAlertClearRequest, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkClusterAlertClearRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.ClusterAlertClearRequest.displayName = 'proto.openstorage.api.ClusterAlertClearRequest';
+  proto.openstorage.api.SdkClusterAlertClearRequest.displayName = 'proto.openstorage.api.SdkClusterAlertClearRequest';
 }
 
 
@@ -12923,8 +16369,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.ClusterAlertClearRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.ClusterAlertClearRequest.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkClusterAlertClearRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkClusterAlertClearRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -12933,11 +16379,11 @@ proto.openstorage.api.ClusterAlertClearRequest.prototype.toObject = function(opt
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.ClusterAlertClearRequest} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkClusterAlertClearRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterAlertClearRequest.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkClusterAlertClearRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     resource: jspb.Message.getFieldWithDefault(msg, 1, 0),
     alertId: jspb.Message.getFieldWithDefault(msg, 2, 0)
@@ -12954,23 +16400,23 @@ proto.openstorage.api.ClusterAlertClearRequest.toObject = function(includeInstan
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.ClusterAlertClearRequest}
+ * @return {!proto.openstorage.api.SdkClusterAlertClearRequest}
  */
-proto.openstorage.api.ClusterAlertClearRequest.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkClusterAlertClearRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.ClusterAlertClearRequest;
-  return proto.openstorage.api.ClusterAlertClearRequest.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkClusterAlertClearRequest;
+  return proto.openstorage.api.SdkClusterAlertClearRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.ClusterAlertClearRequest} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkClusterAlertClearRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.ClusterAlertClearRequest}
+ * @return {!proto.openstorage.api.SdkClusterAlertClearRequest}
  */
-proto.openstorage.api.ClusterAlertClearRequest.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkClusterAlertClearRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -12998,9 +16444,9 @@ proto.openstorage.api.ClusterAlertClearRequest.deserializeBinaryFromReader = fun
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.ClusterAlertClearRequest.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkClusterAlertClearRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.ClusterAlertClearRequest.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkClusterAlertClearRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -13008,11 +16454,11 @@ proto.openstorage.api.ClusterAlertClearRequest.prototype.serializeBinary = funct
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.ClusterAlertClearRequest} message
+ * @param {!proto.openstorage.api.SdkClusterAlertClearRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterAlertClearRequest.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkClusterAlertClearRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getResource();
   if (f !== 0.0) {
@@ -13035,13 +16481,13 @@ proto.openstorage.api.ClusterAlertClearRequest.serializeBinaryToWriter = functio
  * optional ResourceType resource = 1;
  * @return {!proto.openstorage.api.ResourceType}
  */
-proto.openstorage.api.ClusterAlertClearRequest.prototype.getResource = function() {
+proto.openstorage.api.SdkClusterAlertClearRequest.prototype.getResource = function() {
   return /** @type {!proto.openstorage.api.ResourceType} */ (jspb.Message.getFieldWithDefault(this, 1, 0));
 };
 
 
 /** @param {!proto.openstorage.api.ResourceType} value */
-proto.openstorage.api.ClusterAlertClearRequest.prototype.setResource = function(value) {
+proto.openstorage.api.SdkClusterAlertClearRequest.prototype.setResource = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -13050,13 +16496,13 @@ proto.openstorage.api.ClusterAlertClearRequest.prototype.setResource = function(
  * optional int64 alert_id = 2;
  * @return {number}
  */
-proto.openstorage.api.ClusterAlertClearRequest.prototype.getAlertId = function() {
+proto.openstorage.api.SdkClusterAlertClearRequest.prototype.getAlertId = function() {
   return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 2, 0));
 };
 
 
 /** @param {number} value */
-proto.openstorage.api.ClusterAlertClearRequest.prototype.setAlertId = function(value) {
+proto.openstorage.api.SdkClusterAlertClearRequest.prototype.setAlertId = function(value) {
   jspb.Message.setField(this, 2, value);
 };
 
@@ -13072,12 +16518,12 @@ proto.openstorage.api.ClusterAlertClearRequest.prototype.setAlertId = function(v
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.ClusterAlertClearResponse = function(opt_data) {
+proto.openstorage.api.SdkClusterAlertClearResponse = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.ClusterAlertClearResponse, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkClusterAlertClearResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.ClusterAlertClearResponse.displayName = 'proto.openstorage.api.ClusterAlertClearResponse';
+  proto.openstorage.api.SdkClusterAlertClearResponse.displayName = 'proto.openstorage.api.SdkClusterAlertClearResponse';
 }
 
 
@@ -13092,8 +16538,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.ClusterAlertClearResponse.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.ClusterAlertClearResponse.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkClusterAlertClearResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkClusterAlertClearResponse.toObject(opt_includeInstance, this);
 };
 
 
@@ -13102,11 +16548,11 @@ proto.openstorage.api.ClusterAlertClearResponse.prototype.toObject = function(op
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.ClusterAlertClearResponse} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkClusterAlertClearResponse} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterAlertClearResponse.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkClusterAlertClearResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
 
   };
@@ -13122,23 +16568,23 @@ proto.openstorage.api.ClusterAlertClearResponse.toObject = function(includeInsta
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.ClusterAlertClearResponse}
+ * @return {!proto.openstorage.api.SdkClusterAlertClearResponse}
  */
-proto.openstorage.api.ClusterAlertClearResponse.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkClusterAlertClearResponse.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.ClusterAlertClearResponse;
-  return proto.openstorage.api.ClusterAlertClearResponse.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkClusterAlertClearResponse;
+  return proto.openstorage.api.SdkClusterAlertClearResponse.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.ClusterAlertClearResponse} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkClusterAlertClearResponse} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.ClusterAlertClearResponse}
+ * @return {!proto.openstorage.api.SdkClusterAlertClearResponse}
  */
-proto.openstorage.api.ClusterAlertClearResponse.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkClusterAlertClearResponse.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -13158,9 +16604,9 @@ proto.openstorage.api.ClusterAlertClearResponse.deserializeBinaryFromReader = fu
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.ClusterAlertClearResponse.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkClusterAlertClearResponse.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.ClusterAlertClearResponse.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkClusterAlertClearResponse.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -13168,11 +16614,11 @@ proto.openstorage.api.ClusterAlertClearResponse.prototype.serializeBinary = func
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.ClusterAlertClearResponse} message
+ * @param {!proto.openstorage.api.SdkClusterAlertClearResponse} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterAlertClearResponse.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkClusterAlertClearResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
 };
 
@@ -13188,12 +16634,12 @@ proto.openstorage.api.ClusterAlertClearResponse.serializeBinaryToWriter = functi
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.ClusterAlertEraseRequest = function(opt_data) {
+proto.openstorage.api.SdkClusterAlertEraseRequest = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.ClusterAlertEraseRequest, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkClusterAlertEraseRequest, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.ClusterAlertEraseRequest.displayName = 'proto.openstorage.api.ClusterAlertEraseRequest';
+  proto.openstorage.api.SdkClusterAlertEraseRequest.displayName = 'proto.openstorage.api.SdkClusterAlertEraseRequest';
 }
 
 
@@ -13208,8 +16654,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.ClusterAlertEraseRequest.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.ClusterAlertEraseRequest.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkClusterAlertEraseRequest.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkClusterAlertEraseRequest.toObject(opt_includeInstance, this);
 };
 
 
@@ -13218,11 +16664,11 @@ proto.openstorage.api.ClusterAlertEraseRequest.prototype.toObject = function(opt
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.ClusterAlertEraseRequest} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkClusterAlertEraseRequest} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterAlertEraseRequest.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkClusterAlertEraseRequest.toObject = function(includeInstance, msg) {
   var f, obj = {
     resource: jspb.Message.getFieldWithDefault(msg, 1, 0),
     alertId: jspb.Message.getFieldWithDefault(msg, 2, 0)
@@ -13239,23 +16685,23 @@ proto.openstorage.api.ClusterAlertEraseRequest.toObject = function(includeInstan
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.ClusterAlertEraseRequest}
+ * @return {!proto.openstorage.api.SdkClusterAlertEraseRequest}
  */
-proto.openstorage.api.ClusterAlertEraseRequest.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkClusterAlertEraseRequest.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.ClusterAlertEraseRequest;
-  return proto.openstorage.api.ClusterAlertEraseRequest.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkClusterAlertEraseRequest;
+  return proto.openstorage.api.SdkClusterAlertEraseRequest.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.ClusterAlertEraseRequest} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkClusterAlertEraseRequest} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.ClusterAlertEraseRequest}
+ * @return {!proto.openstorage.api.SdkClusterAlertEraseRequest}
  */
-proto.openstorage.api.ClusterAlertEraseRequest.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkClusterAlertEraseRequest.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -13283,9 +16729,9 @@ proto.openstorage.api.ClusterAlertEraseRequest.deserializeBinaryFromReader = fun
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.ClusterAlertEraseRequest.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkClusterAlertEraseRequest.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.ClusterAlertEraseRequest.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkClusterAlertEraseRequest.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -13293,11 +16739,11 @@ proto.openstorage.api.ClusterAlertEraseRequest.prototype.serializeBinary = funct
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.ClusterAlertEraseRequest} message
+ * @param {!proto.openstorage.api.SdkClusterAlertEraseRequest} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterAlertEraseRequest.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkClusterAlertEraseRequest.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
   f = message.getResource();
   if (f !== 0.0) {
@@ -13320,13 +16766,13 @@ proto.openstorage.api.ClusterAlertEraseRequest.serializeBinaryToWriter = functio
  * optional ResourceType resource = 1;
  * @return {!proto.openstorage.api.ResourceType}
  */
-proto.openstorage.api.ClusterAlertEraseRequest.prototype.getResource = function() {
+proto.openstorage.api.SdkClusterAlertEraseRequest.prototype.getResource = function() {
   return /** @type {!proto.openstorage.api.ResourceType} */ (jspb.Message.getFieldWithDefault(this, 1, 0));
 };
 
 
 /** @param {!proto.openstorage.api.ResourceType} value */
-proto.openstorage.api.ClusterAlertEraseRequest.prototype.setResource = function(value) {
+proto.openstorage.api.SdkClusterAlertEraseRequest.prototype.setResource = function(value) {
   jspb.Message.setField(this, 1, value);
 };
 
@@ -13335,13 +16781,13 @@ proto.openstorage.api.ClusterAlertEraseRequest.prototype.setResource = function(
  * optional int64 alert_id = 2;
  * @return {number}
  */
-proto.openstorage.api.ClusterAlertEraseRequest.prototype.getAlertId = function() {
+proto.openstorage.api.SdkClusterAlertEraseRequest.prototype.getAlertId = function() {
   return /** @type {number} */ (jspb.Message.getFieldWithDefault(this, 2, 0));
 };
 
 
 /** @param {number} value */
-proto.openstorage.api.ClusterAlertEraseRequest.prototype.setAlertId = function(value) {
+proto.openstorage.api.SdkClusterAlertEraseRequest.prototype.setAlertId = function(value) {
   jspb.Message.setField(this, 2, value);
 };
 
@@ -13357,12 +16803,12 @@ proto.openstorage.api.ClusterAlertEraseRequest.prototype.setAlertId = function(v
  * @extends {jspb.Message}
  * @constructor
  */
-proto.openstorage.api.ClusterAlertEraseResponse = function(opt_data) {
+proto.openstorage.api.SdkClusterAlertEraseResponse = function(opt_data) {
   jspb.Message.initialize(this, opt_data, 0, -1, null, null);
 };
-goog.inherits(proto.openstorage.api.ClusterAlertEraseResponse, jspb.Message);
+goog.inherits(proto.openstorage.api.SdkClusterAlertEraseResponse, jspb.Message);
 if (goog.DEBUG && !COMPILED) {
-  proto.openstorage.api.ClusterAlertEraseResponse.displayName = 'proto.openstorage.api.ClusterAlertEraseResponse';
+  proto.openstorage.api.SdkClusterAlertEraseResponse.displayName = 'proto.openstorage.api.SdkClusterAlertEraseResponse';
 }
 
 
@@ -13377,8 +16823,8 @@ if (jspb.Message.GENERATE_TO_OBJECT) {
  *     for transitional soy proto support: http://goto/soy-param-migration
  * @return {!Object}
  */
-proto.openstorage.api.ClusterAlertEraseResponse.prototype.toObject = function(opt_includeInstance) {
-  return proto.openstorage.api.ClusterAlertEraseResponse.toObject(opt_includeInstance, this);
+proto.openstorage.api.SdkClusterAlertEraseResponse.prototype.toObject = function(opt_includeInstance) {
+  return proto.openstorage.api.SdkClusterAlertEraseResponse.toObject(opt_includeInstance, this);
 };
 
 
@@ -13387,11 +16833,11 @@ proto.openstorage.api.ClusterAlertEraseResponse.prototype.toObject = function(op
  * @param {boolean|undefined} includeInstance Whether to include the JSPB
  *     instance for transitional soy proto support:
  *     http://goto/soy-param-migration
- * @param {!proto.openstorage.api.ClusterAlertEraseResponse} msg The msg instance to transform.
+ * @param {!proto.openstorage.api.SdkClusterAlertEraseResponse} msg The msg instance to transform.
  * @return {!Object}
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterAlertEraseResponse.toObject = function(includeInstance, msg) {
+proto.openstorage.api.SdkClusterAlertEraseResponse.toObject = function(includeInstance, msg) {
   var f, obj = {
 
   };
@@ -13407,23 +16853,23 @@ proto.openstorage.api.ClusterAlertEraseResponse.toObject = function(includeInsta
 /**
  * Deserializes binary data (in protobuf wire format).
  * @param {jspb.ByteSource} bytes The bytes to deserialize.
- * @return {!proto.openstorage.api.ClusterAlertEraseResponse}
+ * @return {!proto.openstorage.api.SdkClusterAlertEraseResponse}
  */
-proto.openstorage.api.ClusterAlertEraseResponse.deserializeBinary = function(bytes) {
+proto.openstorage.api.SdkClusterAlertEraseResponse.deserializeBinary = function(bytes) {
   var reader = new jspb.BinaryReader(bytes);
-  var msg = new proto.openstorage.api.ClusterAlertEraseResponse;
-  return proto.openstorage.api.ClusterAlertEraseResponse.deserializeBinaryFromReader(msg, reader);
+  var msg = new proto.openstorage.api.SdkClusterAlertEraseResponse;
+  return proto.openstorage.api.SdkClusterAlertEraseResponse.deserializeBinaryFromReader(msg, reader);
 };
 
 
 /**
  * Deserializes binary data (in protobuf wire format) from the
  * given reader into the given message object.
- * @param {!proto.openstorage.api.ClusterAlertEraseResponse} msg The message object to deserialize into.
+ * @param {!proto.openstorage.api.SdkClusterAlertEraseResponse} msg The message object to deserialize into.
  * @param {!jspb.BinaryReader} reader The BinaryReader to use.
- * @return {!proto.openstorage.api.ClusterAlertEraseResponse}
+ * @return {!proto.openstorage.api.SdkClusterAlertEraseResponse}
  */
-proto.openstorage.api.ClusterAlertEraseResponse.deserializeBinaryFromReader = function(msg, reader) {
+proto.openstorage.api.SdkClusterAlertEraseResponse.deserializeBinaryFromReader = function(msg, reader) {
   while (reader.nextField()) {
     if (reader.isEndGroup()) {
       break;
@@ -13443,9 +16889,9 @@ proto.openstorage.api.ClusterAlertEraseResponse.deserializeBinaryFromReader = fu
  * Serializes the message to binary data (in protobuf wire format).
  * @return {!Uint8Array}
  */
-proto.openstorage.api.ClusterAlertEraseResponse.prototype.serializeBinary = function() {
+proto.openstorage.api.SdkClusterAlertEraseResponse.prototype.serializeBinary = function() {
   var writer = new jspb.BinaryWriter();
-  proto.openstorage.api.ClusterAlertEraseResponse.serializeBinaryToWriter(this, writer);
+  proto.openstorage.api.SdkClusterAlertEraseResponse.serializeBinaryToWriter(this, writer);
   return writer.getResultBuffer();
 };
 
@@ -13453,11 +16899,11 @@ proto.openstorage.api.ClusterAlertEraseResponse.prototype.serializeBinary = func
 /**
  * Serializes the given message to binary data (in protobuf wire
  * format), writing to the given BinaryWriter.
- * @param {!proto.openstorage.api.ClusterAlertEraseResponse} message
+ * @param {!proto.openstorage.api.SdkClusterAlertEraseResponse} message
  * @param {!jspb.BinaryWriter} writer
  * @suppress {unusedLocalVariables} f is only used for nested messages
  */
-proto.openstorage.api.ClusterAlertEraseResponse.serializeBinaryToWriter = function(message, writer) {
+proto.openstorage.api.SdkClusterAlertEraseResponse.serializeBinaryToWriter = function(message, writer) {
   var f = undefined;
 };
 

--- a/api/client/sdk/python/api_pb2.py
+++ b/api/client/sdk/python/api_pb2.py
@@ -22,7 +22,7 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='api.proto',
   package='openstorage.api',
   syntax='proto3',
-  serialized_pb=_b('\n\tapi.proto\x12\x0fopenstorage.api\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cgoogle/api/annotations.proto\"\xa3\x02\n\x0fStorageResource\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12.\n\x06medium\x18\x03 \x01(\x0e\x32\x1e.openstorage.api.StorageMedium\x12\x0e\n\x06online\x18\x04 \x01(\x08\x12\x0c\n\x04iops\x18\x05 \x01(\x04\x12\x11\n\tseq_write\x18\x06 \x01(\x01\x12\x10\n\x08seq_read\x18\x07 \x01(\x01\x12\x0e\n\x06randRW\x18\x08 \x01(\x01\x12\x0c\n\x04size\x18\t \x01(\x04\x12\x0c\n\x04used\x18\n \x01(\x04\x12\x16\n\x0erotation_speed\x18\x0b \x01(\t\x12-\n\tlast_scan\x18\x0c \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x10\n\x08metadata\x18\r \x01(\x08\"\x8d\x02\n\x0bStoragePool\x12\n\n\x02ID\x18\x01 \x01(\x05\x12%\n\x03\x43os\x18\x02 \x01(\x0e\x32\x18.openstorage.api.CosType\x12.\n\x06Medium\x18\x03 \x01(\x0e\x32\x1e.openstorage.api.StorageMedium\x12\x11\n\tRaidLevel\x18\x04 \x01(\t\x12\x11\n\tTotalSize\x18\x07 \x01(\x04\x12\x0c\n\x04Used\x18\x08 \x01(\x04\x12\x38\n\x06labels\x18\t \x03(\x0b\x32(.openstorage.api.StoragePool.LabelsEntry\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x9b\x01\n\rVolumeLocator\x12\x0c\n\x04name\x18\x01 \x01(\t\x12G\n\rvolume_labels\x18\x02 \x03(\x0b\x32\x30.openstorage.api.VolumeLocator.VolumeLabelsEntry\x1a\x33\n\x11VolumeLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"&\n\x06Source\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x0c\n\x04seed\x18\x02 \x01(\t\"\x13\n\x05Group\x12\n\n\x02id\x18\x01 \x01(\t\"\xbf\x05\n\nVolumeSpec\x12\x11\n\tephemeral\x18\x01 \x01(\x08\x12\x0c\n\x04size\x18\x02 \x01(\x04\x12\'\n\x06\x66ormat\x18\x03 \x01(\x0e\x32\x17.openstorage.api.FSType\x12\x12\n\nblock_size\x18\x04 \x01(\x03\x12\x10\n\x08ha_level\x18\x05 \x01(\x03\x12%\n\x03\x63os\x18\x06 \x01(\x0e\x32\x18.openstorage.api.CosType\x12.\n\nio_profile\x18\x07 \x01(\x0e\x32\x1a.openstorage.api.IoProfile\x12\x0e\n\x06\x64\x65\x64upe\x18\x08 \x01(\x08\x12\x19\n\x11snapshot_interval\x18\t \x01(\r\x12\x44\n\rvolume_labels\x18\n \x03(\x0b\x32-.openstorage.api.VolumeSpec.VolumeLabelsEntry\x12\x0e\n\x06shared\x18\x0b \x01(\x08\x12\x30\n\x0breplica_set\x18\x0c \x01(\x0b\x32\x1b.openstorage.api.ReplicaSet\x12\x19\n\x11\x61ggregation_level\x18\r \x01(\r\x12\x11\n\tencrypted\x18\x0e \x01(\x08\x12\x12\n\npassphrase\x18\x0f \x01(\t\x12\x19\n\x11snapshot_schedule\x18\x10 \x01(\t\x12\r\n\x05scale\x18\x11 \x01(\r\x12\x0e\n\x06sticky\x18\x12 \x01(\x08\x12%\n\x05group\x18\x15 \x01(\x0b\x32\x16.openstorage.api.Group\x12\x16\n\x0egroup_enforced\x18\x16 \x01(\x08\x12\x12\n\ncompressed\x18\x17 \x01(\x08\x12\x10\n\x08\x63\x61scaded\x18\x18 \x01(\x08\x12\x0f\n\x07journal\x18\x19 \x01(\x08\x12\x10\n\x08sharedv4\x18\x1a \x01(\x08\x1a\x33\n\x11VolumeLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x1b\n\nReplicaSet\x12\r\n\x05nodes\x18\x01 \x03(\t\"\x91\x01\n\x0fRuntimeStateMap\x12I\n\rruntime_state\x18\x01 \x03(\x0b\x32\x32.openstorage.api.RuntimeStateMap.RuntimeStateEntry\x1a\x33\n\x11RuntimeStateEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xf8\x06\n\x06Volume\x12\n\n\x02id\x18\x01 \x01(\t\x12\'\n\x06source\x18\x02 \x01(\x0b\x32\x17.openstorage.api.Source\x12%\n\x05group\x18\x03 \x01(\x0b\x32\x16.openstorage.api.Group\x12\x10\n\x08readonly\x18\x04 \x01(\x08\x12/\n\x07locator\x18\x05 \x01(\x0b\x32\x1e.openstorage.api.VolumeLocator\x12)\n\x05\x63time\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12)\n\x04spec\x18\x07 \x01(\x0b\x32\x1b.openstorage.api.VolumeSpec\x12\r\n\x05usage\x18\x08 \x01(\x04\x12-\n\tlast_scan\x18\t \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\'\n\x06\x66ormat\x18\n \x01(\x0e\x32\x17.openstorage.api.FSType\x12-\n\x06status\x18\x0b \x01(\x0e\x32\x1d.openstorage.api.VolumeStatus\x12+\n\x05state\x18\x0c \x01(\x0e\x32\x1c.openstorage.api.VolumeState\x12\x13\n\x0b\x61ttached_on\x18\r \x01(\t\x12\x34\n\x0e\x61ttached_state\x18\x0e \x01(\x0e\x32\x1c.openstorage.api.AttachState\x12\x13\n\x0b\x64\x65vice_path\x18\x0f \x01(\t\x12\x1a\n\x12secure_device_path\x18\x10 \x01(\t\x12\x13\n\x0b\x61ttach_path\x18\x11 \x03(\t\x12<\n\x0b\x61ttach_info\x18\x12 \x03(\x0b\x32\'.openstorage.api.Volume.AttachInfoEntry\x12\x31\n\x0creplica_sets\x18\x13 \x03(\x0b\x32\x1b.openstorage.api.ReplicaSet\x12\x37\n\rruntime_state\x18\x14 \x03(\x0b\x32 .openstorage.api.RuntimeStateMap\x12\r\n\x05\x65rror\x18\x15 \x01(\t\x12\x39\n\x10volume_consumers\x18\x16 \x03(\x0b\x32\x1f.openstorage.api.VolumeConsumer\x1a\x31\n\x0f\x41ttachInfoEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xbf\x01\n\x05Stats\x12\r\n\x05reads\x18\x01 \x01(\x04\x12\x0f\n\x07read_ms\x18\x02 \x01(\x04\x12\x12\n\nread_bytes\x18\x03 \x01(\x04\x12\x0e\n\x06writes\x18\x04 \x01(\x04\x12\x10\n\x08write_ms\x18\x05 \x01(\x04\x12\x13\n\x0bwrite_bytes\x18\x06 \x01(\x04\x12\x13\n\x0bio_progress\x18\x07 \x01(\x04\x12\r\n\x05io_ms\x18\x08 \x01(\x04\x12\x12\n\nbytes_used\x18\t \x01(\x04\x12\x13\n\x0binterval_ms\x18\n \x01(\x04\"\x90\x02\n\x05\x41lert\x12\n\n\x02id\x18\x01 \x01(\x03\x12/\n\x08severity\x18\x02 \x01(\x0e\x32\x1d.openstorage.api.SeverityType\x12\x12\n\nalert_type\x18\x03 \x01(\x03\x12\x0f\n\x07message\x18\x04 \x01(\t\x12-\n\ttimestamp\x18\x05 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x13\n\x0bresource_id\x18\x06 \x01(\t\x12/\n\x08resource\x18\x07 \x01(\x0e\x32\x1d.openstorage.api.ResourceType\x12\x0f\n\x07\x63leared\x18\x08 \x01(\x08\x12\x0b\n\x03ttl\x18\t \x01(\x04\x12\x12\n\nunique_tag\x18\n \x01(\t\"/\n\x06\x41lerts\x12%\n\x05\x61lert\x18\x01 \x03(\x0b\x32\x16.openstorage.api.Alert\"\x9a\x01\n\x13VolumeCreateRequest\x12/\n\x07locator\x18\x01 \x01(\x0b\x32\x1e.openstorage.api.VolumeLocator\x12\'\n\x06source\x18\x02 \x01(\x0b\x32\x17.openstorage.api.Source\x12)\n\x04spec\x18\x03 \x01(\x0b\x32\x1b.openstorage.api.VolumeSpec\"\x1f\n\x0eVolumeResponse\x12\r\n\x05\x65rror\x18\x01 \x01(\t\"\\\n\x14VolumeCreateResponse\x12\n\n\x02id\x18\x01 \x01(\t\x12\x38\n\x0fvolume_response\x18\x02 \x01(\x0b\x32\x1f.openstorage.api.VolumeResponse\"\xa3\x01\n\x11VolumeStateAction\x12\x32\n\x06\x61ttach\x18\x01 \x01(\x0e\x32\".openstorage.api.VolumeActionParam\x12\x31\n\x05mount\x18\x02 \x01(\x0e\x32\".openstorage.api.VolumeActionParam\x12\x12\n\nmount_path\x18\x03 \x01(\t\x12\x13\n\x0b\x64\x65vice_path\x18\x04 \x01(\t\"\x93\x02\n\x10VolumeSetRequest\x12/\n\x07locator\x18\x01 \x01(\x0b\x32\x1e.openstorage.api.VolumeLocator\x12)\n\x04spec\x18\x02 \x01(\x0b\x32\x1b.openstorage.api.VolumeSpec\x12\x32\n\x06\x61\x63tion\x18\x03 \x01(\x0b\x32\".openstorage.api.VolumeStateAction\x12?\n\x07options\x18\x04 \x03(\x0b\x32..openstorage.api.VolumeSetRequest.OptionsEntry\x1a.\n\x0cOptionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"v\n\x11VolumeSetResponse\x12\'\n\x06volume\x18\x01 \x01(\x0b\x32\x17.openstorage.api.Volume\x12\x38\n\x0fvolume_response\x18\x02 \x01(\x0b\x32\x1f.openstorage.api.VolumeResponse\"b\n\x11SnapCreateRequest\x12\n\n\x02id\x18\x01 \x01(\t\x12/\n\x07locator\x18\x02 \x01(\x0b\x32\x1e.openstorage.api.VolumeLocator\x12\x10\n\x08readonly\x18\x03 \x01(\x08\"[\n\x12SnapCreateResponse\x12\x45\n\x16volume_create_response\x18\x01 \x01(\x0b\x32%.openstorage.api.VolumeCreateResponse\"[\n\nVolumeInfo\x12\x11\n\tvolume_id\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12,\n\x07storage\x18\x03 \x01(\x0b\x32\x1b.openstorage.api.VolumeSpec\"x\n\x0eVolumeConsumer\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tnamespace\x18\x02 \x01(\t\x12\x0c\n\x04type\x18\x03 \x01(\t\x12\x0f\n\x07node_id\x18\x04 \x01(\t\x12\x12\n\nowner_name\x18\x05 \x01(\t\x12\x12\n\nowner_type\x18\x06 \x01(\t\"X\n\x12GraphDriverChanges\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x34\n\x04kind\x18\x02 \x01(\x0e\x32&.openstorage.api.GraphDriverChangeType\" \n\x0f\x43lusterResponse\x12\r\n\x05\x65rror\x18\x01 \x01(\t\"\x80\x01\n\rActiveRequest\x12>\n\x08ReqestKV\x18\x01 \x03(\x0b\x32,.openstorage.api.ActiveRequest.ReqestKVEntry\x1a/\n\rReqestKVEntry\x12\x0b\n\x03key\x18\x01 \x01(\x03\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"]\n\x0e\x41\x63tiveRequests\x12\x14\n\x0cRequestCount\x18\x01 \x01(\x03\x12\x35\n\rActiveRequest\x18\x02 \x03(\x0b\x32\x1e.openstorage.api.ActiveRequest\"\x98\x01\n\x16GroupSnapCreateRequest\x12\n\n\x02id\x18\x01 \x01(\t\x12\x43\n\x06Labels\x18\x02 \x03(\x0b\x32\x33.openstorage.api.GroupSnapCreateRequest.LabelsEntry\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xcb\x01\n\x17GroupSnapCreateResponse\x12J\n\tsnapshots\x18\x01 \x03(\x0b\x32\x37.openstorage.api.GroupSnapCreateResponse.SnapshotsEntry\x12\r\n\x05\x65rror\x18\x02 \x01(\t\x1aU\n\x0eSnapshotsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x32\n\x05value\x18\x02 \x01(\x0b\x32#.openstorage.api.SnapCreateResponse:\x02\x38\x01\"\xf7\x03\n\x0bStorageNode\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0b\n\x03\x63pu\x18\x02 \x01(\x01\x12\x11\n\tmem_total\x18\x03 \x01(\x04\x12\x10\n\x08mem_used\x18\x04 \x01(\x04\x12\x10\n\x08mem_free\x18\x05 \x01(\x04\x12\x10\n\x08\x61vg_load\x18\x06 \x01(\x03\x12\'\n\x06status\x18\x07 \x01(\x0e\x32\x17.openstorage.api.Status\x12\x36\n\x05\x64isks\x18\t \x03(\x0b\x32\'.openstorage.api.StorageNode.DisksEntry\x12+\n\x05pools\x18\n \x03(\x0b\x32\x1c.openstorage.api.StoragePool\x12\x0f\n\x07mgmt_ip\x18\x0b \x01(\t\x12\x0f\n\x07\x64\x61ta_ip\x18\x0c \x01(\t\x12\x10\n\x08hostname\x18\x0f \x01(\t\x12\x41\n\x0bnode_labels\x18\x10 \x03(\x0b\x32,.openstorage.api.StorageNode.NodeLabelsEntry\x1aN\n\nDisksEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12/\n\x05value\x18\x02 \x01(\x0b\x32 .openstorage.api.StorageResource:\x02\x38\x01\x1a\x31\n\x0fNodeLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x83\x01\n\x0eStorageCluster\x12\'\n\x06status\x18\x01 \x01(\x0e\x32\x17.openstorage.api.Status\x12\n\n\x02id\x18\x02 \x01(\t\x12\x0f\n\x07node_id\x18\x03 \x01(\t\x12+\n\x05nodes\x18\x04 \x03(\x0b\x32\x1c.openstorage.api.StorageNode\"\xae\x01\n\x12VolumeMountRequest\x12\x11\n\tvolume_id\x18\x01 \x01(\t\x12\x12\n\nmount_path\x18\x02 \x01(\t\x12\x41\n\x07options\x18\x03 \x03(\x0b\x32\x30.openstorage.api.VolumeMountRequest.OptionsEntry\x1a.\n\x0cOptionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x15\n\x13VolumeMountResponse\"\xb2\x01\n\x14VolumeUnmountRequest\x12\x11\n\tvolume_id\x18\x01 \x01(\t\x12\x12\n\nmount_path\x18\x02 \x01(\t\x12\x43\n\x07options\x18\x03 \x03(\x0b\x32\x32.openstorage.api.VolumeUnmountRequest.OptionsEntry\x1a.\n\x0cOptionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x17\n\x15VolumeUnmountResponse\"\x9c\x01\n\x13VolumeAttachRequest\x12\x11\n\tvolume_id\x18\x01 \x01(\t\x12\x42\n\x07options\x18\x02 \x03(\x0b\x32\x31.openstorage.api.VolumeAttachRequest.OptionsEntry\x1a.\n\x0cOptionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"+\n\x14VolumeAttachResponse\x12\x13\n\x0b\x64\x65vice_path\x18\x01 \x01(\t\"(\n\x13VolumeDetachRequest\x12\x11\n\tvolume_id\x18\x01 \x01(\t\"\x16\n\x14VolumeDetachResponse\"Y\n\x1eOpenStorageVolumeCreateRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12)\n\x04spec\x18\x02 \x01(\x0b\x32\x1b.openstorage.api.VolumeSpec\"4\n\x1fOpenStorageVolumeCreateResponse\x12\x11\n\tvolume_id\x18\x01 \x01(\t\"m\n\x1fVolumeCreateFromVolumeIDRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tparent_id\x18\x02 \x01(\t\x12)\n\x04spec\x18\x03 \x01(\x0b\x32\x1b.openstorage.api.VolumeSpec\"5\n VolumeCreateFromVolumeIDResponse\x12\x11\n\tvolume_id\x18\x01 \x01(\t\"(\n\x13VolumeDeleteRequest\x12\x11\n\tvolume_id\x18\x01 \x01(\t\"\x16\n\x14VolumeDeleteResponse\")\n\x14VolumeInspectRequest\x12\x11\n\tvolume_id\x18\x01 \x01(\t\"@\n\x15VolumeInspectResponse\x12\'\n\x06volume\x18\x01 \x01(\x0b\x32\x17.openstorage.api.Volume\"I\n\x16VolumeEnumerateRequest\x12/\n\x07locator\x18\x01 \x01(\x0b\x32\x1e.openstorage.api.VolumeLocator\"C\n\x17VolumeEnumerateResponse\x12(\n\x07volumes\x18\x01 \x03(\x0b\x32\x17.openstorage.api.Volume\"\xa9\x01\n\x1bVolumeSnapshotCreateRequest\x12\x11\n\tvolume_id\x18\x01 \x01(\t\x12H\n\x06labels\x18\x02 \x03(\x0b\x32\x38.openstorage.api.VolumeSnapshotCreateRequest.LabelsEntry\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"3\n\x1cVolumeSnapshotCreateResponse\x12\x13\n\x0bsnapshot_id\x18\x01 \x01(\t\"F\n\x1cVolumeSnapshotRestoreRequest\x12\x11\n\tvolume_id\x18\x01 \x01(\t\x12\x13\n\x0bsnapshot_id\x18\x02 \x01(\t\"\x1f\n\x1dVolumeSnapshotRestoreResponse\"\xaf\x01\n\x1eVolumeSnapshotEnumerateRequest\x12\x11\n\tvolume_id\x18\x01 \x01(\t\x12K\n\x06labels\x18\x02 \x03(\x0b\x32;.openstorage.api.VolumeSnapshotEnumerateRequest.LabelsEntry\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"M\n\x1fVolumeSnapshotEnumerateResponse\x12*\n\tsnapshots\x18\x01 \x03(\x0b\x32\x17.openstorage.api.Volume\"\x19\n\x17\x43lusterEnumerateRequest\"L\n\x18\x43lusterEnumerateResponse\x12\x30\n\x07\x63luster\x18\x01 \x01(\x0b\x32\x1f.openstorage.api.StorageCluster\"(\n\x15\x43lusterInspectRequest\x12\x0f\n\x07node_id\x18\x01 \x01(\t\"D\n\x16\x43lusterInspectResponse\x12*\n\x04node\x18\x01 \x01(\x0b\x32\x1c.openstorage.api.StorageNode\"\xad\x01\n\x1c\x43lusterAlertEnumerateRequest\x12.\n\ntime_start\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08time_end\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12/\n\x08resource\x18\x03 \x01(\x0e\x32\x1d.openstorage.api.ResourceType\"H\n\x1d\x43lusterAlertEnumerateResponse\x12\'\n\x06\x61lerts\x18\x01 \x01(\x0b\x32\x17.openstorage.api.Alerts\"]\n\x18\x43lusterAlertClearRequest\x12/\n\x08resource\x18\x01 \x01(\x0e\x32\x1d.openstorage.api.ResourceType\x12\x10\n\x08\x61lert_id\x18\x02 \x01(\x03\"\x1b\n\x19\x43lusterAlertClearResponse\"]\n\x18\x43lusterAlertEraseRequest\x12/\n\x08resource\x18\x01 \x01(\x0e\x32\x1d.openstorage.api.ResourceType\x12\x10\n\x08\x61lert_id\x18\x02 \x01(\x03\"\x1b\n\x19\x43lusterAlertEraseResponse*\xee\x02\n\x06Status\x12\x0f\n\x0bSTATUS_NONE\x10\x00\x12\x0f\n\x0bSTATUS_INIT\x10\x01\x12\r\n\tSTATUS_OK\x10\x02\x12\x12\n\x0eSTATUS_OFFLINE\x10\x03\x12\x10\n\x0cSTATUS_ERROR\x10\x04\x12\x18\n\x14STATUS_NOT_IN_QUORUM\x10\x05\x12\x17\n\x13STATUS_DECOMMISSION\x10\x06\x12\x16\n\x12STATUS_MAINTENANCE\x10\x07\x12\x17\n\x13STATUS_STORAGE_DOWN\x10\x08\x12\x1b\n\x17STATUS_STORAGE_DEGRADED\x10\t\x12\x17\n\x13STATUS_NEEDS_REBOOT\x10\n\x12\x1c\n\x18STATUS_STORAGE_REBALANCE\x10\x0b\x12 \n\x1cSTATUS_STORAGE_DRIVE_REPLACE\x10\x0c\x12#\n\x1fSTATUS_NOT_IN_QUORUM_NO_STORAGE\x10\r\x12\x0e\n\nSTATUS_MAX\x10\x0e*\x99\x01\n\nDriverType\x12\x14\n\x10\x44RIVER_TYPE_NONE\x10\x00\x12\x14\n\x10\x44RIVER_TYPE_FILE\x10\x01\x12\x15\n\x11\x44RIVER_TYPE_BLOCK\x10\x02\x12\x16\n\x12\x44RIVER_TYPE_OBJECT\x10\x03\x12\x19\n\x15\x44RIVER_TYPE_CLUSTERED\x10\x04\x12\x15\n\x11\x44RIVER_TYPE_GRAPH\x10\x05*\x95\x01\n\x06\x46SType\x12\x10\n\x0c\x46S_TYPE_NONE\x10\x00\x12\x11\n\rFS_TYPE_BTRFS\x10\x01\x12\x10\n\x0c\x46S_TYPE_EXT4\x10\x02\x12\x10\n\x0c\x46S_TYPE_FUSE\x10\x03\x12\x0f\n\x0b\x46S_TYPE_NFS\x10\x04\x12\x0f\n\x0b\x46S_TYPE_VFS\x10\x05\x12\x0f\n\x0b\x46S_TYPE_XFS\x10\x06\x12\x0f\n\x0b\x46S_TYPE_ZFS\x10\x07*\xab\x01\n\x15GraphDriverChangeType\x12!\n\x1dGRAPH_DRIVER_CHANGE_TYPE_NONE\x10\x00\x12%\n!GRAPH_DRIVER_CHANGE_TYPE_MODIFIED\x10\x01\x12\"\n\x1eGRAPH_DRIVER_CHANGE_TYPE_ADDED\x10\x02\x12$\n GRAPH_DRIVER_CHANGE_TYPE_DELETED\x10\x03*t\n\x0cSeverityType\x12\x16\n\x12SEVERITY_TYPE_NONE\x10\x00\x12\x17\n\x13SEVERITY_TYPE_ALARM\x10\x01\x12\x19\n\x15SEVERITY_TYPE_WARNING\x10\x02\x12\x18\n\x14SEVERITY_TYPE_NOTIFY\x10\x03*\x8c\x01\n\x0cResourceType\x12\x16\n\x12RESOURCE_TYPE_NONE\x10\x00\x12\x18\n\x14RESOURCE_TYPE_VOLUME\x10\x01\x12\x16\n\x12RESOURCE_TYPE_NODE\x10\x02\x12\x19\n\x15RESOURCE_TYPE_CLUSTER\x10\x03\x12\x17\n\x13RESOURCE_TYPE_DRIVE\x10\x04*\x87\x01\n\x0f\x41lertActionType\x12\x1a\n\x16\x41LERT_ACTION_TYPE_NONE\x10\x00\x12\x1c\n\x18\x41LERT_ACTION_TYPE_DELETE\x10\x01\x12\x1c\n\x18\x41LERT_ACTION_TYPE_CREATE\x10\x02\x12\x1c\n\x18\x41LERT_ACTION_TYPE_UPDATE\x10\x03*j\n\x11VolumeActionParam\x12\x1c\n\x18VOLUME_ACTION_PARAM_NONE\x10\x00\x12\x1b\n\x17VOLUME_ACTION_PARAM_OFF\x10\x01\x12\x1a\n\x16VOLUME_ACTION_PARAM_ON\x10\x02*2\n\x07\x43osType\x12\x08\n\x04NONE\x10\x00\x12\x07\n\x03LOW\x10\x01\x12\n\n\x06MEDIUM\x10\x02\x12\x08\n\x04HIGH\x10\x03*~\n\tIoProfile\x12\x19\n\x15IO_PROFILE_SEQUENTIAL\x10\x00\x12\x15\n\x11IO_PROFILE_RANDOM\x10\x01\x12\x11\n\rIO_PROFILE_DB\x10\x02\x12\x18\n\x14IO_PROFILE_DB_REMOTE\x10\x03\x12\x12\n\x0eIO_PROFILE_CMS\x10\x04*\x99\x02\n\x0bVolumeState\x12\x15\n\x11VOLUME_STATE_NONE\x10\x00\x12\x18\n\x14VOLUME_STATE_PENDING\x10\x01\x12\x1a\n\x16VOLUME_STATE_AVAILABLE\x10\x02\x12\x19\n\x15VOLUME_STATE_ATTACHED\x10\x03\x12\x19\n\x15VOLUME_STATE_DETACHED\x10\x04\x12\x1b\n\x17VOLUME_STATE_DETATCHING\x10\x05\x12\x16\n\x12VOLUME_STATE_ERROR\x10\x06\x12\x18\n\x14VOLUME_STATE_DELETED\x10\x07\x12\x1e\n\x1aVOLUME_STATE_TRY_DETACHING\x10\x08\x12\x18\n\x14VOLUME_STATE_RESTORE\x10\t*\x8f\x01\n\x0cVolumeStatus\x12\x16\n\x12VOLUME_STATUS_NONE\x10\x00\x12\x1d\n\x19VOLUME_STATUS_NOT_PRESENT\x10\x01\x12\x14\n\x10VOLUME_STATUS_UP\x10\x02\x12\x16\n\x12VOLUME_STATUS_DOWN\x10\x03\x12\x1a\n\x16VOLUME_STATUS_DEGRADED\x10\x04*]\n\rStorageMedium\x12\x1b\n\x17STORAGE_MEDIUM_MAGNETIC\x10\x00\x12\x16\n\x12STORAGE_MEDIUM_SSD\x10\x01\x12\x17\n\x13STORAGE_MEDIUM_NVME\x10\x02*(\n\rClusterNotify\x12\x17\n\x13\x43LUSTER_NOTIFY_DOWN\x10\x00*e\n\x0b\x41ttachState\x12\x19\n\x15\x41TTACH_STATE_EXTERNAL\x10\x00\x12\x19\n\x15\x41TTACH_STATE_INTERNAL\x10\x01\x12 \n\x1c\x41TTACH_STATE_INTERNAL_SWITCH\x10\x02*T\n\x0eOperationFlags\x12\x14\n\x10OP_FLAGS_UNKNOWN\x10\x00\x12\x11\n\rOP_FLAGS_NONE\x10\x01\x12\x19\n\x15OP_FLAGS_DETACH_FORCE\x10\x02\x32\xc3\x05\n\x12OpenStorageCluster\x12\x82\x01\n\tEnumerate\x12(.openstorage.api.ClusterEnumerateRequest\x1a).openstorage.api.ClusterEnumerateResponse\" \x82\xd3\xe4\x93\x02\x1a\"\x15/v1/cluster/enumerate:\x01*\x12z\n\x07Inspect\x12&.openstorage.api.ClusterInspectRequest\x1a\'.openstorage.api.ClusterInspectResponse\"\x1e\x82\xd3\xe4\x93\x02\x18\"\x13/v1/cluster/inspect:\x01*\x12\x97\x01\n\x0e\x41lertEnumerate\x12-.openstorage.api.ClusterAlertEnumerateRequest\x1a..openstorage.api.ClusterAlertEnumerateResponse\"&\x82\xd3\xe4\x93\x02 \"\x1b/v1/cluster/alert/enumerate:\x01*\x12\x87\x01\n\nAlertClear\x12).openstorage.api.ClusterAlertClearRequest\x1a*.openstorage.api.ClusterAlertClearResponse\"\"\x82\xd3\xe4\x93\x02\x1c\"\x17/v1/cluster/alert/clear:\x01*\x12\x87\x01\n\nAlertErase\x12).openstorage.api.ClusterAlertEraseRequest\x1a*.openstorage.api.ClusterAlertEraseResponse\"\"\x82\xd3\xe4\x93\x02\x1c\"\x17/v1/cluster/alert/erase:\x01*2\xd7\x0c\n\x11OpenStorageVolume\x12\x89\x01\n\x06\x43reate\x12/.openstorage.api.OpenStorageVolumeCreateRequest\x1a\x30.openstorage.api.OpenStorageVolumeCreateResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\"\x11/v1/volume/create:\x01*\x12\x9d\x01\n\x12\x43reateFromVolumeID\x12\x30.openstorage.api.VolumeCreateFromVolumeIDRequest\x1a\x31.openstorage.api.VolumeCreateFromVolumeIDResponse\"\"\x82\xd3\xe4\x93\x02\x1c\"\x17/v1/volume/createfromid:\x01*\x12s\n\x06\x44\x65lete\x12$.openstorage.api.VolumeDeleteRequest\x1a%.openstorage.api.VolumeDeleteResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\"\x11/v1/volume/delete:\x01*\x12w\n\x07Inspect\x12%.openstorage.api.VolumeInspectRequest\x1a&.openstorage.api.VolumeInspectResponse\"\x1d\x82\xd3\xe4\x93\x02\x17\"\x12/v1/volume/inspect:\x01*\x12\x7f\n\tEnumerate\x12\'.openstorage.api.VolumeEnumerateRequest\x1a(.openstorage.api.VolumeEnumerateResponse\"\x1f\x82\xd3\xe4\x93\x02\x19\"\x14/v1/volume/enumerate:\x01*\x12\x94\x01\n\x0eSnapshotCreate\x12,.openstorage.api.VolumeSnapshotCreateRequest\x1a-.openstorage.api.VolumeSnapshotCreateResponse\"%\x82\xd3\xe4\x93\x02\x1f\"\x1a/v1/volume/snapshot/create:\x01*\x12\x98\x01\n\x0fSnapshotRestore\x12-.openstorage.api.VolumeSnapshotRestoreRequest\x1a..openstorage.api.VolumeSnapshotRestoreResponse\"&\x82\xd3\xe4\x93\x02 \"\x1b/v1/volume/snapshot/restore:\x01*\x12\xa0\x01\n\x11SnapshotEnumerate\x12/.openstorage.api.VolumeSnapshotEnumerateRequest\x1a\x30.openstorage.api.VolumeSnapshotEnumerateResponse\"(\x82\xd3\xe4\x93\x02\"\"\x1d/v1/volume/snapshot/enumerate:\x01*\x12s\n\x06\x41ttach\x12$.openstorage.api.VolumeAttachRequest\x1a%.openstorage.api.VolumeAttachResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\"\x11/v1/volume/attach:\x01*\x12s\n\x06\x44\x65tach\x12$.openstorage.api.VolumeDetachRequest\x1a%.openstorage.api.VolumeDetachResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\"\x11/v1/volume/detach:\x01*\x12o\n\x05Mount\x12#.openstorage.api.VolumeMountRequest\x1a$.openstorage.api.VolumeMountResponse\"\x1b\x82\xd3\xe4\x93\x02\x15\"\x10/v1/volume/mount:\x01*\x12w\n\x07Unmount\x12%.openstorage.api.VolumeUnmountRequest\x1a&.openstorage.api.VolumeUnmountResponse\"\x1d\x82\xd3\xe4\x93\x02\x17\"\x12/v1/volume/unmount:\x01*B\x1c\n\x13\x63om.openstorage.apiP\x01Z\x03\x61pib\x06proto3')
+  serialized_pb=_b('\n\tapi.proto\x12\x0fopenstorage.api\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1cgoogle/api/annotations.proto\"\xa3\x02\n\x0fStorageResource\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12.\n\x06medium\x18\x03 \x01(\x0e\x32\x1e.openstorage.api.StorageMedium\x12\x0e\n\x06online\x18\x04 \x01(\x08\x12\x0c\n\x04iops\x18\x05 \x01(\x04\x12\x11\n\tseq_write\x18\x06 \x01(\x01\x12\x10\n\x08seq_read\x18\x07 \x01(\x01\x12\x0e\n\x06randRW\x18\x08 \x01(\x01\x12\x0c\n\x04size\x18\t \x01(\x04\x12\x0c\n\x04used\x18\n \x01(\x04\x12\x16\n\x0erotation_speed\x18\x0b \x01(\t\x12-\n\tlast_scan\x18\x0c \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x10\n\x08metadata\x18\r \x01(\x08\"\x8d\x02\n\x0bStoragePool\x12\n\n\x02ID\x18\x01 \x01(\x05\x12%\n\x03\x43os\x18\x02 \x01(\x0e\x32\x18.openstorage.api.CosType\x12.\n\x06Medium\x18\x03 \x01(\x0e\x32\x1e.openstorage.api.StorageMedium\x12\x11\n\tRaidLevel\x18\x04 \x01(\t\x12\x11\n\tTotalSize\x18\x07 \x01(\x04\x12\x0c\n\x04Used\x18\x08 \x01(\x04\x12\x38\n\x06labels\x18\t \x03(\x0b\x32(.openstorage.api.StoragePool.LabelsEntry\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x9b\x01\n\rVolumeLocator\x12\x0c\n\x04name\x18\x01 \x01(\t\x12G\n\rvolume_labels\x18\x02 \x03(\x0b\x32\x30.openstorage.api.VolumeLocator.VolumeLabelsEntry\x1a\x33\n\x11VolumeLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"&\n\x06Source\x12\x0e\n\x06parent\x18\x01 \x01(\t\x12\x0c\n\x04seed\x18\x02 \x01(\t\"\x13\n\x05Group\x12\n\n\x02id\x18\x01 \x01(\t\"\xbf\x05\n\nVolumeSpec\x12\x11\n\tephemeral\x18\x01 \x01(\x08\x12\x0c\n\x04size\x18\x02 \x01(\x04\x12\'\n\x06\x66ormat\x18\x03 \x01(\x0e\x32\x17.openstorage.api.FSType\x12\x12\n\nblock_size\x18\x04 \x01(\x03\x12\x10\n\x08ha_level\x18\x05 \x01(\x03\x12%\n\x03\x63os\x18\x06 \x01(\x0e\x32\x18.openstorage.api.CosType\x12.\n\nio_profile\x18\x07 \x01(\x0e\x32\x1a.openstorage.api.IoProfile\x12\x0e\n\x06\x64\x65\x64upe\x18\x08 \x01(\x08\x12\x19\n\x11snapshot_interval\x18\t \x01(\r\x12\x44\n\rvolume_labels\x18\n \x03(\x0b\x32-.openstorage.api.VolumeSpec.VolumeLabelsEntry\x12\x0e\n\x06shared\x18\x0b \x01(\x08\x12\x30\n\x0breplica_set\x18\x0c \x01(\x0b\x32\x1b.openstorage.api.ReplicaSet\x12\x19\n\x11\x61ggregation_level\x18\r \x01(\r\x12\x11\n\tencrypted\x18\x0e \x01(\x08\x12\x12\n\npassphrase\x18\x0f \x01(\t\x12\x19\n\x11snapshot_schedule\x18\x10 \x01(\t\x12\r\n\x05scale\x18\x11 \x01(\r\x12\x0e\n\x06sticky\x18\x12 \x01(\x08\x12%\n\x05group\x18\x15 \x01(\x0b\x32\x16.openstorage.api.Group\x12\x16\n\x0egroup_enforced\x18\x16 \x01(\x08\x12\x12\n\ncompressed\x18\x17 \x01(\x08\x12\x10\n\x08\x63\x61scaded\x18\x18 \x01(\x08\x12\x0f\n\x07journal\x18\x19 \x01(\x08\x12\x10\n\x08sharedv4\x18\x1a \x01(\x08\x1a\x33\n\x11VolumeLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x1b\n\nReplicaSet\x12\r\n\x05nodes\x18\x01 \x03(\t\"\x91\x01\n\x0fRuntimeStateMap\x12I\n\rruntime_state\x18\x01 \x03(\x0b\x32\x32.openstorage.api.RuntimeStateMap.RuntimeStateEntry\x1a\x33\n\x11RuntimeStateEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xf8\x06\n\x06Volume\x12\n\n\x02id\x18\x01 \x01(\t\x12\'\n\x06source\x18\x02 \x01(\x0b\x32\x17.openstorage.api.Source\x12%\n\x05group\x18\x03 \x01(\x0b\x32\x16.openstorage.api.Group\x12\x10\n\x08readonly\x18\x04 \x01(\x08\x12/\n\x07locator\x18\x05 \x01(\x0b\x32\x1e.openstorage.api.VolumeLocator\x12)\n\x05\x63time\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12)\n\x04spec\x18\x07 \x01(\x0b\x32\x1b.openstorage.api.VolumeSpec\x12\r\n\x05usage\x18\x08 \x01(\x04\x12-\n\tlast_scan\x18\t \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\'\n\x06\x66ormat\x18\n \x01(\x0e\x32\x17.openstorage.api.FSType\x12-\n\x06status\x18\x0b \x01(\x0e\x32\x1d.openstorage.api.VolumeStatus\x12+\n\x05state\x18\x0c \x01(\x0e\x32\x1c.openstorage.api.VolumeState\x12\x13\n\x0b\x61ttached_on\x18\r \x01(\t\x12\x34\n\x0e\x61ttached_state\x18\x0e \x01(\x0e\x32\x1c.openstorage.api.AttachState\x12\x13\n\x0b\x64\x65vice_path\x18\x0f \x01(\t\x12\x1a\n\x12secure_device_path\x18\x10 \x01(\t\x12\x13\n\x0b\x61ttach_path\x18\x11 \x03(\t\x12<\n\x0b\x61ttach_info\x18\x12 \x03(\x0b\x32\'.openstorage.api.Volume.AttachInfoEntry\x12\x31\n\x0creplica_sets\x18\x13 \x03(\x0b\x32\x1b.openstorage.api.ReplicaSet\x12\x37\n\rruntime_state\x18\x14 \x03(\x0b\x32 .openstorage.api.RuntimeStateMap\x12\r\n\x05\x65rror\x18\x15 \x01(\t\x12\x39\n\x10volume_consumers\x18\x16 \x03(\x0b\x32\x1f.openstorage.api.VolumeConsumer\x1a\x31\n\x0f\x41ttachInfoEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xbf\x01\n\x05Stats\x12\r\n\x05reads\x18\x01 \x01(\x04\x12\x0f\n\x07read_ms\x18\x02 \x01(\x04\x12\x12\n\nread_bytes\x18\x03 \x01(\x04\x12\x0e\n\x06writes\x18\x04 \x01(\x04\x12\x10\n\x08write_ms\x18\x05 \x01(\x04\x12\x13\n\x0bwrite_bytes\x18\x06 \x01(\x04\x12\x13\n\x0bio_progress\x18\x07 \x01(\x04\x12\r\n\x05io_ms\x18\x08 \x01(\x04\x12\x12\n\nbytes_used\x18\t \x01(\x04\x12\x13\n\x0binterval_ms\x18\n \x01(\x04\"\x90\x02\n\x05\x41lert\x12\n\n\x02id\x18\x01 \x01(\x03\x12/\n\x08severity\x18\x02 \x01(\x0e\x32\x1d.openstorage.api.SeverityType\x12\x12\n\nalert_type\x18\x03 \x01(\x03\x12\x0f\n\x07message\x18\x04 \x01(\t\x12-\n\ttimestamp\x18\x05 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x13\n\x0bresource_id\x18\x06 \x01(\t\x12/\n\x08resource\x18\x07 \x01(\x0e\x32\x1d.openstorage.api.ResourceType\x12\x0f\n\x07\x63leared\x18\x08 \x01(\x08\x12\x0b\n\x03ttl\x18\t \x01(\x04\x12\x12\n\nunique_tag\x18\n \x01(\t\"/\n\x06\x41lerts\x12%\n\x05\x61lert\x18\x01 \x03(\x0b\x32\x16.openstorage.api.Alert\"\xdd\x01\n\x0fObjectstoreInfo\x12\x0c\n\x04uuid\x18\x01 \x01(\t\x12\x11\n\tvolume_id\x18\x02 \x01(\t\x12\x0f\n\x07\x65nabled\x18\x03 \x01(\x08\x12\x0e\n\x06status\x18\x04 \x01(\t\x12\x0e\n\x06\x61\x63tion\x18\x05 \x01(\x03\x12\x12\n\naccess_key\x18\x06 \x01(\t\x12\x12\n\nsecret_key\x18\x07 \x01(\t\x12\x11\n\tendpoints\x18\x08 \x03(\t\x12\x18\n\x10\x63urrent_endPoint\x18\t \x01(\t\x12\x13\n\x0b\x61\x63\x63\x65ss_port\x18\n \x01(\x03\x12\x0e\n\x06region\x18\x0b \x01(\t\"\x9a\x01\n\x13VolumeCreateRequest\x12/\n\x07locator\x18\x01 \x01(\x0b\x32\x1e.openstorage.api.VolumeLocator\x12\'\n\x06source\x18\x02 \x01(\x0b\x32\x17.openstorage.api.Source\x12)\n\x04spec\x18\x03 \x01(\x0b\x32\x1b.openstorage.api.VolumeSpec\"\x1f\n\x0eVolumeResponse\x12\r\n\x05\x65rror\x18\x01 \x01(\t\"\\\n\x14VolumeCreateResponse\x12\n\n\x02id\x18\x01 \x01(\t\x12\x38\n\x0fvolume_response\x18\x02 \x01(\x0b\x32\x1f.openstorage.api.VolumeResponse\"\xa3\x01\n\x11VolumeStateAction\x12\x32\n\x06\x61ttach\x18\x01 \x01(\x0e\x32\".openstorage.api.VolumeActionParam\x12\x31\n\x05mount\x18\x02 \x01(\x0e\x32\".openstorage.api.VolumeActionParam\x12\x12\n\nmount_path\x18\x03 \x01(\t\x12\x13\n\x0b\x64\x65vice_path\x18\x04 \x01(\t\"\x93\x02\n\x10VolumeSetRequest\x12/\n\x07locator\x18\x01 \x01(\x0b\x32\x1e.openstorage.api.VolumeLocator\x12)\n\x04spec\x18\x02 \x01(\x0b\x32\x1b.openstorage.api.VolumeSpec\x12\x32\n\x06\x61\x63tion\x18\x03 \x01(\x0b\x32\".openstorage.api.VolumeStateAction\x12?\n\x07options\x18\x04 \x03(\x0b\x32..openstorage.api.VolumeSetRequest.OptionsEntry\x1a.\n\x0cOptionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"v\n\x11VolumeSetResponse\x12\'\n\x06volume\x18\x01 \x01(\x0b\x32\x17.openstorage.api.Volume\x12\x38\n\x0fvolume_response\x18\x02 \x01(\x0b\x32\x1f.openstorage.api.VolumeResponse\"b\n\x11SnapCreateRequest\x12\n\n\x02id\x18\x01 \x01(\t\x12/\n\x07locator\x18\x02 \x01(\x0b\x32\x1e.openstorage.api.VolumeLocator\x12\x10\n\x08readonly\x18\x03 \x01(\x08\"[\n\x12SnapCreateResponse\x12\x45\n\x16volume_create_response\x18\x01 \x01(\x0b\x32%.openstorage.api.VolumeCreateResponse\"[\n\nVolumeInfo\x12\x11\n\tvolume_id\x18\x01 \x01(\t\x12\x0c\n\x04path\x18\x02 \x01(\t\x12,\n\x07storage\x18\x03 \x01(\x0b\x32\x1b.openstorage.api.VolumeSpec\"x\n\x0eVolumeConsumer\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tnamespace\x18\x02 \x01(\t\x12\x0c\n\x04type\x18\x03 \x01(\t\x12\x0f\n\x07node_id\x18\x04 \x01(\t\x12\x12\n\nowner_name\x18\x05 \x01(\t\x12\x12\n\nowner_type\x18\x06 \x01(\t\"X\n\x12GraphDriverChanges\x12\x0c\n\x04path\x18\x01 \x01(\t\x12\x34\n\x04kind\x18\x02 \x01(\x0e\x32&.openstorage.api.GraphDriverChangeType\" \n\x0f\x43lusterResponse\x12\r\n\x05\x65rror\x18\x01 \x01(\t\"\x80\x01\n\rActiveRequest\x12>\n\x08ReqestKV\x18\x01 \x03(\x0b\x32,.openstorage.api.ActiveRequest.ReqestKVEntry\x1a/\n\rReqestKVEntry\x12\x0b\n\x03key\x18\x01 \x01(\x03\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"]\n\x0e\x41\x63tiveRequests\x12\x14\n\x0cRequestCount\x18\x01 \x01(\x03\x12\x35\n\rActiveRequest\x18\x02 \x03(\x0b\x32\x1e.openstorage.api.ActiveRequest\"\x98\x01\n\x16GroupSnapCreateRequest\x12\n\n\x02id\x18\x01 \x01(\t\x12\x43\n\x06Labels\x18\x02 \x03(\x0b\x32\x33.openstorage.api.GroupSnapCreateRequest.LabelsEntry\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\xcb\x01\n\x17GroupSnapCreateResponse\x12J\n\tsnapshots\x18\x01 \x03(\x0b\x32\x37.openstorage.api.GroupSnapCreateResponse.SnapshotsEntry\x12\r\n\x05\x65rror\x18\x02 \x01(\t\x1aU\n\x0eSnapshotsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\x32\n\x05value\x18\x02 \x01(\x0b\x32#.openstorage.api.SnapCreateResponse:\x02\x38\x01\"\xf7\x03\n\x0bStorageNode\x12\n\n\x02id\x18\x01 \x01(\t\x12\x0b\n\x03\x63pu\x18\x02 \x01(\x01\x12\x11\n\tmem_total\x18\x03 \x01(\x04\x12\x10\n\x08mem_used\x18\x04 \x01(\x04\x12\x10\n\x08mem_free\x18\x05 \x01(\x04\x12\x10\n\x08\x61vg_load\x18\x06 \x01(\x03\x12\'\n\x06status\x18\x07 \x01(\x0e\x32\x17.openstorage.api.Status\x12\x36\n\x05\x64isks\x18\t \x03(\x0b\x32\'.openstorage.api.StorageNode.DisksEntry\x12+\n\x05pools\x18\n \x03(\x0b\x32\x1c.openstorage.api.StoragePool\x12\x0f\n\x07mgmt_ip\x18\x0b \x01(\t\x12\x0f\n\x07\x64\x61ta_ip\x18\x0c \x01(\t\x12\x10\n\x08hostname\x18\x0f \x01(\t\x12\x41\n\x0bnode_labels\x18\x10 \x03(\x0b\x32,.openstorage.api.StorageNode.NodeLabelsEntry\x1aN\n\nDisksEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12/\n\x05value\x18\x02 \x01(\x0b\x32 .openstorage.api.StorageResource:\x02\x38\x01\x1a\x31\n\x0fNodeLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x83\x01\n\x0eStorageCluster\x12\'\n\x06status\x18\x01 \x01(\x0e\x32\x17.openstorage.api.Status\x12\n\n\x02id\x18\x02 \x01(\t\x12\x0f\n\x07node_id\x18\x03 \x01(\t\x12+\n\x05nodes\x18\x04 \x03(\x0b\x32\x1c.openstorage.api.StorageNode\"W\n\x1fSdkCredentialCreateAzureRequest\x12\x34\n\ncredential\x18\x01 \x01(\x0b\x32 .openstorage.api.AzureCredential\"9\n SdkCredentialCreateAzureResponse\x12\x15\n\rcredential_id\x18\x01 \x01(\t\"Y\n SdkCredentialCreateGoogleRequest\x12\x35\n\ncredential\x18\x01 \x01(\x0b\x32!.openstorage.api.GoogleCredential\":\n!SdkCredentialCreateGoogleResponse\x12\x15\n\rcredential_id\x18\x01 \x01(\t\"R\n\x1dSdkCredentialCreateAWSRequest\x12\x31\n\ncredential\x18\x01 \x01(\x0b\x32\x1d.openstorage.api.S3Credential\"7\n\x1eSdkCredentialCreateAWSResponse\x12\x15\n\rcredential_id\x18\x01 \x01(\t\"o\n\x0cS3Credential\x12\x15\n\rcredential_id\x18\x01 \x01(\t\x12\x12\n\naccess_key\x18\x02 \x01(\t\x12\x12\n\nsecret_key\x18\x03 \x01(\t\x12\x10\n\x08\x65ndpoint\x18\x04 \x01(\t\x12\x0e\n\x06region\x18\x05 \x01(\t\"S\n\x0f\x41zureCredential\x12\x15\n\rcredential_id\x18\x01 \x01(\t\x12\x14\n\x0c\x61\x63\x63ount_name\x18\x02 \x01(\t\x12\x13\n\x0b\x61\x63\x63ount_key\x18\x03 \x01(\t\"O\n\x10GoogleCredential\x12\x15\n\rcredential_id\x18\x01 \x01(\t\x12\x12\n\nproject_id\x18\x02 \x01(\t\x12\x10\n\x08json_key\x18\x03 \x01(\t\"9\n SdkCredentialEnumerateAWSRequest\x12\x15\n\rcredential_id\x18\x01 \x01(\t\"V\n!SdkCredentialEnumerateAWSResponse\x12\x31\n\ncredential\x18\x01 \x03(\x0b\x32\x1d.openstorage.api.S3Credential\";\n\"SdkCredentialEnumerateAzureRequest\x12\x15\n\rcredential_id\x18\x01 \x01(\t\"[\n#SdkCredentialEnumerateAzureResponse\x12\x34\n\ncredential\x18\x01 \x03(\x0b\x32 .openstorage.api.AzureCredential\"<\n#SdkCredentialEnumerateGoogleRequest\x12\x15\n\rcredential_id\x18\x01 \x01(\t\"]\n$SdkCredentialEnumerateGoogleResponse\x12\x35\n\ncredential\x18\x01 \x03(\x0b\x32!.openstorage.api.GoogleCredential\"3\n\x1aSdkCredentialDeleteRequest\x12\x15\n\rcredential_id\x18\x01 \x01(\t\"\x1d\n\x1bSdkCredentialDeleteResponse\"5\n\x1cSdkCredentialValidateRequest\x12\x15\n\rcredential_id\x18\x01 \x01(\t\"\x1f\n\x1dSdkCredentialValidateResponse\"\xb4\x01\n\x15SdkVolumeMountRequest\x12\x11\n\tvolume_id\x18\x01 \x01(\t\x12\x12\n\nmount_path\x18\x02 \x01(\t\x12\x44\n\x07options\x18\x03 \x03(\x0b\x32\x33.openstorage.api.SdkVolumeMountRequest.OptionsEntry\x1a.\n\x0cOptionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x18\n\x16SdkVolumeMountResponse\"\xb8\x01\n\x17SdkVolumeUnmountRequest\x12\x11\n\tvolume_id\x18\x01 \x01(\t\x12\x12\n\nmount_path\x18\x02 \x01(\t\x12\x46\n\x07options\x18\x03 \x03(\x0b\x32\x35.openstorage.api.SdkVolumeUnmountRequest.OptionsEntry\x1a.\n\x0cOptionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"\x1a\n\x18SdkVolumeUnmountResponse\"\xa2\x01\n\x16SdkVolumeAttachRequest\x12\x11\n\tvolume_id\x18\x01 \x01(\t\x12\x45\n\x07options\x18\x02 \x03(\x0b\x32\x34.openstorage.api.SdkVolumeAttachRequest.OptionsEntry\x1a.\n\x0cOptionsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\".\n\x17SdkVolumeAttachResponse\x12\x13\n\x0b\x64\x65vice_path\x18\x01 \x01(\t\"+\n\x16SdkVolumeDetachRequest\x12\x11\n\tvolume_id\x18\x01 \x01(\t\"\x19\n\x17SdkVolumeDetachResponse\"Q\n\x16SdkVolumeCreateRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12)\n\x04spec\x18\x02 \x01(\x0b\x32\x1b.openstorage.api.VolumeSpec\",\n\x17SdkVolumeCreateResponse\x12\x11\n\tvolume_id\x18\x01 \x01(\t\"p\n\"SdkVolumeCreateFromVolumeIdRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x11\n\tparent_id\x18\x02 \x01(\t\x12)\n\x04spec\x18\x03 \x01(\x0b\x32\x1b.openstorage.api.VolumeSpec\"8\n#SdkVolumeCreateFromVolumeIdResponse\x12\x11\n\tvolume_id\x18\x01 \x01(\t\"+\n\x16SdkVolumeDeleteRequest\x12\x11\n\tvolume_id\x18\x01 \x01(\t\"\x19\n\x17SdkVolumeDeleteResponse\",\n\x17SdkVolumeInspectRequest\x12\x11\n\tvolume_id\x18\x01 \x01(\t\"C\n\x18SdkVolumeInspectResponse\x12\'\n\x06volume\x18\x01 \x01(\x0b\x32\x17.openstorage.api.Volume\"L\n\x19SdkVolumeEnumerateRequest\x12/\n\x07locator\x18\x01 \x01(\x0b\x32\x1e.openstorage.api.VolumeLocator\"F\n\x1aSdkVolumeEnumerateResponse\x12(\n\x07volumes\x18\x01 \x03(\x0b\x32\x17.openstorage.api.Volume\"\xaf\x01\n\x1eSdkVolumeSnapshotCreateRequest\x12\x11\n\tvolume_id\x18\x01 \x01(\t\x12K\n\x06labels\x18\x02 \x03(\x0b\x32;.openstorage.api.SdkVolumeSnapshotCreateRequest.LabelsEntry\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"6\n\x1fSdkVolumeSnapshotCreateResponse\x12\x13\n\x0bsnapshot_id\x18\x01 \x01(\t\"I\n\x1fSdkVolumeSnapshotRestoreRequest\x12\x11\n\tvolume_id\x18\x01 \x01(\t\x12\x13\n\x0bsnapshot_id\x18\x02 \x01(\t\"\"\n SdkVolumeSnapshotRestoreResponse\"\xb5\x01\n!SdkVolumeSnapshotEnumerateRequest\x12\x11\n\tvolume_id\x18\x01 \x01(\t\x12N\n\x06labels\x18\x02 \x03(\x0b\x32>.openstorage.api.SdkVolumeSnapshotEnumerateRequest.LabelsEntry\x1a-\n\x0bLabelsEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\"P\n\"SdkVolumeSnapshotEnumerateResponse\x12*\n\tsnapshots\x18\x01 \x03(\x0b\x32\x17.openstorage.api.Volume\"\x1c\n\x1aSdkClusterEnumerateRequest\"O\n\x1bSdkClusterEnumerateResponse\x12\x30\n\x07\x63luster\x18\x01 \x01(\x0b\x32\x1f.openstorage.api.StorageCluster\"+\n\x18SdkClusterInspectRequest\x12\x0f\n\x07node_id\x18\x01 \x01(\t\"G\n\x19SdkClusterInspectResponse\x12*\n\x04node\x18\x01 \x01(\x0b\x32\x1c.openstorage.api.StorageNode\"\xb0\x01\n\x1fSdkClusterAlertEnumerateRequest\x12.\n\ntime_start\x18\x01 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12,\n\x08time_end\x18\x02 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12/\n\x08resource\x18\x03 \x01(\x0e\x32\x1d.openstorage.api.ResourceType\"K\n SdkClusterAlertEnumerateResponse\x12\'\n\x06\x61lerts\x18\x01 \x01(\x0b\x32\x17.openstorage.api.Alerts\"`\n\x1bSdkClusterAlertClearRequest\x12/\n\x08resource\x18\x01 \x01(\x0e\x32\x1d.openstorage.api.ResourceType\x12\x10\n\x08\x61lert_id\x18\x02 \x01(\x03\"\x1e\n\x1cSdkClusterAlertClearResponse\"`\n\x1bSdkClusterAlertEraseRequest\x12/\n\x08resource\x18\x01 \x01(\x0e\x32\x1d.openstorage.api.ResourceType\x12\x10\n\x08\x61lert_id\x18\x02 \x01(\x03\"\x1e\n\x1cSdkClusterAlertEraseResponse*\xee\x02\n\x06Status\x12\x0f\n\x0bSTATUS_NONE\x10\x00\x12\x0f\n\x0bSTATUS_INIT\x10\x01\x12\r\n\tSTATUS_OK\x10\x02\x12\x12\n\x0eSTATUS_OFFLINE\x10\x03\x12\x10\n\x0cSTATUS_ERROR\x10\x04\x12\x18\n\x14STATUS_NOT_IN_QUORUM\x10\x05\x12\x17\n\x13STATUS_DECOMMISSION\x10\x06\x12\x16\n\x12STATUS_MAINTENANCE\x10\x07\x12\x17\n\x13STATUS_STORAGE_DOWN\x10\x08\x12\x1b\n\x17STATUS_STORAGE_DEGRADED\x10\t\x12\x17\n\x13STATUS_NEEDS_REBOOT\x10\n\x12\x1c\n\x18STATUS_STORAGE_REBALANCE\x10\x0b\x12 \n\x1cSTATUS_STORAGE_DRIVE_REPLACE\x10\x0c\x12#\n\x1fSTATUS_NOT_IN_QUORUM_NO_STORAGE\x10\r\x12\x0e\n\nSTATUS_MAX\x10\x0e*\x99\x01\n\nDriverType\x12\x14\n\x10\x44RIVER_TYPE_NONE\x10\x00\x12\x14\n\x10\x44RIVER_TYPE_FILE\x10\x01\x12\x15\n\x11\x44RIVER_TYPE_BLOCK\x10\x02\x12\x16\n\x12\x44RIVER_TYPE_OBJECT\x10\x03\x12\x19\n\x15\x44RIVER_TYPE_CLUSTERED\x10\x04\x12\x15\n\x11\x44RIVER_TYPE_GRAPH\x10\x05*\x95\x01\n\x06\x46SType\x12\x10\n\x0c\x46S_TYPE_NONE\x10\x00\x12\x11\n\rFS_TYPE_BTRFS\x10\x01\x12\x10\n\x0c\x46S_TYPE_EXT4\x10\x02\x12\x10\n\x0c\x46S_TYPE_FUSE\x10\x03\x12\x0f\n\x0b\x46S_TYPE_NFS\x10\x04\x12\x0f\n\x0b\x46S_TYPE_VFS\x10\x05\x12\x0f\n\x0b\x46S_TYPE_XFS\x10\x06\x12\x0f\n\x0b\x46S_TYPE_ZFS\x10\x07*\xab\x01\n\x15GraphDriverChangeType\x12!\n\x1dGRAPH_DRIVER_CHANGE_TYPE_NONE\x10\x00\x12%\n!GRAPH_DRIVER_CHANGE_TYPE_MODIFIED\x10\x01\x12\"\n\x1eGRAPH_DRIVER_CHANGE_TYPE_ADDED\x10\x02\x12$\n GRAPH_DRIVER_CHANGE_TYPE_DELETED\x10\x03*t\n\x0cSeverityType\x12\x16\n\x12SEVERITY_TYPE_NONE\x10\x00\x12\x17\n\x13SEVERITY_TYPE_ALARM\x10\x01\x12\x19\n\x15SEVERITY_TYPE_WARNING\x10\x02\x12\x18\n\x14SEVERITY_TYPE_NOTIFY\x10\x03*\x8c\x01\n\x0cResourceType\x12\x16\n\x12RESOURCE_TYPE_NONE\x10\x00\x12\x18\n\x14RESOURCE_TYPE_VOLUME\x10\x01\x12\x16\n\x12RESOURCE_TYPE_NODE\x10\x02\x12\x19\n\x15RESOURCE_TYPE_CLUSTER\x10\x03\x12\x17\n\x13RESOURCE_TYPE_DRIVE\x10\x04*\x87\x01\n\x0f\x41lertActionType\x12\x1a\n\x16\x41LERT_ACTION_TYPE_NONE\x10\x00\x12\x1c\n\x18\x41LERT_ACTION_TYPE_DELETE\x10\x01\x12\x1c\n\x18\x41LERT_ACTION_TYPE_CREATE\x10\x02\x12\x1c\n\x18\x41LERT_ACTION_TYPE_UPDATE\x10\x03*j\n\x11VolumeActionParam\x12\x1c\n\x18VOLUME_ACTION_PARAM_NONE\x10\x00\x12\x1b\n\x17VOLUME_ACTION_PARAM_OFF\x10\x01\x12\x1a\n\x16VOLUME_ACTION_PARAM_ON\x10\x02*2\n\x07\x43osType\x12\x08\n\x04NONE\x10\x00\x12\x07\n\x03LOW\x10\x01\x12\n\n\x06MEDIUM\x10\x02\x12\x08\n\x04HIGH\x10\x03*~\n\tIoProfile\x12\x19\n\x15IO_PROFILE_SEQUENTIAL\x10\x00\x12\x15\n\x11IO_PROFILE_RANDOM\x10\x01\x12\x11\n\rIO_PROFILE_DB\x10\x02\x12\x18\n\x14IO_PROFILE_DB_REMOTE\x10\x03\x12\x12\n\x0eIO_PROFILE_CMS\x10\x04*\x99\x02\n\x0bVolumeState\x12\x15\n\x11VOLUME_STATE_NONE\x10\x00\x12\x18\n\x14VOLUME_STATE_PENDING\x10\x01\x12\x1a\n\x16VOLUME_STATE_AVAILABLE\x10\x02\x12\x19\n\x15VOLUME_STATE_ATTACHED\x10\x03\x12\x19\n\x15VOLUME_STATE_DETACHED\x10\x04\x12\x1b\n\x17VOLUME_STATE_DETATCHING\x10\x05\x12\x16\n\x12VOLUME_STATE_ERROR\x10\x06\x12\x18\n\x14VOLUME_STATE_DELETED\x10\x07\x12\x1e\n\x1aVOLUME_STATE_TRY_DETACHING\x10\x08\x12\x18\n\x14VOLUME_STATE_RESTORE\x10\t*\x8f\x01\n\x0cVolumeStatus\x12\x16\n\x12VOLUME_STATUS_NONE\x10\x00\x12\x1d\n\x19VOLUME_STATUS_NOT_PRESENT\x10\x01\x12\x14\n\x10VOLUME_STATUS_UP\x10\x02\x12\x16\n\x12VOLUME_STATUS_DOWN\x10\x03\x12\x1a\n\x16VOLUME_STATUS_DEGRADED\x10\x04*]\n\rStorageMedium\x12\x1b\n\x17STORAGE_MEDIUM_MAGNETIC\x10\x00\x12\x16\n\x12STORAGE_MEDIUM_SSD\x10\x01\x12\x17\n\x13STORAGE_MEDIUM_NVME\x10\x02*(\n\rClusterNotify\x12\x17\n\x13\x43LUSTER_NOTIFY_DOWN\x10\x00*e\n\x0b\x41ttachState\x12\x19\n\x15\x41TTACH_STATE_EXTERNAL\x10\x00\x12\x19\n\x15\x41TTACH_STATE_INTERNAL\x10\x01\x12 \n\x1c\x41TTACH_STATE_INTERNAL_SWITCH\x10\x02*T\n\x0eOperationFlags\x12\x14\n\x10OP_FLAGS_UNKNOWN\x10\x00\x12\x11\n\rOP_FLAGS_NONE\x10\x01\x12\x19\n\x15OP_FLAGS_DETACH_FORCE\x10\x02\x32\xe2\x05\n\x12OpenStorageCluster\x12\x88\x01\n\tEnumerate\x12+.openstorage.api.SdkClusterEnumerateRequest\x1a,.openstorage.api.SdkClusterEnumerateResponse\" \x82\xd3\xe4\x93\x02\x1a\"\x15/v1/cluster/enumerate:\x01*\x12\x80\x01\n\x07Inspect\x12).openstorage.api.SdkClusterInspectRequest\x1a*.openstorage.api.SdkClusterInspectResponse\"\x1e\x82\xd3\xe4\x93\x02\x18\"\x13/v1/cluster/inspect:\x01*\x12\x9d\x01\n\x0e\x41lertEnumerate\x12\x30.openstorage.api.SdkClusterAlertEnumerateRequest\x1a\x31.openstorage.api.SdkClusterAlertEnumerateResponse\"&\x82\xd3\xe4\x93\x02 \"\x1b/v1/cluster/alert/enumerate:\x01*\x12\x8d\x01\n\nAlertClear\x12,.openstorage.api.SdkClusterAlertClearRequest\x1a-.openstorage.api.SdkClusterAlertClearResponse\"\"\x82\xd3\xe4\x93\x02\x1c\"\x17/v1/cluster/alert/clear:\x01*\x12\x8d\x01\n\nAlertErase\x12,.openstorage.api.SdkClusterAlertEraseRequest\x1a-.openstorage.api.SdkClusterAlertEraseResponse\"\"\x82\xd3\xe4\x93\x02\x1c\"\x17/v1/cluster/alert/erase:\x01*2\x89\r\n\x11OpenStorageVolume\x12y\n\x06\x43reate\x12\'.openstorage.api.SdkVolumeCreateRequest\x1a(.openstorage.api.SdkVolumeCreateResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\"\x11/v1/volume/create:\x01*\x12\xa3\x01\n\x12\x43reateFromVolumeId\x12\x33.openstorage.api.SdkVolumeCreateFromVolumeIdRequest\x1a\x34.openstorage.api.SdkVolumeCreateFromVolumeIdResponse\"\"\x82\xd3\xe4\x93\x02\x1c\"\x17/v1/volume/createfromid:\x01*\x12y\n\x06\x44\x65lete\x12\'.openstorage.api.SdkVolumeDeleteRequest\x1a(.openstorage.api.SdkVolumeDeleteResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\"\x11/v1/volume/delete:\x01*\x12}\n\x07Inspect\x12(.openstorage.api.SdkVolumeInspectRequest\x1a).openstorage.api.SdkVolumeInspectResponse\"\x1d\x82\xd3\xe4\x93\x02\x17\"\x12/v1/volume/inspect:\x01*\x12\x85\x01\n\tEnumerate\x12*.openstorage.api.SdkVolumeEnumerateRequest\x1a+.openstorage.api.SdkVolumeEnumerateResponse\"\x1f\x82\xd3\xe4\x93\x02\x19\"\x14/v1/volume/enumerate:\x01*\x12\x9a\x01\n\x0eSnapshotCreate\x12/.openstorage.api.SdkVolumeSnapshotCreateRequest\x1a\x30.openstorage.api.SdkVolumeSnapshotCreateResponse\"%\x82\xd3\xe4\x93\x02\x1f\"\x1a/v1/volume/snapshot/create:\x01*\x12\x9e\x01\n\x0fSnapshotRestore\x12\x30.openstorage.api.SdkVolumeSnapshotRestoreRequest\x1a\x31.openstorage.api.SdkVolumeSnapshotRestoreResponse\"&\x82\xd3\xe4\x93\x02 \"\x1b/v1/volume/snapshot/restore:\x01*\x12\xa6\x01\n\x11SnapshotEnumerate\x12\x32.openstorage.api.SdkVolumeSnapshotEnumerateRequest\x1a\x33.openstorage.api.SdkVolumeSnapshotEnumerateResponse\"(\x82\xd3\xe4\x93\x02\"\"\x1d/v1/volume/snapshot/enumerate:\x01*\x12y\n\x06\x41ttach\x12\'.openstorage.api.SdkVolumeAttachRequest\x1a(.openstorage.api.SdkVolumeAttachResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\"\x11/v1/volume/attach:\x01*\x12y\n\x06\x44\x65tach\x12\'.openstorage.api.SdkVolumeDetachRequest\x1a(.openstorage.api.SdkVolumeDetachResponse\"\x1c\x82\xd3\xe4\x93\x02\x16\"\x11/v1/volume/detach:\x01*\x12u\n\x05Mount\x12&.openstorage.api.SdkVolumeMountRequest\x1a\'.openstorage.api.SdkVolumeMountResponse\"\x1b\x82\xd3\xe4\x93\x02\x15\"\x10/v1/volume/mount:\x01*\x12}\n\x07Unmount\x12(.openstorage.api.SdkVolumeUnmountRequest\x1a).openstorage.api.SdkVolumeUnmountResponse\"\x1d\x82\xd3\xe4\x93\x02\x17\"\x12/v1/volume/unmount:\x01*2\xa8\n\n\x16OpenStorageCredentials\x12\x96\x01\n\x0c\x43reateForAWS\x12..openstorage.api.SdkCredentialCreateAWSRequest\x1a/.openstorage.api.SdkCredentialCreateAWSResponse\"%\x82\xd3\xe4\x93\x02\x1f\"\x1a/v1/credentials/create/aws:\x01*\x12\x9e\x01\n\x0e\x43reateForAzure\x12\x30.openstorage.api.SdkCredentialCreateAzureRequest\x1a\x31.openstorage.api.SdkCredentialCreateAzureResponse\"\'\x82\xd3\xe4\x93\x02!\"\x1c/v1/credentials/create/azure:\x01*\x12\xa2\x01\n\x0f\x43reateForGoogle\x12\x31.openstorage.api.SdkCredentialCreateGoogleRequest\x1a\x32.openstorage.api.SdkCredentialCreateGoogleResponse\"(\x82\xd3\xe4\x93\x02\"\"\x1d/v1/credentials/create/google:\x01*\x12\xa2\x01\n\x0f\x45numerateForAWS\x12\x31.openstorage.api.SdkCredentialEnumerateAWSRequest\x1a\x32.openstorage.api.SdkCredentialEnumerateAWSResponse\"(\x82\xd3\xe4\x93\x02\"\"\x1d/v1/credentials/enumerate/aws:\x01*\x12\xaa\x01\n\x11\x45numerateForAzure\x12\x33.openstorage.api.SdkCredentialEnumerateAzureRequest\x1a\x34.openstorage.api.SdkCredentialEnumerateAzureResponse\"*\x82\xd3\xe4\x93\x02$\"\x1f/v1/credentials/enumerate/azure:\x01*\x12\xae\x01\n\x12\x45numerateForGoogle\x12\x34.openstorage.api.SdkCredentialEnumerateGoogleRequest\x1a\x35.openstorage.api.SdkCredentialEnumerateGoogleResponse\"+\x82\xd3\xe4\x93\x02%\" /v1/credentials/enumerate/google:\x01*\x12\x90\x01\n\x10\x43redentialDelete\x12+.openstorage.api.SdkCredentialDeleteRequest\x1a,.openstorage.api.SdkCredentialDeleteResponse\"!\x82\xd3\xe4\x93\x02\x1b\"\x16/v1/credentials/delete:\x01*\x12\x98\x01\n\x12\x43redentialValidate\x12-.openstorage.api.SdkCredentialValidateRequest\x1a..openstorage.api.SdkCredentialValidateResponse\"#\x82\xd3\xe4\x93\x02\x1d\"\x18/v1/credentials/validate:\x01*B\x1c\n\x13\x63om.openstorage.apiP\x01Z\x03\x61pib\x06proto3')
   ,
   dependencies=[google_dot_protobuf_dot_timestamp__pb2.DESCRIPTOR,google_dot_api_dot_annotations__pb2.DESCRIPTOR,])
 
@@ -95,8 +95,8 @@ _STATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8386,
-  serialized_end=8752,
+  serialized_start=10054,
+  serialized_end=10420,
 )
 _sym_db.RegisterEnumDescriptor(_STATUS)
 
@@ -134,8 +134,8 @@ _DRIVERTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8755,
-  serialized_end=8908,
+  serialized_start=10423,
+  serialized_end=10576,
 )
 _sym_db.RegisterEnumDescriptor(_DRIVERTYPE)
 
@@ -181,8 +181,8 @@ _FSTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=8911,
-  serialized_end=9060,
+  serialized_start=10579,
+  serialized_end=10728,
 )
 _sym_db.RegisterEnumDescriptor(_FSTYPE)
 
@@ -212,8 +212,8 @@ _GRAPHDRIVERCHANGETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=9063,
-  serialized_end=9234,
+  serialized_start=10731,
+  serialized_end=10902,
 )
 _sym_db.RegisterEnumDescriptor(_GRAPHDRIVERCHANGETYPE)
 
@@ -243,8 +243,8 @@ _SEVERITYTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=9236,
-  serialized_end=9352,
+  serialized_start=10904,
+  serialized_end=11020,
 )
 _sym_db.RegisterEnumDescriptor(_SEVERITYTYPE)
 
@@ -278,8 +278,8 @@ _RESOURCETYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=9355,
-  serialized_end=9495,
+  serialized_start=11023,
+  serialized_end=11163,
 )
 _sym_db.RegisterEnumDescriptor(_RESOURCETYPE)
 
@@ -309,8 +309,8 @@ _ALERTACTIONTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=9498,
-  serialized_end=9633,
+  serialized_start=11166,
+  serialized_end=11301,
 )
 _sym_db.RegisterEnumDescriptor(_ALERTACTIONTYPE)
 
@@ -336,8 +336,8 @@ _VOLUMEACTIONPARAM = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=9635,
-  serialized_end=9741,
+  serialized_start=11303,
+  serialized_end=11409,
 )
 _sym_db.RegisterEnumDescriptor(_VOLUMEACTIONPARAM)
 
@@ -367,8 +367,8 @@ _COSTYPE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=9743,
-  serialized_end=9793,
+  serialized_start=11411,
+  serialized_end=11461,
 )
 _sym_db.RegisterEnumDescriptor(_COSTYPE)
 
@@ -402,8 +402,8 @@ _IOPROFILE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=9795,
-  serialized_end=9921,
+  serialized_start=11463,
+  serialized_end=11589,
 )
 _sym_db.RegisterEnumDescriptor(_IOPROFILE)
 
@@ -457,8 +457,8 @@ _VOLUMESTATE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=9924,
-  serialized_end=10205,
+  serialized_start=11592,
+  serialized_end=11873,
 )
 _sym_db.RegisterEnumDescriptor(_VOLUMESTATE)
 
@@ -492,8 +492,8 @@ _VOLUMESTATUS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=10208,
-  serialized_end=10351,
+  serialized_start=11876,
+  serialized_end=12019,
 )
 _sym_db.RegisterEnumDescriptor(_VOLUMESTATUS)
 
@@ -519,8 +519,8 @@ _STORAGEMEDIUM = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=10353,
-  serialized_end=10446,
+  serialized_start=12021,
+  serialized_end=12114,
 )
 _sym_db.RegisterEnumDescriptor(_STORAGEMEDIUM)
 
@@ -538,8 +538,8 @@ _CLUSTERNOTIFY = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=10448,
-  serialized_end=10488,
+  serialized_start=12116,
+  serialized_end=12156,
 )
 _sym_db.RegisterEnumDescriptor(_CLUSTERNOTIFY)
 
@@ -565,8 +565,8 @@ _ATTACHSTATE = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=10490,
-  serialized_end=10591,
+  serialized_start=12158,
+  serialized_end=12259,
 )
 _sym_db.RegisterEnumDescriptor(_ATTACHSTATE)
 
@@ -592,8 +592,8 @@ _OPERATIONFLAGS = _descriptor.EnumDescriptor(
   ],
   containing_type=None,
   options=None,
-  serialized_start=10593,
-  serialized_end=10677,
+  serialized_start=12261,
+  serialized_end=12345,
 )
 _sym_db.RegisterEnumDescriptor(_OPERATIONFLAGS)
 
@@ -1815,6 +1815,107 @@ _ALERTS = _descriptor.Descriptor(
 )
 
 
+_OBJECTSTOREINFO = _descriptor.Descriptor(
+  name='ObjectstoreInfo',
+  full_name='openstorage.api.ObjectstoreInfo',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='uuid', full_name='openstorage.api.ObjectstoreInfo.uuid', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='volume_id', full_name='openstorage.api.ObjectstoreInfo.volume_id', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='enabled', full_name='openstorage.api.ObjectstoreInfo.enabled', index=2,
+      number=3, type=8, cpp_type=7, label=1,
+      has_default_value=False, default_value=False,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='status', full_name='openstorage.api.ObjectstoreInfo.status', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='action', full_name='openstorage.api.ObjectstoreInfo.action', index=4,
+      number=5, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='access_key', full_name='openstorage.api.ObjectstoreInfo.access_key', index=5,
+      number=6, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='secret_key', full_name='openstorage.api.ObjectstoreInfo.secret_key', index=6,
+      number=7, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='endpoints', full_name='openstorage.api.ObjectstoreInfo.endpoints', index=7,
+      number=8, type=9, cpp_type=9, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='current_endPoint', full_name='openstorage.api.ObjectstoreInfo.current_endPoint', index=8,
+      number=9, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='access_port', full_name='openstorage.api.ObjectstoreInfo.access_port', index=9,
+      number=10, type=3, cpp_type=2, label=1,
+      has_default_value=False, default_value=0,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='region', full_name='openstorage.api.ObjectstoreInfo.region', index=10,
+      number=11, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=3171,
+  serialized_end=3392,
+)
+
+
 _VOLUMECREATEREQUEST = _descriptor.Descriptor(
   name='VolumeCreateRequest',
   full_name='openstorage.api.VolumeCreateRequest',
@@ -1855,8 +1956,8 @@ _VOLUMECREATEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3171,
-  serialized_end=3325,
+  serialized_start=3395,
+  serialized_end=3549,
 )
 
 
@@ -1886,8 +1987,8 @@ _VOLUMERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3327,
-  serialized_end=3358,
+  serialized_start=3551,
+  serialized_end=3582,
 )
 
 
@@ -1924,8 +2025,8 @@ _VOLUMECREATERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3360,
-  serialized_end=3452,
+  serialized_start=3584,
+  serialized_end=3676,
 )
 
 
@@ -1976,8 +2077,8 @@ _VOLUMESTATEACTION = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3455,
-  serialized_end=3618,
+  serialized_start=3679,
+  serialized_end=3842,
 )
 
 
@@ -2014,8 +2115,8 @@ _VOLUMESETREQUEST_OPTIONSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3850,
-  serialized_end=3896,
+  serialized_start=4074,
+  serialized_end=4120,
 )
 
 _VOLUMESETREQUEST = _descriptor.Descriptor(
@@ -2065,8 +2166,8 @@ _VOLUMESETREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3621,
-  serialized_end=3896,
+  serialized_start=3845,
+  serialized_end=4120,
 )
 
 
@@ -2103,8 +2204,8 @@ _VOLUMESETRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3898,
-  serialized_end=4016,
+  serialized_start=4122,
+  serialized_end=4240,
 )
 
 
@@ -2148,8 +2249,8 @@ _SNAPCREATEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4018,
-  serialized_end=4116,
+  serialized_start=4242,
+  serialized_end=4340,
 )
 
 
@@ -2179,8 +2280,8 @@ _SNAPCREATERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4118,
-  serialized_end=4209,
+  serialized_start=4342,
+  serialized_end=4433,
 )
 
 
@@ -2224,8 +2325,8 @@ _VOLUMEINFO = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4211,
-  serialized_end=4302,
+  serialized_start=4435,
+  serialized_end=4526,
 )
 
 
@@ -2290,8 +2391,8 @@ _VOLUMECONSUMER = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4304,
-  serialized_end=4424,
+  serialized_start=4528,
+  serialized_end=4648,
 )
 
 
@@ -2328,8 +2429,8 @@ _GRAPHDRIVERCHANGES = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4426,
-  serialized_end=4514,
+  serialized_start=4650,
+  serialized_end=4738,
 )
 
 
@@ -2359,8 +2460,8 @@ _CLUSTERRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4516,
-  serialized_end=4548,
+  serialized_start=4740,
+  serialized_end=4772,
 )
 
 
@@ -2397,8 +2498,8 @@ _ACTIVEREQUEST_REQESTKVENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4632,
-  serialized_end=4679,
+  serialized_start=4856,
+  serialized_end=4903,
 )
 
 _ACTIVEREQUEST = _descriptor.Descriptor(
@@ -2427,8 +2528,8 @@ _ACTIVEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4551,
-  serialized_end=4679,
+  serialized_start=4775,
+  serialized_end=4903,
 )
 
 
@@ -2465,8 +2566,8 @@ _ACTIVEREQUESTS = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4681,
-  serialized_end=4774,
+  serialized_start=4905,
+  serialized_end=4998,
 )
 
 
@@ -2540,8 +2641,8 @@ _GROUPSNAPCREATEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4777,
-  serialized_end=4929,
+  serialized_start=5001,
+  serialized_end=5153,
 )
 
 
@@ -2578,8 +2679,8 @@ _GROUPSNAPCREATERESPONSE_SNAPSHOTSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5050,
-  serialized_end=5135,
+  serialized_start=5274,
+  serialized_end=5359,
 )
 
 _GROUPSNAPCREATERESPONSE = _descriptor.Descriptor(
@@ -2615,8 +2716,8 @@ _GROUPSNAPCREATERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=4932,
-  serialized_end=5135,
+  serialized_start=5156,
+  serialized_end=5359,
 )
 
 
@@ -2653,8 +2754,8 @@ _STORAGENODE_DISKSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5512,
-  serialized_end=5590,
+  serialized_start=5736,
+  serialized_end=5814,
 )
 
 _STORAGENODE_NODELABELSENTRY = _descriptor.Descriptor(
@@ -2690,8 +2791,8 @@ _STORAGENODE_NODELABELSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5592,
-  serialized_end=5641,
+  serialized_start=5816,
+  serialized_end=5865,
 )
 
 _STORAGENODE = _descriptor.Descriptor(
@@ -2804,8 +2905,8 @@ _STORAGENODE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5138,
-  serialized_end=5641,
+  serialized_start=5362,
+  serialized_end=5865,
 )
 
 
@@ -2856,27 +2957,658 @@ _STORAGECLUSTER = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5644,
-  serialized_end=5775,
+  serialized_start=5868,
+  serialized_end=5999,
 )
 
 
-_VOLUMEMOUNTREQUEST_OPTIONSENTRY = _descriptor.Descriptor(
-  name='OptionsEntry',
-  full_name='openstorage.api.VolumeMountRequest.OptionsEntry',
+_SDKCREDENTIALCREATEAZUREREQUEST = _descriptor.Descriptor(
+  name='SdkCredentialCreateAzureRequest',
+  full_name='openstorage.api.SdkCredentialCreateAzureRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='key', full_name='openstorage.api.VolumeMountRequest.OptionsEntry.key', index=0,
+      name='credential', full_name='openstorage.api.SdkCredentialCreateAzureRequest.credential', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=6001,
+  serialized_end=6088,
+)
+
+
+_SDKCREDENTIALCREATEAZURERESPONSE = _descriptor.Descriptor(
+  name='SdkCredentialCreateAzureResponse',
+  full_name='openstorage.api.SdkCredentialCreateAzureResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='credential_id', full_name='openstorage.api.SdkCredentialCreateAzureResponse.credential_id', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=6090,
+  serialized_end=6147,
+)
+
+
+_SDKCREDENTIALCREATEGOOGLEREQUEST = _descriptor.Descriptor(
+  name='SdkCredentialCreateGoogleRequest',
+  full_name='openstorage.api.SdkCredentialCreateGoogleRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='credential', full_name='openstorage.api.SdkCredentialCreateGoogleRequest.credential', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=6149,
+  serialized_end=6238,
+)
+
+
+_SDKCREDENTIALCREATEGOOGLERESPONSE = _descriptor.Descriptor(
+  name='SdkCredentialCreateGoogleResponse',
+  full_name='openstorage.api.SdkCredentialCreateGoogleResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='credential_id', full_name='openstorage.api.SdkCredentialCreateGoogleResponse.credential_id', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=6240,
+  serialized_end=6298,
+)
+
+
+_SDKCREDENTIALCREATEAWSREQUEST = _descriptor.Descriptor(
+  name='SdkCredentialCreateAWSRequest',
+  full_name='openstorage.api.SdkCredentialCreateAWSRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='credential', full_name='openstorage.api.SdkCredentialCreateAWSRequest.credential', index=0,
+      number=1, type=11, cpp_type=10, label=1,
+      has_default_value=False, default_value=None,
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=6300,
+  serialized_end=6382,
+)
+
+
+_SDKCREDENTIALCREATEAWSRESPONSE = _descriptor.Descriptor(
+  name='SdkCredentialCreateAWSResponse',
+  full_name='openstorage.api.SdkCredentialCreateAWSResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='credential_id', full_name='openstorage.api.SdkCredentialCreateAWSResponse.credential_id', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=6384,
+  serialized_end=6439,
+)
+
+
+_S3CREDENTIAL = _descriptor.Descriptor(
+  name='S3Credential',
+  full_name='openstorage.api.S3Credential',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='credential_id', full_name='openstorage.api.S3Credential.credential_id', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='value', full_name='openstorage.api.VolumeMountRequest.OptionsEntry.value', index=1,
+      name='access_key', full_name='openstorage.api.S3Credential.access_key', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='secret_key', full_name='openstorage.api.S3Credential.secret_key', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='endpoint', full_name='openstorage.api.S3Credential.endpoint', index=3,
+      number=4, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='region', full_name='openstorage.api.S3Credential.region', index=4,
+      number=5, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=6441,
+  serialized_end=6552,
+)
+
+
+_AZURECREDENTIAL = _descriptor.Descriptor(
+  name='AzureCredential',
+  full_name='openstorage.api.AzureCredential',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='credential_id', full_name='openstorage.api.AzureCredential.credential_id', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='account_name', full_name='openstorage.api.AzureCredential.account_name', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='account_key', full_name='openstorage.api.AzureCredential.account_key', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=6554,
+  serialized_end=6637,
+)
+
+
+_GOOGLECREDENTIAL = _descriptor.Descriptor(
+  name='GoogleCredential',
+  full_name='openstorage.api.GoogleCredential',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='credential_id', full_name='openstorage.api.GoogleCredential.credential_id', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='project_id', full_name='openstorage.api.GoogleCredential.project_id', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='json_key', full_name='openstorage.api.GoogleCredential.json_key', index=2,
+      number=3, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=6639,
+  serialized_end=6718,
+)
+
+
+_SDKCREDENTIALENUMERATEAWSREQUEST = _descriptor.Descriptor(
+  name='SdkCredentialEnumerateAWSRequest',
+  full_name='openstorage.api.SdkCredentialEnumerateAWSRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='credential_id', full_name='openstorage.api.SdkCredentialEnumerateAWSRequest.credential_id', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=6720,
+  serialized_end=6777,
+)
+
+
+_SDKCREDENTIALENUMERATEAWSRESPONSE = _descriptor.Descriptor(
+  name='SdkCredentialEnumerateAWSResponse',
+  full_name='openstorage.api.SdkCredentialEnumerateAWSResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='credential', full_name='openstorage.api.SdkCredentialEnumerateAWSResponse.credential', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=6779,
+  serialized_end=6865,
+)
+
+
+_SDKCREDENTIALENUMERATEAZUREREQUEST = _descriptor.Descriptor(
+  name='SdkCredentialEnumerateAzureRequest',
+  full_name='openstorage.api.SdkCredentialEnumerateAzureRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='credential_id', full_name='openstorage.api.SdkCredentialEnumerateAzureRequest.credential_id', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=6867,
+  serialized_end=6926,
+)
+
+
+_SDKCREDENTIALENUMERATEAZURERESPONSE = _descriptor.Descriptor(
+  name='SdkCredentialEnumerateAzureResponse',
+  full_name='openstorage.api.SdkCredentialEnumerateAzureResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='credential', full_name='openstorage.api.SdkCredentialEnumerateAzureResponse.credential', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=6928,
+  serialized_end=7019,
+)
+
+
+_SDKCREDENTIALENUMERATEGOOGLEREQUEST = _descriptor.Descriptor(
+  name='SdkCredentialEnumerateGoogleRequest',
+  full_name='openstorage.api.SdkCredentialEnumerateGoogleRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='credential_id', full_name='openstorage.api.SdkCredentialEnumerateGoogleRequest.credential_id', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=7021,
+  serialized_end=7081,
+)
+
+
+_SDKCREDENTIALENUMERATEGOOGLERESPONSE = _descriptor.Descriptor(
+  name='SdkCredentialEnumerateGoogleResponse',
+  full_name='openstorage.api.SdkCredentialEnumerateGoogleResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='credential', full_name='openstorage.api.SdkCredentialEnumerateGoogleResponse.credential', index=0,
+      number=1, type=11, cpp_type=10, label=3,
+      has_default_value=False, default_value=[],
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=7083,
+  serialized_end=7176,
+)
+
+
+_SDKCREDENTIALDELETEREQUEST = _descriptor.Descriptor(
+  name='SdkCredentialDeleteRequest',
+  full_name='openstorage.api.SdkCredentialDeleteRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='credential_id', full_name='openstorage.api.SdkCredentialDeleteRequest.credential_id', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=7178,
+  serialized_end=7229,
+)
+
+
+_SDKCREDENTIALDELETERESPONSE = _descriptor.Descriptor(
+  name='SdkCredentialDeleteResponse',
+  full_name='openstorage.api.SdkCredentialDeleteResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=7231,
+  serialized_end=7260,
+)
+
+
+_SDKCREDENTIALVALIDATEREQUEST = _descriptor.Descriptor(
+  name='SdkCredentialValidateRequest',
+  full_name='openstorage.api.SdkCredentialValidateRequest',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='credential_id', full_name='openstorage.api.SdkCredentialValidateRequest.credential_id', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=7262,
+  serialized_end=7315,
+)
+
+
+_SDKCREDENTIALVALIDATERESPONSE = _descriptor.Descriptor(
+  name='SdkCredentialValidateResponse',
+  full_name='openstorage.api.SdkCredentialValidateResponse',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=7317,
+  serialized_end=7348,
+)
+
+
+_SDKVOLUMEMOUNTREQUEST_OPTIONSENTRY = _descriptor.Descriptor(
+  name='OptionsEntry',
+  full_name='openstorage.api.SdkVolumeMountRequest.OptionsEntry',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='key', full_name='openstorage.api.SdkVolumeMountRequest.OptionsEntry.key', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='value', full_name='openstorage.api.SdkVolumeMountRequest.OptionsEntry.value', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -2894,33 +3626,33 @@ _VOLUMEMOUNTREQUEST_OPTIONSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3850,
-  serialized_end=3896,
+  serialized_start=4074,
+  serialized_end=4120,
 )
 
-_VOLUMEMOUNTREQUEST = _descriptor.Descriptor(
-  name='VolumeMountRequest',
-  full_name='openstorage.api.VolumeMountRequest',
+_SDKVOLUMEMOUNTREQUEST = _descriptor.Descriptor(
+  name='SdkVolumeMountRequest',
+  full_name='openstorage.api.SdkVolumeMountRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='volume_id', full_name='openstorage.api.VolumeMountRequest.volume_id', index=0,
+      name='volume_id', full_name='openstorage.api.SdkVolumeMountRequest.volume_id', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='mount_path', full_name='openstorage.api.VolumeMountRequest.mount_path', index=1,
+      name='mount_path', full_name='openstorage.api.SdkVolumeMountRequest.mount_path', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='options', full_name='openstorage.api.VolumeMountRequest.options', index=2,
+      name='options', full_name='openstorage.api.SdkVolumeMountRequest.options', index=2,
       number=3, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -2929,7 +3661,7 @@ _VOLUMEMOUNTREQUEST = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_VOLUMEMOUNTREQUEST_OPTIONSENTRY, ],
+  nested_types=[_SDKVOLUMEMOUNTREQUEST_OPTIONSENTRY, ],
   enum_types=[
   ],
   options=None,
@@ -2938,14 +3670,14 @@ _VOLUMEMOUNTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5778,
-  serialized_end=5952,
+  serialized_start=7351,
+  serialized_end=7531,
 )
 
 
-_VOLUMEMOUNTRESPONSE = _descriptor.Descriptor(
-  name='VolumeMountResponse',
-  full_name='openstorage.api.VolumeMountResponse',
+_SDKVOLUMEMOUNTRESPONSE = _descriptor.Descriptor(
+  name='SdkVolumeMountResponse',
+  full_name='openstorage.api.SdkVolumeMountResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -2962,27 +3694,27 @@ _VOLUMEMOUNTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5954,
-  serialized_end=5975,
+  serialized_start=7533,
+  serialized_end=7557,
 )
 
 
-_VOLUMEUNMOUNTREQUEST_OPTIONSENTRY = _descriptor.Descriptor(
+_SDKVOLUMEUNMOUNTREQUEST_OPTIONSENTRY = _descriptor.Descriptor(
   name='OptionsEntry',
-  full_name='openstorage.api.VolumeUnmountRequest.OptionsEntry',
+  full_name='openstorage.api.SdkVolumeUnmountRequest.OptionsEntry',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='key', full_name='openstorage.api.VolumeUnmountRequest.OptionsEntry.key', index=0,
+      name='key', full_name='openstorage.api.SdkVolumeUnmountRequest.OptionsEntry.key', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='value', full_name='openstorage.api.VolumeUnmountRequest.OptionsEntry.value', index=1,
+      name='value', full_name='openstorage.api.SdkVolumeUnmountRequest.OptionsEntry.value', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -3000,33 +3732,33 @@ _VOLUMEUNMOUNTREQUEST_OPTIONSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3850,
-  serialized_end=3896,
+  serialized_start=4074,
+  serialized_end=4120,
 )
 
-_VOLUMEUNMOUNTREQUEST = _descriptor.Descriptor(
-  name='VolumeUnmountRequest',
-  full_name='openstorage.api.VolumeUnmountRequest',
+_SDKVOLUMEUNMOUNTREQUEST = _descriptor.Descriptor(
+  name='SdkVolumeUnmountRequest',
+  full_name='openstorage.api.SdkVolumeUnmountRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='volume_id', full_name='openstorage.api.VolumeUnmountRequest.volume_id', index=0,
+      name='volume_id', full_name='openstorage.api.SdkVolumeUnmountRequest.volume_id', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='mount_path', full_name='openstorage.api.VolumeUnmountRequest.mount_path', index=1,
+      name='mount_path', full_name='openstorage.api.SdkVolumeUnmountRequest.mount_path', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='options', full_name='openstorage.api.VolumeUnmountRequest.options', index=2,
+      name='options', full_name='openstorage.api.SdkVolumeUnmountRequest.options', index=2,
       number=3, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -3035,7 +3767,7 @@ _VOLUMEUNMOUNTREQUEST = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_VOLUMEUNMOUNTREQUEST_OPTIONSENTRY, ],
+  nested_types=[_SDKVOLUMEUNMOUNTREQUEST_OPTIONSENTRY, ],
   enum_types=[
   ],
   options=None,
@@ -3044,14 +3776,14 @@ _VOLUMEUNMOUNTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=5978,
-  serialized_end=6156,
+  serialized_start=7560,
+  serialized_end=7744,
 )
 
 
-_VOLUMEUNMOUNTRESPONSE = _descriptor.Descriptor(
-  name='VolumeUnmountResponse',
-  full_name='openstorage.api.VolumeUnmountResponse',
+_SDKVOLUMEUNMOUNTRESPONSE = _descriptor.Descriptor(
+  name='SdkVolumeUnmountResponse',
+  full_name='openstorage.api.SdkVolumeUnmountResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -3068,27 +3800,27 @@ _VOLUMEUNMOUNTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6158,
-  serialized_end=6181,
+  serialized_start=7746,
+  serialized_end=7772,
 )
 
 
-_VOLUMEATTACHREQUEST_OPTIONSENTRY = _descriptor.Descriptor(
+_SDKVOLUMEATTACHREQUEST_OPTIONSENTRY = _descriptor.Descriptor(
   name='OptionsEntry',
-  full_name='openstorage.api.VolumeAttachRequest.OptionsEntry',
+  full_name='openstorage.api.SdkVolumeAttachRequest.OptionsEntry',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='key', full_name='openstorage.api.VolumeAttachRequest.OptionsEntry.key', index=0,
+      name='key', full_name='openstorage.api.SdkVolumeAttachRequest.OptionsEntry.key', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='value', full_name='openstorage.api.VolumeAttachRequest.OptionsEntry.value', index=1,
+      name='value', full_name='openstorage.api.SdkVolumeAttachRequest.OptionsEntry.value', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -3106,26 +3838,26 @@ _VOLUMEATTACHREQUEST_OPTIONSENTRY = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=3850,
-  serialized_end=3896,
+  serialized_start=4074,
+  serialized_end=4120,
 )
 
-_VOLUMEATTACHREQUEST = _descriptor.Descriptor(
-  name='VolumeAttachRequest',
-  full_name='openstorage.api.VolumeAttachRequest',
+_SDKVOLUMEATTACHREQUEST = _descriptor.Descriptor(
+  name='SdkVolumeAttachRequest',
+  full_name='openstorage.api.SdkVolumeAttachRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='volume_id', full_name='openstorage.api.VolumeAttachRequest.volume_id', index=0,
+      name='volume_id', full_name='openstorage.api.SdkVolumeAttachRequest.volume_id', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='options', full_name='openstorage.api.VolumeAttachRequest.options', index=1,
+      name='options', full_name='openstorage.api.SdkVolumeAttachRequest.options', index=1,
       number=2, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -3134,7 +3866,7 @@ _VOLUMEATTACHREQUEST = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_VOLUMEATTACHREQUEST_OPTIONSENTRY, ],
+  nested_types=[_SDKVOLUMEATTACHREQUEST_OPTIONSENTRY, ],
   enum_types=[
   ],
   options=None,
@@ -3143,20 +3875,20 @@ _VOLUMEATTACHREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6184,
-  serialized_end=6340,
+  serialized_start=7775,
+  serialized_end=7937,
 )
 
 
-_VOLUMEATTACHRESPONSE = _descriptor.Descriptor(
-  name='VolumeAttachResponse',
-  full_name='openstorage.api.VolumeAttachResponse',
+_SDKVOLUMEATTACHRESPONSE = _descriptor.Descriptor(
+  name='SdkVolumeAttachResponse',
+  full_name='openstorage.api.SdkVolumeAttachResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='device_path', full_name='openstorage.api.VolumeAttachResponse.device_path', index=0,
+      name='device_path', full_name='openstorage.api.SdkVolumeAttachResponse.device_path', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -3174,20 +3906,20 @@ _VOLUMEATTACHRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6342,
-  serialized_end=6385,
+  serialized_start=7939,
+  serialized_end=7985,
 )
 
 
-_VOLUMEDETACHREQUEST = _descriptor.Descriptor(
-  name='VolumeDetachRequest',
-  full_name='openstorage.api.VolumeDetachRequest',
+_SDKVOLUMEDETACHREQUEST = _descriptor.Descriptor(
+  name='SdkVolumeDetachRequest',
+  full_name='openstorage.api.SdkVolumeDetachRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='volume_id', full_name='openstorage.api.VolumeDetachRequest.volume_id', index=0,
+      name='volume_id', full_name='openstorage.api.SdkVolumeDetachRequest.volume_id', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -3205,14 +3937,14 @@ _VOLUMEDETACHREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6387,
-  serialized_end=6427,
+  serialized_start=7987,
+  serialized_end=8030,
 )
 
 
-_VOLUMEDETACHRESPONSE = _descriptor.Descriptor(
-  name='VolumeDetachResponse',
-  full_name='openstorage.api.VolumeDetachResponse',
+_SDKVOLUMEDETACHRESPONSE = _descriptor.Descriptor(
+  name='SdkVolumeDetachResponse',
+  full_name='openstorage.api.SdkVolumeDetachResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -3229,27 +3961,27 @@ _VOLUMEDETACHRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6429,
-  serialized_end=6451,
+  serialized_start=8032,
+  serialized_end=8057,
 )
 
 
-_OPENSTORAGEVOLUMECREATEREQUEST = _descriptor.Descriptor(
-  name='OpenStorageVolumeCreateRequest',
-  full_name='openstorage.api.OpenStorageVolumeCreateRequest',
+_SDKVOLUMECREATEREQUEST = _descriptor.Descriptor(
+  name='SdkVolumeCreateRequest',
+  full_name='openstorage.api.SdkVolumeCreateRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='name', full_name='openstorage.api.OpenStorageVolumeCreateRequest.name', index=0,
+      name='name', full_name='openstorage.api.SdkVolumeCreateRequest.name', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='spec', full_name='openstorage.api.OpenStorageVolumeCreateRequest.spec', index=1,
+      name='spec', full_name='openstorage.api.SdkVolumeCreateRequest.spec', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -3267,20 +3999,20 @@ _OPENSTORAGEVOLUMECREATEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6453,
-  serialized_end=6542,
+  serialized_start=8059,
+  serialized_end=8140,
 )
 
 
-_OPENSTORAGEVOLUMECREATERESPONSE = _descriptor.Descriptor(
-  name='OpenStorageVolumeCreateResponse',
-  full_name='openstorage.api.OpenStorageVolumeCreateResponse',
+_SDKVOLUMECREATERESPONSE = _descriptor.Descriptor(
+  name='SdkVolumeCreateResponse',
+  full_name='openstorage.api.SdkVolumeCreateResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='volume_id', full_name='openstorage.api.OpenStorageVolumeCreateResponse.volume_id', index=0,
+      name='volume_id', full_name='openstorage.api.SdkVolumeCreateResponse.volume_id', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -3298,34 +4030,34 @@ _OPENSTORAGEVOLUMECREATERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6544,
-  serialized_end=6596,
+  serialized_start=8142,
+  serialized_end=8186,
 )
 
 
-_VOLUMECREATEFROMVOLUMEIDREQUEST = _descriptor.Descriptor(
-  name='VolumeCreateFromVolumeIDRequest',
-  full_name='openstorage.api.VolumeCreateFromVolumeIDRequest',
+_SDKVOLUMECREATEFROMVOLUMEIDREQUEST = _descriptor.Descriptor(
+  name='SdkVolumeCreateFromVolumeIdRequest',
+  full_name='openstorage.api.SdkVolumeCreateFromVolumeIdRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='name', full_name='openstorage.api.VolumeCreateFromVolumeIDRequest.name', index=0,
+      name='name', full_name='openstorage.api.SdkVolumeCreateFromVolumeIdRequest.name', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='parent_id', full_name='openstorage.api.VolumeCreateFromVolumeIDRequest.parent_id', index=1,
+      name='parent_id', full_name='openstorage.api.SdkVolumeCreateFromVolumeIdRequest.parent_id', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='spec', full_name='openstorage.api.VolumeCreateFromVolumeIDRequest.spec', index=2,
+      name='spec', full_name='openstorage.api.SdkVolumeCreateFromVolumeIdRequest.spec', index=2,
       number=3, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -3343,20 +4075,20 @@ _VOLUMECREATEFROMVOLUMEIDREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6598,
-  serialized_end=6707,
+  serialized_start=8188,
+  serialized_end=8300,
 )
 
 
-_VOLUMECREATEFROMVOLUMEIDRESPONSE = _descriptor.Descriptor(
-  name='VolumeCreateFromVolumeIDResponse',
-  full_name='openstorage.api.VolumeCreateFromVolumeIDResponse',
+_SDKVOLUMECREATEFROMVOLUMEIDRESPONSE = _descriptor.Descriptor(
+  name='SdkVolumeCreateFromVolumeIdResponse',
+  full_name='openstorage.api.SdkVolumeCreateFromVolumeIdResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='volume_id', full_name='openstorage.api.VolumeCreateFromVolumeIDResponse.volume_id', index=0,
+      name='volume_id', full_name='openstorage.api.SdkVolumeCreateFromVolumeIdResponse.volume_id', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -3374,20 +4106,20 @@ _VOLUMECREATEFROMVOLUMEIDRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6709,
-  serialized_end=6762,
+  serialized_start=8302,
+  serialized_end=8358,
 )
 
 
-_VOLUMEDELETEREQUEST = _descriptor.Descriptor(
-  name='VolumeDeleteRequest',
-  full_name='openstorage.api.VolumeDeleteRequest',
+_SDKVOLUMEDELETEREQUEST = _descriptor.Descriptor(
+  name='SdkVolumeDeleteRequest',
+  full_name='openstorage.api.SdkVolumeDeleteRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='volume_id', full_name='openstorage.api.VolumeDeleteRequest.volume_id', index=0,
+      name='volume_id', full_name='openstorage.api.SdkVolumeDeleteRequest.volume_id', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -3405,14 +4137,14 @@ _VOLUMEDELETEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6764,
-  serialized_end=6804,
+  serialized_start=8360,
+  serialized_end=8403,
 )
 
 
-_VOLUMEDELETERESPONSE = _descriptor.Descriptor(
-  name='VolumeDeleteResponse',
-  full_name='openstorage.api.VolumeDeleteResponse',
+_SDKVOLUMEDELETERESPONSE = _descriptor.Descriptor(
+  name='SdkVolumeDeleteResponse',
+  full_name='openstorage.api.SdkVolumeDeleteResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -3429,20 +4161,20 @@ _VOLUMEDELETERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6806,
-  serialized_end=6828,
+  serialized_start=8405,
+  serialized_end=8430,
 )
 
 
-_VOLUMEINSPECTREQUEST = _descriptor.Descriptor(
-  name='VolumeInspectRequest',
-  full_name='openstorage.api.VolumeInspectRequest',
+_SDKVOLUMEINSPECTREQUEST = _descriptor.Descriptor(
+  name='SdkVolumeInspectRequest',
+  full_name='openstorage.api.SdkVolumeInspectRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='volume_id', full_name='openstorage.api.VolumeInspectRequest.volume_id', index=0,
+      name='volume_id', full_name='openstorage.api.SdkVolumeInspectRequest.volume_id', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -3460,20 +4192,20 @@ _VOLUMEINSPECTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6830,
-  serialized_end=6871,
+  serialized_start=8432,
+  serialized_end=8476,
 )
 
 
-_VOLUMEINSPECTRESPONSE = _descriptor.Descriptor(
-  name='VolumeInspectResponse',
-  full_name='openstorage.api.VolumeInspectResponse',
+_SDKVOLUMEINSPECTRESPONSE = _descriptor.Descriptor(
+  name='SdkVolumeInspectResponse',
+  full_name='openstorage.api.SdkVolumeInspectResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='volume', full_name='openstorage.api.VolumeInspectResponse.volume', index=0,
+      name='volume', full_name='openstorage.api.SdkVolumeInspectResponse.volume', index=0,
       number=1, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -3491,20 +4223,20 @@ _VOLUMEINSPECTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6873,
-  serialized_end=6937,
+  serialized_start=8478,
+  serialized_end=8545,
 )
 
 
-_VOLUMEENUMERATEREQUEST = _descriptor.Descriptor(
-  name='VolumeEnumerateRequest',
-  full_name='openstorage.api.VolumeEnumerateRequest',
+_SDKVOLUMEENUMERATEREQUEST = _descriptor.Descriptor(
+  name='SdkVolumeEnumerateRequest',
+  full_name='openstorage.api.SdkVolumeEnumerateRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='locator', full_name='openstorage.api.VolumeEnumerateRequest.locator', index=0,
+      name='locator', full_name='openstorage.api.SdkVolumeEnumerateRequest.locator', index=0,
       number=1, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -3522,20 +4254,20 @@ _VOLUMEENUMERATEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=6939,
-  serialized_end=7012,
+  serialized_start=8547,
+  serialized_end=8623,
 )
 
 
-_VOLUMEENUMERATERESPONSE = _descriptor.Descriptor(
-  name='VolumeEnumerateResponse',
-  full_name='openstorage.api.VolumeEnumerateResponse',
+_SDKVOLUMEENUMERATERESPONSE = _descriptor.Descriptor(
+  name='SdkVolumeEnumerateResponse',
+  full_name='openstorage.api.SdkVolumeEnumerateResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='volumes', full_name='openstorage.api.VolumeEnumerateResponse.volumes', index=0,
+      name='volumes', full_name='openstorage.api.SdkVolumeEnumerateResponse.volumes', index=0,
       number=1, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -3553,27 +4285,27 @@ _VOLUMEENUMERATERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7014,
-  serialized_end=7081,
+  serialized_start=8625,
+  serialized_end=8695,
 )
 
 
-_VOLUMESNAPSHOTCREATEREQUEST_LABELSENTRY = _descriptor.Descriptor(
+_SDKVOLUMESNAPSHOTCREATEREQUEST_LABELSENTRY = _descriptor.Descriptor(
   name='LabelsEntry',
-  full_name='openstorage.api.VolumeSnapshotCreateRequest.LabelsEntry',
+  full_name='openstorage.api.SdkVolumeSnapshotCreateRequest.LabelsEntry',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='key', full_name='openstorage.api.VolumeSnapshotCreateRequest.LabelsEntry.key', index=0,
+      name='key', full_name='openstorage.api.SdkVolumeSnapshotCreateRequest.LabelsEntry.key', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='value', full_name='openstorage.api.VolumeSnapshotCreateRequest.LabelsEntry.value', index=1,
+      name='value', full_name='openstorage.api.SdkVolumeSnapshotCreateRequest.LabelsEntry.value', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -3595,22 +4327,22 @@ _VOLUMESNAPSHOTCREATEREQUEST_LABELSENTRY = _descriptor.Descriptor(
   serialized_end=657,
 )
 
-_VOLUMESNAPSHOTCREATEREQUEST = _descriptor.Descriptor(
-  name='VolumeSnapshotCreateRequest',
-  full_name='openstorage.api.VolumeSnapshotCreateRequest',
+_SDKVOLUMESNAPSHOTCREATEREQUEST = _descriptor.Descriptor(
+  name='SdkVolumeSnapshotCreateRequest',
+  full_name='openstorage.api.SdkVolumeSnapshotCreateRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='volume_id', full_name='openstorage.api.VolumeSnapshotCreateRequest.volume_id', index=0,
+      name='volume_id', full_name='openstorage.api.SdkVolumeSnapshotCreateRequest.volume_id', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='labels', full_name='openstorage.api.VolumeSnapshotCreateRequest.labels', index=1,
+      name='labels', full_name='openstorage.api.SdkVolumeSnapshotCreateRequest.labels', index=1,
       number=2, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -3619,7 +4351,7 @@ _VOLUMESNAPSHOTCREATEREQUEST = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_VOLUMESNAPSHOTCREATEREQUEST_LABELSENTRY, ],
+  nested_types=[_SDKVOLUMESNAPSHOTCREATEREQUEST_LABELSENTRY, ],
   enum_types=[
   ],
   options=None,
@@ -3628,20 +4360,20 @@ _VOLUMESNAPSHOTCREATEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7084,
-  serialized_end=7253,
+  serialized_start=8698,
+  serialized_end=8873,
 )
 
 
-_VOLUMESNAPSHOTCREATERESPONSE = _descriptor.Descriptor(
-  name='VolumeSnapshotCreateResponse',
-  full_name='openstorage.api.VolumeSnapshotCreateResponse',
+_SDKVOLUMESNAPSHOTCREATERESPONSE = _descriptor.Descriptor(
+  name='SdkVolumeSnapshotCreateResponse',
+  full_name='openstorage.api.SdkVolumeSnapshotCreateResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='snapshot_id', full_name='openstorage.api.VolumeSnapshotCreateResponse.snapshot_id', index=0,
+      name='snapshot_id', full_name='openstorage.api.SdkVolumeSnapshotCreateResponse.snapshot_id', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -3659,27 +4391,27 @@ _VOLUMESNAPSHOTCREATERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7255,
-  serialized_end=7306,
+  serialized_start=8875,
+  serialized_end=8929,
 )
 
 
-_VOLUMESNAPSHOTRESTOREREQUEST = _descriptor.Descriptor(
-  name='VolumeSnapshotRestoreRequest',
-  full_name='openstorage.api.VolumeSnapshotRestoreRequest',
+_SDKVOLUMESNAPSHOTRESTOREREQUEST = _descriptor.Descriptor(
+  name='SdkVolumeSnapshotRestoreRequest',
+  full_name='openstorage.api.SdkVolumeSnapshotRestoreRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='volume_id', full_name='openstorage.api.VolumeSnapshotRestoreRequest.volume_id', index=0,
+      name='volume_id', full_name='openstorage.api.SdkVolumeSnapshotRestoreRequest.volume_id', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='snapshot_id', full_name='openstorage.api.VolumeSnapshotRestoreRequest.snapshot_id', index=1,
+      name='snapshot_id', full_name='openstorage.api.SdkVolumeSnapshotRestoreRequest.snapshot_id', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -3697,14 +4429,14 @@ _VOLUMESNAPSHOTRESTOREREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7308,
-  serialized_end=7378,
+  serialized_start=8931,
+  serialized_end=9004,
 )
 
 
-_VOLUMESNAPSHOTRESTORERESPONSE = _descriptor.Descriptor(
-  name='VolumeSnapshotRestoreResponse',
-  full_name='openstorage.api.VolumeSnapshotRestoreResponse',
+_SDKVOLUMESNAPSHOTRESTORERESPONSE = _descriptor.Descriptor(
+  name='SdkVolumeSnapshotRestoreResponse',
+  full_name='openstorage.api.SdkVolumeSnapshotRestoreResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -3721,27 +4453,27 @@ _VOLUMESNAPSHOTRESTORERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7380,
-  serialized_end=7411,
+  serialized_start=9006,
+  serialized_end=9040,
 )
 
 
-_VOLUMESNAPSHOTENUMERATEREQUEST_LABELSENTRY = _descriptor.Descriptor(
+_SDKVOLUMESNAPSHOTENUMERATEREQUEST_LABELSENTRY = _descriptor.Descriptor(
   name='LabelsEntry',
-  full_name='openstorage.api.VolumeSnapshotEnumerateRequest.LabelsEntry',
+  full_name='openstorage.api.SdkVolumeSnapshotEnumerateRequest.LabelsEntry',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='key', full_name='openstorage.api.VolumeSnapshotEnumerateRequest.LabelsEntry.key', index=0,
+      name='key', full_name='openstorage.api.SdkVolumeSnapshotEnumerateRequest.LabelsEntry.key', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='value', full_name='openstorage.api.VolumeSnapshotEnumerateRequest.LabelsEntry.value', index=1,
+      name='value', full_name='openstorage.api.SdkVolumeSnapshotEnumerateRequest.LabelsEntry.value', index=1,
       number=2, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -3763,22 +4495,22 @@ _VOLUMESNAPSHOTENUMERATEREQUEST_LABELSENTRY = _descriptor.Descriptor(
   serialized_end=657,
 )
 
-_VOLUMESNAPSHOTENUMERATEREQUEST = _descriptor.Descriptor(
-  name='VolumeSnapshotEnumerateRequest',
-  full_name='openstorage.api.VolumeSnapshotEnumerateRequest',
+_SDKVOLUMESNAPSHOTENUMERATEREQUEST = _descriptor.Descriptor(
+  name='SdkVolumeSnapshotEnumerateRequest',
+  full_name='openstorage.api.SdkVolumeSnapshotEnumerateRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='volume_id', full_name='openstorage.api.VolumeSnapshotEnumerateRequest.volume_id', index=0,
+      name='volume_id', full_name='openstorage.api.SdkVolumeSnapshotEnumerateRequest.volume_id', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='labels', full_name='openstorage.api.VolumeSnapshotEnumerateRequest.labels', index=1,
+      name='labels', full_name='openstorage.api.SdkVolumeSnapshotEnumerateRequest.labels', index=1,
       number=2, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -3787,7 +4519,7 @@ _VOLUMESNAPSHOTENUMERATEREQUEST = _descriptor.Descriptor(
   ],
   extensions=[
   ],
-  nested_types=[_VOLUMESNAPSHOTENUMERATEREQUEST_LABELSENTRY, ],
+  nested_types=[_SDKVOLUMESNAPSHOTENUMERATEREQUEST_LABELSENTRY, ],
   enum_types=[
   ],
   options=None,
@@ -3796,20 +4528,20 @@ _VOLUMESNAPSHOTENUMERATEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7414,
-  serialized_end=7589,
+  serialized_start=9043,
+  serialized_end=9224,
 )
 
 
-_VOLUMESNAPSHOTENUMERATERESPONSE = _descriptor.Descriptor(
-  name='VolumeSnapshotEnumerateResponse',
-  full_name='openstorage.api.VolumeSnapshotEnumerateResponse',
+_SDKVOLUMESNAPSHOTENUMERATERESPONSE = _descriptor.Descriptor(
+  name='SdkVolumeSnapshotEnumerateResponse',
+  full_name='openstorage.api.SdkVolumeSnapshotEnumerateResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='snapshots', full_name='openstorage.api.VolumeSnapshotEnumerateResponse.snapshots', index=0,
+      name='snapshots', full_name='openstorage.api.SdkVolumeSnapshotEnumerateResponse.snapshots', index=0,
       number=1, type=11, cpp_type=10, label=3,
       has_default_value=False, default_value=[],
       message_type=None, enum_type=None, containing_type=None,
@@ -3827,14 +4559,14 @@ _VOLUMESNAPSHOTENUMERATERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7591,
-  serialized_end=7668,
+  serialized_start=9226,
+  serialized_end=9306,
 )
 
 
-_CLUSTERENUMERATEREQUEST = _descriptor.Descriptor(
-  name='ClusterEnumerateRequest',
-  full_name='openstorage.api.ClusterEnumerateRequest',
+_SDKCLUSTERENUMERATEREQUEST = _descriptor.Descriptor(
+  name='SdkClusterEnumerateRequest',
+  full_name='openstorage.api.SdkClusterEnumerateRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -3851,20 +4583,20 @@ _CLUSTERENUMERATEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7670,
-  serialized_end=7695,
+  serialized_start=9308,
+  serialized_end=9336,
 )
 
 
-_CLUSTERENUMERATERESPONSE = _descriptor.Descriptor(
-  name='ClusterEnumerateResponse',
-  full_name='openstorage.api.ClusterEnumerateResponse',
+_SDKCLUSTERENUMERATERESPONSE = _descriptor.Descriptor(
+  name='SdkClusterEnumerateResponse',
+  full_name='openstorage.api.SdkClusterEnumerateResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='cluster', full_name='openstorage.api.ClusterEnumerateResponse.cluster', index=0,
+      name='cluster', full_name='openstorage.api.SdkClusterEnumerateResponse.cluster', index=0,
       number=1, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -3882,20 +4614,20 @@ _CLUSTERENUMERATERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7697,
-  serialized_end=7773,
+  serialized_start=9338,
+  serialized_end=9417,
 )
 
 
-_CLUSTERINSPECTREQUEST = _descriptor.Descriptor(
-  name='ClusterInspectRequest',
-  full_name='openstorage.api.ClusterInspectRequest',
+_SDKCLUSTERINSPECTREQUEST = _descriptor.Descriptor(
+  name='SdkClusterInspectRequest',
+  full_name='openstorage.api.SdkClusterInspectRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='node_id', full_name='openstorage.api.ClusterInspectRequest.node_id', index=0,
+      name='node_id', full_name='openstorage.api.SdkClusterInspectRequest.node_id', index=0,
       number=1, type=9, cpp_type=9, label=1,
       has_default_value=False, default_value=_b("").decode('utf-8'),
       message_type=None, enum_type=None, containing_type=None,
@@ -3913,20 +4645,20 @@ _CLUSTERINSPECTREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7775,
-  serialized_end=7815,
+  serialized_start=9419,
+  serialized_end=9462,
 )
 
 
-_CLUSTERINSPECTRESPONSE = _descriptor.Descriptor(
-  name='ClusterInspectResponse',
-  full_name='openstorage.api.ClusterInspectResponse',
+_SDKCLUSTERINSPECTRESPONSE = _descriptor.Descriptor(
+  name='SdkClusterInspectResponse',
+  full_name='openstorage.api.SdkClusterInspectResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='node', full_name='openstorage.api.ClusterInspectResponse.node', index=0,
+      name='node', full_name='openstorage.api.SdkClusterInspectResponse.node', index=0,
       number=1, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -3944,34 +4676,34 @@ _CLUSTERINSPECTRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7817,
-  serialized_end=7885,
+  serialized_start=9464,
+  serialized_end=9535,
 )
 
 
-_CLUSTERALERTENUMERATEREQUEST = _descriptor.Descriptor(
-  name='ClusterAlertEnumerateRequest',
-  full_name='openstorage.api.ClusterAlertEnumerateRequest',
+_SDKCLUSTERALERTENUMERATEREQUEST = _descriptor.Descriptor(
+  name='SdkClusterAlertEnumerateRequest',
+  full_name='openstorage.api.SdkClusterAlertEnumerateRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='time_start', full_name='openstorage.api.ClusterAlertEnumerateRequest.time_start', index=0,
+      name='time_start', full_name='openstorage.api.SdkClusterAlertEnumerateRequest.time_start', index=0,
       number=1, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='time_end', full_name='openstorage.api.ClusterAlertEnumerateRequest.time_end', index=1,
+      name='time_end', full_name='openstorage.api.SdkClusterAlertEnumerateRequest.time_end', index=1,
       number=2, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='resource', full_name='openstorage.api.ClusterAlertEnumerateRequest.resource', index=2,
+      name='resource', full_name='openstorage.api.SdkClusterAlertEnumerateRequest.resource', index=2,
       number=3, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -3989,20 +4721,20 @@ _CLUSTERALERTENUMERATEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=7888,
-  serialized_end=8061,
+  serialized_start=9538,
+  serialized_end=9714,
 )
 
 
-_CLUSTERALERTENUMERATERESPONSE = _descriptor.Descriptor(
-  name='ClusterAlertEnumerateResponse',
-  full_name='openstorage.api.ClusterAlertEnumerateResponse',
+_SDKCLUSTERALERTENUMERATERESPONSE = _descriptor.Descriptor(
+  name='SdkClusterAlertEnumerateResponse',
+  full_name='openstorage.api.SdkClusterAlertEnumerateResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='alerts', full_name='openstorage.api.ClusterAlertEnumerateResponse.alerts', index=0,
+      name='alerts', full_name='openstorage.api.SdkClusterAlertEnumerateResponse.alerts', index=0,
       number=1, type=11, cpp_type=10, label=1,
       has_default_value=False, default_value=None,
       message_type=None, enum_type=None, containing_type=None,
@@ -4020,27 +4752,27 @@ _CLUSTERALERTENUMERATERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8063,
-  serialized_end=8135,
+  serialized_start=9716,
+  serialized_end=9791,
 )
 
 
-_CLUSTERALERTCLEARREQUEST = _descriptor.Descriptor(
-  name='ClusterAlertClearRequest',
-  full_name='openstorage.api.ClusterAlertClearRequest',
+_SDKCLUSTERALERTCLEARREQUEST = _descriptor.Descriptor(
+  name='SdkClusterAlertClearRequest',
+  full_name='openstorage.api.SdkClusterAlertClearRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='resource', full_name='openstorage.api.ClusterAlertClearRequest.resource', index=0,
+      name='resource', full_name='openstorage.api.SdkClusterAlertClearRequest.resource', index=0,
       number=1, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='alert_id', full_name='openstorage.api.ClusterAlertClearRequest.alert_id', index=1,
+      name='alert_id', full_name='openstorage.api.SdkClusterAlertClearRequest.alert_id', index=1,
       number=2, type=3, cpp_type=2, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -4058,14 +4790,14 @@ _CLUSTERALERTCLEARREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8137,
-  serialized_end=8230,
+  serialized_start=9793,
+  serialized_end=9889,
 )
 
 
-_CLUSTERALERTCLEARRESPONSE = _descriptor.Descriptor(
-  name='ClusterAlertClearResponse',
-  full_name='openstorage.api.ClusterAlertClearResponse',
+_SDKCLUSTERALERTCLEARRESPONSE = _descriptor.Descriptor(
+  name='SdkClusterAlertClearResponse',
+  full_name='openstorage.api.SdkClusterAlertClearResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -4082,27 +4814,27 @@ _CLUSTERALERTCLEARRESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8232,
-  serialized_end=8259,
+  serialized_start=9891,
+  serialized_end=9921,
 )
 
 
-_CLUSTERALERTERASEREQUEST = _descriptor.Descriptor(
-  name='ClusterAlertEraseRequest',
-  full_name='openstorage.api.ClusterAlertEraseRequest',
+_SDKCLUSTERALERTERASEREQUEST = _descriptor.Descriptor(
+  name='SdkClusterAlertEraseRequest',
+  full_name='openstorage.api.SdkClusterAlertEraseRequest',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
   fields=[
     _descriptor.FieldDescriptor(
-      name='resource', full_name='openstorage.api.ClusterAlertEraseRequest.resource', index=0,
+      name='resource', full_name='openstorage.api.SdkClusterAlertEraseRequest.resource', index=0,
       number=1, type=14, cpp_type=8, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
       is_extension=False, extension_scope=None,
       options=None, file=DESCRIPTOR),
     _descriptor.FieldDescriptor(
-      name='alert_id', full_name='openstorage.api.ClusterAlertEraseRequest.alert_id', index=1,
+      name='alert_id', full_name='openstorage.api.SdkClusterAlertEraseRequest.alert_id', index=1,
       number=2, type=3, cpp_type=2, label=1,
       has_default_value=False, default_value=0,
       message_type=None, enum_type=None, containing_type=None,
@@ -4120,14 +4852,14 @@ _CLUSTERALERTERASEREQUEST = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8261,
-  serialized_end=8354,
+  serialized_start=9923,
+  serialized_end=10019,
 )
 
 
-_CLUSTERALERTERASERESPONSE = _descriptor.Descriptor(
-  name='ClusterAlertEraseResponse',
-  full_name='openstorage.api.ClusterAlertEraseResponse',
+_SDKCLUSTERALERTERASERESPONSE = _descriptor.Descriptor(
+  name='SdkClusterAlertEraseResponse',
+  full_name='openstorage.api.SdkClusterAlertEraseResponse',
   filename=None,
   file=DESCRIPTOR,
   containing_type=None,
@@ -4144,8 +4876,8 @@ _CLUSTERALERTERASERESPONSE = _descriptor.Descriptor(
   extension_ranges=[],
   oneofs=[
   ],
-  serialized_start=8356,
-  serialized_end=8383,
+  serialized_start=10021,
+  serialized_end=10051,
 )
 
 _STORAGERESOURCE.fields_by_name['medium'].enum_type = _STORAGEMEDIUM
@@ -4218,30 +4950,36 @@ _STORAGENODE.fields_by_name['pools'].message_type = _STORAGEPOOL
 _STORAGENODE.fields_by_name['node_labels'].message_type = _STORAGENODE_NODELABELSENTRY
 _STORAGECLUSTER.fields_by_name['status'].enum_type = _STATUS
 _STORAGECLUSTER.fields_by_name['nodes'].message_type = _STORAGENODE
-_VOLUMEMOUNTREQUEST_OPTIONSENTRY.containing_type = _VOLUMEMOUNTREQUEST
-_VOLUMEMOUNTREQUEST.fields_by_name['options'].message_type = _VOLUMEMOUNTREQUEST_OPTIONSENTRY
-_VOLUMEUNMOUNTREQUEST_OPTIONSENTRY.containing_type = _VOLUMEUNMOUNTREQUEST
-_VOLUMEUNMOUNTREQUEST.fields_by_name['options'].message_type = _VOLUMEUNMOUNTREQUEST_OPTIONSENTRY
-_VOLUMEATTACHREQUEST_OPTIONSENTRY.containing_type = _VOLUMEATTACHREQUEST
-_VOLUMEATTACHREQUEST.fields_by_name['options'].message_type = _VOLUMEATTACHREQUEST_OPTIONSENTRY
-_OPENSTORAGEVOLUMECREATEREQUEST.fields_by_name['spec'].message_type = _VOLUMESPEC
-_VOLUMECREATEFROMVOLUMEIDREQUEST.fields_by_name['spec'].message_type = _VOLUMESPEC
-_VOLUMEINSPECTRESPONSE.fields_by_name['volume'].message_type = _VOLUME
-_VOLUMEENUMERATEREQUEST.fields_by_name['locator'].message_type = _VOLUMELOCATOR
-_VOLUMEENUMERATERESPONSE.fields_by_name['volumes'].message_type = _VOLUME
-_VOLUMESNAPSHOTCREATEREQUEST_LABELSENTRY.containing_type = _VOLUMESNAPSHOTCREATEREQUEST
-_VOLUMESNAPSHOTCREATEREQUEST.fields_by_name['labels'].message_type = _VOLUMESNAPSHOTCREATEREQUEST_LABELSENTRY
-_VOLUMESNAPSHOTENUMERATEREQUEST_LABELSENTRY.containing_type = _VOLUMESNAPSHOTENUMERATEREQUEST
-_VOLUMESNAPSHOTENUMERATEREQUEST.fields_by_name['labels'].message_type = _VOLUMESNAPSHOTENUMERATEREQUEST_LABELSENTRY
-_VOLUMESNAPSHOTENUMERATERESPONSE.fields_by_name['snapshots'].message_type = _VOLUME
-_CLUSTERENUMERATERESPONSE.fields_by_name['cluster'].message_type = _STORAGECLUSTER
-_CLUSTERINSPECTRESPONSE.fields_by_name['node'].message_type = _STORAGENODE
-_CLUSTERALERTENUMERATEREQUEST.fields_by_name['time_start'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
-_CLUSTERALERTENUMERATEREQUEST.fields_by_name['time_end'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
-_CLUSTERALERTENUMERATEREQUEST.fields_by_name['resource'].enum_type = _RESOURCETYPE
-_CLUSTERALERTENUMERATERESPONSE.fields_by_name['alerts'].message_type = _ALERTS
-_CLUSTERALERTCLEARREQUEST.fields_by_name['resource'].enum_type = _RESOURCETYPE
-_CLUSTERALERTERASEREQUEST.fields_by_name['resource'].enum_type = _RESOURCETYPE
+_SDKCREDENTIALCREATEAZUREREQUEST.fields_by_name['credential'].message_type = _AZURECREDENTIAL
+_SDKCREDENTIALCREATEGOOGLEREQUEST.fields_by_name['credential'].message_type = _GOOGLECREDENTIAL
+_SDKCREDENTIALCREATEAWSREQUEST.fields_by_name['credential'].message_type = _S3CREDENTIAL
+_SDKCREDENTIALENUMERATEAWSRESPONSE.fields_by_name['credential'].message_type = _S3CREDENTIAL
+_SDKCREDENTIALENUMERATEAZURERESPONSE.fields_by_name['credential'].message_type = _AZURECREDENTIAL
+_SDKCREDENTIALENUMERATEGOOGLERESPONSE.fields_by_name['credential'].message_type = _GOOGLECREDENTIAL
+_SDKVOLUMEMOUNTREQUEST_OPTIONSENTRY.containing_type = _SDKVOLUMEMOUNTREQUEST
+_SDKVOLUMEMOUNTREQUEST.fields_by_name['options'].message_type = _SDKVOLUMEMOUNTREQUEST_OPTIONSENTRY
+_SDKVOLUMEUNMOUNTREQUEST_OPTIONSENTRY.containing_type = _SDKVOLUMEUNMOUNTREQUEST
+_SDKVOLUMEUNMOUNTREQUEST.fields_by_name['options'].message_type = _SDKVOLUMEUNMOUNTREQUEST_OPTIONSENTRY
+_SDKVOLUMEATTACHREQUEST_OPTIONSENTRY.containing_type = _SDKVOLUMEATTACHREQUEST
+_SDKVOLUMEATTACHREQUEST.fields_by_name['options'].message_type = _SDKVOLUMEATTACHREQUEST_OPTIONSENTRY
+_SDKVOLUMECREATEREQUEST.fields_by_name['spec'].message_type = _VOLUMESPEC
+_SDKVOLUMECREATEFROMVOLUMEIDREQUEST.fields_by_name['spec'].message_type = _VOLUMESPEC
+_SDKVOLUMEINSPECTRESPONSE.fields_by_name['volume'].message_type = _VOLUME
+_SDKVOLUMEENUMERATEREQUEST.fields_by_name['locator'].message_type = _VOLUMELOCATOR
+_SDKVOLUMEENUMERATERESPONSE.fields_by_name['volumes'].message_type = _VOLUME
+_SDKVOLUMESNAPSHOTCREATEREQUEST_LABELSENTRY.containing_type = _SDKVOLUMESNAPSHOTCREATEREQUEST
+_SDKVOLUMESNAPSHOTCREATEREQUEST.fields_by_name['labels'].message_type = _SDKVOLUMESNAPSHOTCREATEREQUEST_LABELSENTRY
+_SDKVOLUMESNAPSHOTENUMERATEREQUEST_LABELSENTRY.containing_type = _SDKVOLUMESNAPSHOTENUMERATEREQUEST
+_SDKVOLUMESNAPSHOTENUMERATEREQUEST.fields_by_name['labels'].message_type = _SDKVOLUMESNAPSHOTENUMERATEREQUEST_LABELSENTRY
+_SDKVOLUMESNAPSHOTENUMERATERESPONSE.fields_by_name['snapshots'].message_type = _VOLUME
+_SDKCLUSTERENUMERATERESPONSE.fields_by_name['cluster'].message_type = _STORAGECLUSTER
+_SDKCLUSTERINSPECTRESPONSE.fields_by_name['node'].message_type = _STORAGENODE
+_SDKCLUSTERALERTENUMERATEREQUEST.fields_by_name['time_start'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
+_SDKCLUSTERALERTENUMERATEREQUEST.fields_by_name['time_end'].message_type = google_dot_protobuf_dot_timestamp__pb2._TIMESTAMP
+_SDKCLUSTERALERTENUMERATEREQUEST.fields_by_name['resource'].enum_type = _RESOURCETYPE
+_SDKCLUSTERALERTENUMERATERESPONSE.fields_by_name['alerts'].message_type = _ALERTS
+_SDKCLUSTERALERTCLEARREQUEST.fields_by_name['resource'].enum_type = _RESOURCETYPE
+_SDKCLUSTERALERTERASEREQUEST.fields_by_name['resource'].enum_type = _RESOURCETYPE
 DESCRIPTOR.message_types_by_name['StorageResource'] = _STORAGERESOURCE
 DESCRIPTOR.message_types_by_name['StoragePool'] = _STORAGEPOOL
 DESCRIPTOR.message_types_by_name['VolumeLocator'] = _VOLUMELOCATOR
@@ -4254,6 +4992,7 @@ DESCRIPTOR.message_types_by_name['Volume'] = _VOLUME
 DESCRIPTOR.message_types_by_name['Stats'] = _STATS
 DESCRIPTOR.message_types_by_name['Alert'] = _ALERT
 DESCRIPTOR.message_types_by_name['Alerts'] = _ALERTS
+DESCRIPTOR.message_types_by_name['ObjectstoreInfo'] = _OBJECTSTOREINFO
 DESCRIPTOR.message_types_by_name['VolumeCreateRequest'] = _VOLUMECREATEREQUEST
 DESCRIPTOR.message_types_by_name['VolumeResponse'] = _VOLUMERESPONSE
 DESCRIPTOR.message_types_by_name['VolumeCreateResponse'] = _VOLUMECREATERESPONSE
@@ -4272,40 +5011,59 @@ DESCRIPTOR.message_types_by_name['GroupSnapCreateRequest'] = _GROUPSNAPCREATEREQ
 DESCRIPTOR.message_types_by_name['GroupSnapCreateResponse'] = _GROUPSNAPCREATERESPONSE
 DESCRIPTOR.message_types_by_name['StorageNode'] = _STORAGENODE
 DESCRIPTOR.message_types_by_name['StorageCluster'] = _STORAGECLUSTER
-DESCRIPTOR.message_types_by_name['VolumeMountRequest'] = _VOLUMEMOUNTREQUEST
-DESCRIPTOR.message_types_by_name['VolumeMountResponse'] = _VOLUMEMOUNTRESPONSE
-DESCRIPTOR.message_types_by_name['VolumeUnmountRequest'] = _VOLUMEUNMOUNTREQUEST
-DESCRIPTOR.message_types_by_name['VolumeUnmountResponse'] = _VOLUMEUNMOUNTRESPONSE
-DESCRIPTOR.message_types_by_name['VolumeAttachRequest'] = _VOLUMEATTACHREQUEST
-DESCRIPTOR.message_types_by_name['VolumeAttachResponse'] = _VOLUMEATTACHRESPONSE
-DESCRIPTOR.message_types_by_name['VolumeDetachRequest'] = _VOLUMEDETACHREQUEST
-DESCRIPTOR.message_types_by_name['VolumeDetachResponse'] = _VOLUMEDETACHRESPONSE
-DESCRIPTOR.message_types_by_name['OpenStorageVolumeCreateRequest'] = _OPENSTORAGEVOLUMECREATEREQUEST
-DESCRIPTOR.message_types_by_name['OpenStorageVolumeCreateResponse'] = _OPENSTORAGEVOLUMECREATERESPONSE
-DESCRIPTOR.message_types_by_name['VolumeCreateFromVolumeIDRequest'] = _VOLUMECREATEFROMVOLUMEIDREQUEST
-DESCRIPTOR.message_types_by_name['VolumeCreateFromVolumeIDResponse'] = _VOLUMECREATEFROMVOLUMEIDRESPONSE
-DESCRIPTOR.message_types_by_name['VolumeDeleteRequest'] = _VOLUMEDELETEREQUEST
-DESCRIPTOR.message_types_by_name['VolumeDeleteResponse'] = _VOLUMEDELETERESPONSE
-DESCRIPTOR.message_types_by_name['VolumeInspectRequest'] = _VOLUMEINSPECTREQUEST
-DESCRIPTOR.message_types_by_name['VolumeInspectResponse'] = _VOLUMEINSPECTRESPONSE
-DESCRIPTOR.message_types_by_name['VolumeEnumerateRequest'] = _VOLUMEENUMERATEREQUEST
-DESCRIPTOR.message_types_by_name['VolumeEnumerateResponse'] = _VOLUMEENUMERATERESPONSE
-DESCRIPTOR.message_types_by_name['VolumeSnapshotCreateRequest'] = _VOLUMESNAPSHOTCREATEREQUEST
-DESCRIPTOR.message_types_by_name['VolumeSnapshotCreateResponse'] = _VOLUMESNAPSHOTCREATERESPONSE
-DESCRIPTOR.message_types_by_name['VolumeSnapshotRestoreRequest'] = _VOLUMESNAPSHOTRESTOREREQUEST
-DESCRIPTOR.message_types_by_name['VolumeSnapshotRestoreResponse'] = _VOLUMESNAPSHOTRESTORERESPONSE
-DESCRIPTOR.message_types_by_name['VolumeSnapshotEnumerateRequest'] = _VOLUMESNAPSHOTENUMERATEREQUEST
-DESCRIPTOR.message_types_by_name['VolumeSnapshotEnumerateResponse'] = _VOLUMESNAPSHOTENUMERATERESPONSE
-DESCRIPTOR.message_types_by_name['ClusterEnumerateRequest'] = _CLUSTERENUMERATEREQUEST
-DESCRIPTOR.message_types_by_name['ClusterEnumerateResponse'] = _CLUSTERENUMERATERESPONSE
-DESCRIPTOR.message_types_by_name['ClusterInspectRequest'] = _CLUSTERINSPECTREQUEST
-DESCRIPTOR.message_types_by_name['ClusterInspectResponse'] = _CLUSTERINSPECTRESPONSE
-DESCRIPTOR.message_types_by_name['ClusterAlertEnumerateRequest'] = _CLUSTERALERTENUMERATEREQUEST
-DESCRIPTOR.message_types_by_name['ClusterAlertEnumerateResponse'] = _CLUSTERALERTENUMERATERESPONSE
-DESCRIPTOR.message_types_by_name['ClusterAlertClearRequest'] = _CLUSTERALERTCLEARREQUEST
-DESCRIPTOR.message_types_by_name['ClusterAlertClearResponse'] = _CLUSTERALERTCLEARRESPONSE
-DESCRIPTOR.message_types_by_name['ClusterAlertEraseRequest'] = _CLUSTERALERTERASEREQUEST
-DESCRIPTOR.message_types_by_name['ClusterAlertEraseResponse'] = _CLUSTERALERTERASERESPONSE
+DESCRIPTOR.message_types_by_name['SdkCredentialCreateAzureRequest'] = _SDKCREDENTIALCREATEAZUREREQUEST
+DESCRIPTOR.message_types_by_name['SdkCredentialCreateAzureResponse'] = _SDKCREDENTIALCREATEAZURERESPONSE
+DESCRIPTOR.message_types_by_name['SdkCredentialCreateGoogleRequest'] = _SDKCREDENTIALCREATEGOOGLEREQUEST
+DESCRIPTOR.message_types_by_name['SdkCredentialCreateGoogleResponse'] = _SDKCREDENTIALCREATEGOOGLERESPONSE
+DESCRIPTOR.message_types_by_name['SdkCredentialCreateAWSRequest'] = _SDKCREDENTIALCREATEAWSREQUEST
+DESCRIPTOR.message_types_by_name['SdkCredentialCreateAWSResponse'] = _SDKCREDENTIALCREATEAWSRESPONSE
+DESCRIPTOR.message_types_by_name['S3Credential'] = _S3CREDENTIAL
+DESCRIPTOR.message_types_by_name['AzureCredential'] = _AZURECREDENTIAL
+DESCRIPTOR.message_types_by_name['GoogleCredential'] = _GOOGLECREDENTIAL
+DESCRIPTOR.message_types_by_name['SdkCredentialEnumerateAWSRequest'] = _SDKCREDENTIALENUMERATEAWSREQUEST
+DESCRIPTOR.message_types_by_name['SdkCredentialEnumerateAWSResponse'] = _SDKCREDENTIALENUMERATEAWSRESPONSE
+DESCRIPTOR.message_types_by_name['SdkCredentialEnumerateAzureRequest'] = _SDKCREDENTIALENUMERATEAZUREREQUEST
+DESCRIPTOR.message_types_by_name['SdkCredentialEnumerateAzureResponse'] = _SDKCREDENTIALENUMERATEAZURERESPONSE
+DESCRIPTOR.message_types_by_name['SdkCredentialEnumerateGoogleRequest'] = _SDKCREDENTIALENUMERATEGOOGLEREQUEST
+DESCRIPTOR.message_types_by_name['SdkCredentialEnumerateGoogleResponse'] = _SDKCREDENTIALENUMERATEGOOGLERESPONSE
+DESCRIPTOR.message_types_by_name['SdkCredentialDeleteRequest'] = _SDKCREDENTIALDELETEREQUEST
+DESCRIPTOR.message_types_by_name['SdkCredentialDeleteResponse'] = _SDKCREDENTIALDELETERESPONSE
+DESCRIPTOR.message_types_by_name['SdkCredentialValidateRequest'] = _SDKCREDENTIALVALIDATEREQUEST
+DESCRIPTOR.message_types_by_name['SdkCredentialValidateResponse'] = _SDKCREDENTIALVALIDATERESPONSE
+DESCRIPTOR.message_types_by_name['SdkVolumeMountRequest'] = _SDKVOLUMEMOUNTREQUEST
+DESCRIPTOR.message_types_by_name['SdkVolumeMountResponse'] = _SDKVOLUMEMOUNTRESPONSE
+DESCRIPTOR.message_types_by_name['SdkVolumeUnmountRequest'] = _SDKVOLUMEUNMOUNTREQUEST
+DESCRIPTOR.message_types_by_name['SdkVolumeUnmountResponse'] = _SDKVOLUMEUNMOUNTRESPONSE
+DESCRIPTOR.message_types_by_name['SdkVolumeAttachRequest'] = _SDKVOLUMEATTACHREQUEST
+DESCRIPTOR.message_types_by_name['SdkVolumeAttachResponse'] = _SDKVOLUMEATTACHRESPONSE
+DESCRIPTOR.message_types_by_name['SdkVolumeDetachRequest'] = _SDKVOLUMEDETACHREQUEST
+DESCRIPTOR.message_types_by_name['SdkVolumeDetachResponse'] = _SDKVOLUMEDETACHRESPONSE
+DESCRIPTOR.message_types_by_name['SdkVolumeCreateRequest'] = _SDKVOLUMECREATEREQUEST
+DESCRIPTOR.message_types_by_name['SdkVolumeCreateResponse'] = _SDKVOLUMECREATERESPONSE
+DESCRIPTOR.message_types_by_name['SdkVolumeCreateFromVolumeIdRequest'] = _SDKVOLUMECREATEFROMVOLUMEIDREQUEST
+DESCRIPTOR.message_types_by_name['SdkVolumeCreateFromVolumeIdResponse'] = _SDKVOLUMECREATEFROMVOLUMEIDRESPONSE
+DESCRIPTOR.message_types_by_name['SdkVolumeDeleteRequest'] = _SDKVOLUMEDELETEREQUEST
+DESCRIPTOR.message_types_by_name['SdkVolumeDeleteResponse'] = _SDKVOLUMEDELETERESPONSE
+DESCRIPTOR.message_types_by_name['SdkVolumeInspectRequest'] = _SDKVOLUMEINSPECTREQUEST
+DESCRIPTOR.message_types_by_name['SdkVolumeInspectResponse'] = _SDKVOLUMEINSPECTRESPONSE
+DESCRIPTOR.message_types_by_name['SdkVolumeEnumerateRequest'] = _SDKVOLUMEENUMERATEREQUEST
+DESCRIPTOR.message_types_by_name['SdkVolumeEnumerateResponse'] = _SDKVOLUMEENUMERATERESPONSE
+DESCRIPTOR.message_types_by_name['SdkVolumeSnapshotCreateRequest'] = _SDKVOLUMESNAPSHOTCREATEREQUEST
+DESCRIPTOR.message_types_by_name['SdkVolumeSnapshotCreateResponse'] = _SDKVOLUMESNAPSHOTCREATERESPONSE
+DESCRIPTOR.message_types_by_name['SdkVolumeSnapshotRestoreRequest'] = _SDKVOLUMESNAPSHOTRESTOREREQUEST
+DESCRIPTOR.message_types_by_name['SdkVolumeSnapshotRestoreResponse'] = _SDKVOLUMESNAPSHOTRESTORERESPONSE
+DESCRIPTOR.message_types_by_name['SdkVolumeSnapshotEnumerateRequest'] = _SDKVOLUMESNAPSHOTENUMERATEREQUEST
+DESCRIPTOR.message_types_by_name['SdkVolumeSnapshotEnumerateResponse'] = _SDKVOLUMESNAPSHOTENUMERATERESPONSE
+DESCRIPTOR.message_types_by_name['SdkClusterEnumerateRequest'] = _SDKCLUSTERENUMERATEREQUEST
+DESCRIPTOR.message_types_by_name['SdkClusterEnumerateResponse'] = _SDKCLUSTERENUMERATERESPONSE
+DESCRIPTOR.message_types_by_name['SdkClusterInspectRequest'] = _SDKCLUSTERINSPECTREQUEST
+DESCRIPTOR.message_types_by_name['SdkClusterInspectResponse'] = _SDKCLUSTERINSPECTRESPONSE
+DESCRIPTOR.message_types_by_name['SdkClusterAlertEnumerateRequest'] = _SDKCLUSTERALERTENUMERATEREQUEST
+DESCRIPTOR.message_types_by_name['SdkClusterAlertEnumerateResponse'] = _SDKCLUSTERALERTENUMERATERESPONSE
+DESCRIPTOR.message_types_by_name['SdkClusterAlertClearRequest'] = _SDKCLUSTERALERTCLEARREQUEST
+DESCRIPTOR.message_types_by_name['SdkClusterAlertClearResponse'] = _SDKCLUSTERALERTCLEARRESPONSE
+DESCRIPTOR.message_types_by_name['SdkClusterAlertEraseRequest'] = _SDKCLUSTERALERTERASEREQUEST
+DESCRIPTOR.message_types_by_name['SdkClusterAlertEraseResponse'] = _SDKCLUSTERALERTERASERESPONSE
 DESCRIPTOR.enum_types_by_name['Status'] = _STATUS
 DESCRIPTOR.enum_types_by_name['DriverType'] = _DRIVERTYPE
 DESCRIPTOR.enum_types_by_name['FSType'] = _FSTYPE
@@ -4447,6 +5205,13 @@ Alerts = _reflection.GeneratedProtocolMessageType('Alerts', (_message.Message,),
   # @@protoc_insertion_point(class_scope:openstorage.api.Alerts)
   ))
 _sym_db.RegisterMessage(Alerts)
+
+ObjectstoreInfo = _reflection.GeneratedProtocolMessageType('ObjectstoreInfo', (_message.Message,), dict(
+  DESCRIPTOR = _OBJECTSTOREINFO,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.ObjectstoreInfo)
+  ))
+_sym_db.RegisterMessage(ObjectstoreInfo)
 
 VolumeCreateRequest = _reflection.GeneratedProtocolMessageType('VolumeCreateRequest', (_message.Message,), dict(
   DESCRIPTOR = _VOLUMECREATEREQUEST,
@@ -4622,283 +5387,416 @@ StorageCluster = _reflection.GeneratedProtocolMessageType('StorageCluster', (_me
   ))
 _sym_db.RegisterMessage(StorageCluster)
 
-VolumeMountRequest = _reflection.GeneratedProtocolMessageType('VolumeMountRequest', (_message.Message,), dict(
+SdkCredentialCreateAzureRequest = _reflection.GeneratedProtocolMessageType('SdkCredentialCreateAzureRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCREDENTIALCREATEAZUREREQUEST,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkCredentialCreateAzureRequest)
+  ))
+_sym_db.RegisterMessage(SdkCredentialCreateAzureRequest)
+
+SdkCredentialCreateAzureResponse = _reflection.GeneratedProtocolMessageType('SdkCredentialCreateAzureResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCREDENTIALCREATEAZURERESPONSE,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkCredentialCreateAzureResponse)
+  ))
+_sym_db.RegisterMessage(SdkCredentialCreateAzureResponse)
+
+SdkCredentialCreateGoogleRequest = _reflection.GeneratedProtocolMessageType('SdkCredentialCreateGoogleRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCREDENTIALCREATEGOOGLEREQUEST,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkCredentialCreateGoogleRequest)
+  ))
+_sym_db.RegisterMessage(SdkCredentialCreateGoogleRequest)
+
+SdkCredentialCreateGoogleResponse = _reflection.GeneratedProtocolMessageType('SdkCredentialCreateGoogleResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCREDENTIALCREATEGOOGLERESPONSE,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkCredentialCreateGoogleResponse)
+  ))
+_sym_db.RegisterMessage(SdkCredentialCreateGoogleResponse)
+
+SdkCredentialCreateAWSRequest = _reflection.GeneratedProtocolMessageType('SdkCredentialCreateAWSRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCREDENTIALCREATEAWSREQUEST,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkCredentialCreateAWSRequest)
+  ))
+_sym_db.RegisterMessage(SdkCredentialCreateAWSRequest)
+
+SdkCredentialCreateAWSResponse = _reflection.GeneratedProtocolMessageType('SdkCredentialCreateAWSResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCREDENTIALCREATEAWSRESPONSE,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkCredentialCreateAWSResponse)
+  ))
+_sym_db.RegisterMessage(SdkCredentialCreateAWSResponse)
+
+S3Credential = _reflection.GeneratedProtocolMessageType('S3Credential', (_message.Message,), dict(
+  DESCRIPTOR = _S3CREDENTIAL,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.S3Credential)
+  ))
+_sym_db.RegisterMessage(S3Credential)
+
+AzureCredential = _reflection.GeneratedProtocolMessageType('AzureCredential', (_message.Message,), dict(
+  DESCRIPTOR = _AZURECREDENTIAL,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.AzureCredential)
+  ))
+_sym_db.RegisterMessage(AzureCredential)
+
+GoogleCredential = _reflection.GeneratedProtocolMessageType('GoogleCredential', (_message.Message,), dict(
+  DESCRIPTOR = _GOOGLECREDENTIAL,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.GoogleCredential)
+  ))
+_sym_db.RegisterMessage(GoogleCredential)
+
+SdkCredentialEnumerateAWSRequest = _reflection.GeneratedProtocolMessageType('SdkCredentialEnumerateAWSRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCREDENTIALENUMERATEAWSREQUEST,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkCredentialEnumerateAWSRequest)
+  ))
+_sym_db.RegisterMessage(SdkCredentialEnumerateAWSRequest)
+
+SdkCredentialEnumerateAWSResponse = _reflection.GeneratedProtocolMessageType('SdkCredentialEnumerateAWSResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCREDENTIALENUMERATEAWSRESPONSE,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkCredentialEnumerateAWSResponse)
+  ))
+_sym_db.RegisterMessage(SdkCredentialEnumerateAWSResponse)
+
+SdkCredentialEnumerateAzureRequest = _reflection.GeneratedProtocolMessageType('SdkCredentialEnumerateAzureRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCREDENTIALENUMERATEAZUREREQUEST,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkCredentialEnumerateAzureRequest)
+  ))
+_sym_db.RegisterMessage(SdkCredentialEnumerateAzureRequest)
+
+SdkCredentialEnumerateAzureResponse = _reflection.GeneratedProtocolMessageType('SdkCredentialEnumerateAzureResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCREDENTIALENUMERATEAZURERESPONSE,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkCredentialEnumerateAzureResponse)
+  ))
+_sym_db.RegisterMessage(SdkCredentialEnumerateAzureResponse)
+
+SdkCredentialEnumerateGoogleRequest = _reflection.GeneratedProtocolMessageType('SdkCredentialEnumerateGoogleRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCREDENTIALENUMERATEGOOGLEREQUEST,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkCredentialEnumerateGoogleRequest)
+  ))
+_sym_db.RegisterMessage(SdkCredentialEnumerateGoogleRequest)
+
+SdkCredentialEnumerateGoogleResponse = _reflection.GeneratedProtocolMessageType('SdkCredentialEnumerateGoogleResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCREDENTIALENUMERATEGOOGLERESPONSE,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkCredentialEnumerateGoogleResponse)
+  ))
+_sym_db.RegisterMessage(SdkCredentialEnumerateGoogleResponse)
+
+SdkCredentialDeleteRequest = _reflection.GeneratedProtocolMessageType('SdkCredentialDeleteRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCREDENTIALDELETEREQUEST,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkCredentialDeleteRequest)
+  ))
+_sym_db.RegisterMessage(SdkCredentialDeleteRequest)
+
+SdkCredentialDeleteResponse = _reflection.GeneratedProtocolMessageType('SdkCredentialDeleteResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCREDENTIALDELETERESPONSE,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkCredentialDeleteResponse)
+  ))
+_sym_db.RegisterMessage(SdkCredentialDeleteResponse)
+
+SdkCredentialValidateRequest = _reflection.GeneratedProtocolMessageType('SdkCredentialValidateRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCREDENTIALVALIDATEREQUEST,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkCredentialValidateRequest)
+  ))
+_sym_db.RegisterMessage(SdkCredentialValidateRequest)
+
+SdkCredentialValidateResponse = _reflection.GeneratedProtocolMessageType('SdkCredentialValidateResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCREDENTIALVALIDATERESPONSE,
+  __module__ = 'api_pb2'
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkCredentialValidateResponse)
+  ))
+_sym_db.RegisterMessage(SdkCredentialValidateResponse)
+
+SdkVolumeMountRequest = _reflection.GeneratedProtocolMessageType('SdkVolumeMountRequest', (_message.Message,), dict(
 
   OptionsEntry = _reflection.GeneratedProtocolMessageType('OptionsEntry', (_message.Message,), dict(
-    DESCRIPTOR = _VOLUMEMOUNTREQUEST_OPTIONSENTRY,
+    DESCRIPTOR = _SDKVOLUMEMOUNTREQUEST_OPTIONSENTRY,
     __module__ = 'api_pb2'
-    # @@protoc_insertion_point(class_scope:openstorage.api.VolumeMountRequest.OptionsEntry)
+    # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeMountRequest.OptionsEntry)
     ))
   ,
-  DESCRIPTOR = _VOLUMEMOUNTREQUEST,
+  DESCRIPTOR = _SDKVOLUMEMOUNTREQUEST,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeMountRequest)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeMountRequest)
   ))
-_sym_db.RegisterMessage(VolumeMountRequest)
-_sym_db.RegisterMessage(VolumeMountRequest.OptionsEntry)
+_sym_db.RegisterMessage(SdkVolumeMountRequest)
+_sym_db.RegisterMessage(SdkVolumeMountRequest.OptionsEntry)
 
-VolumeMountResponse = _reflection.GeneratedProtocolMessageType('VolumeMountResponse', (_message.Message,), dict(
-  DESCRIPTOR = _VOLUMEMOUNTRESPONSE,
+SdkVolumeMountResponse = _reflection.GeneratedProtocolMessageType('SdkVolumeMountResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKVOLUMEMOUNTRESPONSE,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeMountResponse)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeMountResponse)
   ))
-_sym_db.RegisterMessage(VolumeMountResponse)
+_sym_db.RegisterMessage(SdkVolumeMountResponse)
 
-VolumeUnmountRequest = _reflection.GeneratedProtocolMessageType('VolumeUnmountRequest', (_message.Message,), dict(
+SdkVolumeUnmountRequest = _reflection.GeneratedProtocolMessageType('SdkVolumeUnmountRequest', (_message.Message,), dict(
 
   OptionsEntry = _reflection.GeneratedProtocolMessageType('OptionsEntry', (_message.Message,), dict(
-    DESCRIPTOR = _VOLUMEUNMOUNTREQUEST_OPTIONSENTRY,
+    DESCRIPTOR = _SDKVOLUMEUNMOUNTREQUEST_OPTIONSENTRY,
     __module__ = 'api_pb2'
-    # @@protoc_insertion_point(class_scope:openstorage.api.VolumeUnmountRequest.OptionsEntry)
+    # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeUnmountRequest.OptionsEntry)
     ))
   ,
-  DESCRIPTOR = _VOLUMEUNMOUNTREQUEST,
+  DESCRIPTOR = _SDKVOLUMEUNMOUNTREQUEST,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeUnmountRequest)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeUnmountRequest)
   ))
-_sym_db.RegisterMessage(VolumeUnmountRequest)
-_sym_db.RegisterMessage(VolumeUnmountRequest.OptionsEntry)
+_sym_db.RegisterMessage(SdkVolumeUnmountRequest)
+_sym_db.RegisterMessage(SdkVolumeUnmountRequest.OptionsEntry)
 
-VolumeUnmountResponse = _reflection.GeneratedProtocolMessageType('VolumeUnmountResponse', (_message.Message,), dict(
-  DESCRIPTOR = _VOLUMEUNMOUNTRESPONSE,
+SdkVolumeUnmountResponse = _reflection.GeneratedProtocolMessageType('SdkVolumeUnmountResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKVOLUMEUNMOUNTRESPONSE,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeUnmountResponse)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeUnmountResponse)
   ))
-_sym_db.RegisterMessage(VolumeUnmountResponse)
+_sym_db.RegisterMessage(SdkVolumeUnmountResponse)
 
-VolumeAttachRequest = _reflection.GeneratedProtocolMessageType('VolumeAttachRequest', (_message.Message,), dict(
+SdkVolumeAttachRequest = _reflection.GeneratedProtocolMessageType('SdkVolumeAttachRequest', (_message.Message,), dict(
 
   OptionsEntry = _reflection.GeneratedProtocolMessageType('OptionsEntry', (_message.Message,), dict(
-    DESCRIPTOR = _VOLUMEATTACHREQUEST_OPTIONSENTRY,
+    DESCRIPTOR = _SDKVOLUMEATTACHREQUEST_OPTIONSENTRY,
     __module__ = 'api_pb2'
-    # @@protoc_insertion_point(class_scope:openstorage.api.VolumeAttachRequest.OptionsEntry)
+    # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeAttachRequest.OptionsEntry)
     ))
   ,
-  DESCRIPTOR = _VOLUMEATTACHREQUEST,
+  DESCRIPTOR = _SDKVOLUMEATTACHREQUEST,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeAttachRequest)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeAttachRequest)
   ))
-_sym_db.RegisterMessage(VolumeAttachRequest)
-_sym_db.RegisterMessage(VolumeAttachRequest.OptionsEntry)
+_sym_db.RegisterMessage(SdkVolumeAttachRequest)
+_sym_db.RegisterMessage(SdkVolumeAttachRequest.OptionsEntry)
 
-VolumeAttachResponse = _reflection.GeneratedProtocolMessageType('VolumeAttachResponse', (_message.Message,), dict(
-  DESCRIPTOR = _VOLUMEATTACHRESPONSE,
+SdkVolumeAttachResponse = _reflection.GeneratedProtocolMessageType('SdkVolumeAttachResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKVOLUMEATTACHRESPONSE,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeAttachResponse)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeAttachResponse)
   ))
-_sym_db.RegisterMessage(VolumeAttachResponse)
+_sym_db.RegisterMessage(SdkVolumeAttachResponse)
 
-VolumeDetachRequest = _reflection.GeneratedProtocolMessageType('VolumeDetachRequest', (_message.Message,), dict(
-  DESCRIPTOR = _VOLUMEDETACHREQUEST,
+SdkVolumeDetachRequest = _reflection.GeneratedProtocolMessageType('SdkVolumeDetachRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKVOLUMEDETACHREQUEST,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeDetachRequest)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeDetachRequest)
   ))
-_sym_db.RegisterMessage(VolumeDetachRequest)
+_sym_db.RegisterMessage(SdkVolumeDetachRequest)
 
-VolumeDetachResponse = _reflection.GeneratedProtocolMessageType('VolumeDetachResponse', (_message.Message,), dict(
-  DESCRIPTOR = _VOLUMEDETACHRESPONSE,
+SdkVolumeDetachResponse = _reflection.GeneratedProtocolMessageType('SdkVolumeDetachResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKVOLUMEDETACHRESPONSE,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeDetachResponse)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeDetachResponse)
   ))
-_sym_db.RegisterMessage(VolumeDetachResponse)
+_sym_db.RegisterMessage(SdkVolumeDetachResponse)
 
-OpenStorageVolumeCreateRequest = _reflection.GeneratedProtocolMessageType('OpenStorageVolumeCreateRequest', (_message.Message,), dict(
-  DESCRIPTOR = _OPENSTORAGEVOLUMECREATEREQUEST,
+SdkVolumeCreateRequest = _reflection.GeneratedProtocolMessageType('SdkVolumeCreateRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKVOLUMECREATEREQUEST,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.OpenStorageVolumeCreateRequest)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeCreateRequest)
   ))
-_sym_db.RegisterMessage(OpenStorageVolumeCreateRequest)
+_sym_db.RegisterMessage(SdkVolumeCreateRequest)
 
-OpenStorageVolumeCreateResponse = _reflection.GeneratedProtocolMessageType('OpenStorageVolumeCreateResponse', (_message.Message,), dict(
-  DESCRIPTOR = _OPENSTORAGEVOLUMECREATERESPONSE,
+SdkVolumeCreateResponse = _reflection.GeneratedProtocolMessageType('SdkVolumeCreateResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKVOLUMECREATERESPONSE,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.OpenStorageVolumeCreateResponse)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeCreateResponse)
   ))
-_sym_db.RegisterMessage(OpenStorageVolumeCreateResponse)
+_sym_db.RegisterMessage(SdkVolumeCreateResponse)
 
-VolumeCreateFromVolumeIDRequest = _reflection.GeneratedProtocolMessageType('VolumeCreateFromVolumeIDRequest', (_message.Message,), dict(
-  DESCRIPTOR = _VOLUMECREATEFROMVOLUMEIDREQUEST,
+SdkVolumeCreateFromVolumeIdRequest = _reflection.GeneratedProtocolMessageType('SdkVolumeCreateFromVolumeIdRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKVOLUMECREATEFROMVOLUMEIDREQUEST,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeCreateFromVolumeIDRequest)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeCreateFromVolumeIdRequest)
   ))
-_sym_db.RegisterMessage(VolumeCreateFromVolumeIDRequest)
+_sym_db.RegisterMessage(SdkVolumeCreateFromVolumeIdRequest)
 
-VolumeCreateFromVolumeIDResponse = _reflection.GeneratedProtocolMessageType('VolumeCreateFromVolumeIDResponse', (_message.Message,), dict(
-  DESCRIPTOR = _VOLUMECREATEFROMVOLUMEIDRESPONSE,
+SdkVolumeCreateFromVolumeIdResponse = _reflection.GeneratedProtocolMessageType('SdkVolumeCreateFromVolumeIdResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKVOLUMECREATEFROMVOLUMEIDRESPONSE,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeCreateFromVolumeIDResponse)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeCreateFromVolumeIdResponse)
   ))
-_sym_db.RegisterMessage(VolumeCreateFromVolumeIDResponse)
+_sym_db.RegisterMessage(SdkVolumeCreateFromVolumeIdResponse)
 
-VolumeDeleteRequest = _reflection.GeneratedProtocolMessageType('VolumeDeleteRequest', (_message.Message,), dict(
-  DESCRIPTOR = _VOLUMEDELETEREQUEST,
+SdkVolumeDeleteRequest = _reflection.GeneratedProtocolMessageType('SdkVolumeDeleteRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKVOLUMEDELETEREQUEST,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeDeleteRequest)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeDeleteRequest)
   ))
-_sym_db.RegisterMessage(VolumeDeleteRequest)
+_sym_db.RegisterMessage(SdkVolumeDeleteRequest)
 
-VolumeDeleteResponse = _reflection.GeneratedProtocolMessageType('VolumeDeleteResponse', (_message.Message,), dict(
-  DESCRIPTOR = _VOLUMEDELETERESPONSE,
+SdkVolumeDeleteResponse = _reflection.GeneratedProtocolMessageType('SdkVolumeDeleteResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKVOLUMEDELETERESPONSE,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeDeleteResponse)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeDeleteResponse)
   ))
-_sym_db.RegisterMessage(VolumeDeleteResponse)
+_sym_db.RegisterMessage(SdkVolumeDeleteResponse)
 
-VolumeInspectRequest = _reflection.GeneratedProtocolMessageType('VolumeInspectRequest', (_message.Message,), dict(
-  DESCRIPTOR = _VOLUMEINSPECTREQUEST,
+SdkVolumeInspectRequest = _reflection.GeneratedProtocolMessageType('SdkVolumeInspectRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKVOLUMEINSPECTREQUEST,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeInspectRequest)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeInspectRequest)
   ))
-_sym_db.RegisterMessage(VolumeInspectRequest)
+_sym_db.RegisterMessage(SdkVolumeInspectRequest)
 
-VolumeInspectResponse = _reflection.GeneratedProtocolMessageType('VolumeInspectResponse', (_message.Message,), dict(
-  DESCRIPTOR = _VOLUMEINSPECTRESPONSE,
+SdkVolumeInspectResponse = _reflection.GeneratedProtocolMessageType('SdkVolumeInspectResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKVOLUMEINSPECTRESPONSE,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeInspectResponse)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeInspectResponse)
   ))
-_sym_db.RegisterMessage(VolumeInspectResponse)
+_sym_db.RegisterMessage(SdkVolumeInspectResponse)
 
-VolumeEnumerateRequest = _reflection.GeneratedProtocolMessageType('VolumeEnumerateRequest', (_message.Message,), dict(
-  DESCRIPTOR = _VOLUMEENUMERATEREQUEST,
+SdkVolumeEnumerateRequest = _reflection.GeneratedProtocolMessageType('SdkVolumeEnumerateRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKVOLUMEENUMERATEREQUEST,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeEnumerateRequest)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeEnumerateRequest)
   ))
-_sym_db.RegisterMessage(VolumeEnumerateRequest)
+_sym_db.RegisterMessage(SdkVolumeEnumerateRequest)
 
-VolumeEnumerateResponse = _reflection.GeneratedProtocolMessageType('VolumeEnumerateResponse', (_message.Message,), dict(
-  DESCRIPTOR = _VOLUMEENUMERATERESPONSE,
+SdkVolumeEnumerateResponse = _reflection.GeneratedProtocolMessageType('SdkVolumeEnumerateResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKVOLUMEENUMERATERESPONSE,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeEnumerateResponse)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeEnumerateResponse)
   ))
-_sym_db.RegisterMessage(VolumeEnumerateResponse)
+_sym_db.RegisterMessage(SdkVolumeEnumerateResponse)
 
-VolumeSnapshotCreateRequest = _reflection.GeneratedProtocolMessageType('VolumeSnapshotCreateRequest', (_message.Message,), dict(
+SdkVolumeSnapshotCreateRequest = _reflection.GeneratedProtocolMessageType('SdkVolumeSnapshotCreateRequest', (_message.Message,), dict(
 
   LabelsEntry = _reflection.GeneratedProtocolMessageType('LabelsEntry', (_message.Message,), dict(
-    DESCRIPTOR = _VOLUMESNAPSHOTCREATEREQUEST_LABELSENTRY,
+    DESCRIPTOR = _SDKVOLUMESNAPSHOTCREATEREQUEST_LABELSENTRY,
     __module__ = 'api_pb2'
-    # @@protoc_insertion_point(class_scope:openstorage.api.VolumeSnapshotCreateRequest.LabelsEntry)
+    # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeSnapshotCreateRequest.LabelsEntry)
     ))
   ,
-  DESCRIPTOR = _VOLUMESNAPSHOTCREATEREQUEST,
+  DESCRIPTOR = _SDKVOLUMESNAPSHOTCREATEREQUEST,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeSnapshotCreateRequest)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeSnapshotCreateRequest)
   ))
-_sym_db.RegisterMessage(VolumeSnapshotCreateRequest)
-_sym_db.RegisterMessage(VolumeSnapshotCreateRequest.LabelsEntry)
+_sym_db.RegisterMessage(SdkVolumeSnapshotCreateRequest)
+_sym_db.RegisterMessage(SdkVolumeSnapshotCreateRequest.LabelsEntry)
 
-VolumeSnapshotCreateResponse = _reflection.GeneratedProtocolMessageType('VolumeSnapshotCreateResponse', (_message.Message,), dict(
-  DESCRIPTOR = _VOLUMESNAPSHOTCREATERESPONSE,
+SdkVolumeSnapshotCreateResponse = _reflection.GeneratedProtocolMessageType('SdkVolumeSnapshotCreateResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKVOLUMESNAPSHOTCREATERESPONSE,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeSnapshotCreateResponse)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeSnapshotCreateResponse)
   ))
-_sym_db.RegisterMessage(VolumeSnapshotCreateResponse)
+_sym_db.RegisterMessage(SdkVolumeSnapshotCreateResponse)
 
-VolumeSnapshotRestoreRequest = _reflection.GeneratedProtocolMessageType('VolumeSnapshotRestoreRequest', (_message.Message,), dict(
-  DESCRIPTOR = _VOLUMESNAPSHOTRESTOREREQUEST,
+SdkVolumeSnapshotRestoreRequest = _reflection.GeneratedProtocolMessageType('SdkVolumeSnapshotRestoreRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKVOLUMESNAPSHOTRESTOREREQUEST,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeSnapshotRestoreRequest)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeSnapshotRestoreRequest)
   ))
-_sym_db.RegisterMessage(VolumeSnapshotRestoreRequest)
+_sym_db.RegisterMessage(SdkVolumeSnapshotRestoreRequest)
 
-VolumeSnapshotRestoreResponse = _reflection.GeneratedProtocolMessageType('VolumeSnapshotRestoreResponse', (_message.Message,), dict(
-  DESCRIPTOR = _VOLUMESNAPSHOTRESTORERESPONSE,
+SdkVolumeSnapshotRestoreResponse = _reflection.GeneratedProtocolMessageType('SdkVolumeSnapshotRestoreResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKVOLUMESNAPSHOTRESTORERESPONSE,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeSnapshotRestoreResponse)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeSnapshotRestoreResponse)
   ))
-_sym_db.RegisterMessage(VolumeSnapshotRestoreResponse)
+_sym_db.RegisterMessage(SdkVolumeSnapshotRestoreResponse)
 
-VolumeSnapshotEnumerateRequest = _reflection.GeneratedProtocolMessageType('VolumeSnapshotEnumerateRequest', (_message.Message,), dict(
+SdkVolumeSnapshotEnumerateRequest = _reflection.GeneratedProtocolMessageType('SdkVolumeSnapshotEnumerateRequest', (_message.Message,), dict(
 
   LabelsEntry = _reflection.GeneratedProtocolMessageType('LabelsEntry', (_message.Message,), dict(
-    DESCRIPTOR = _VOLUMESNAPSHOTENUMERATEREQUEST_LABELSENTRY,
+    DESCRIPTOR = _SDKVOLUMESNAPSHOTENUMERATEREQUEST_LABELSENTRY,
     __module__ = 'api_pb2'
-    # @@protoc_insertion_point(class_scope:openstorage.api.VolumeSnapshotEnumerateRequest.LabelsEntry)
+    # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeSnapshotEnumerateRequest.LabelsEntry)
     ))
   ,
-  DESCRIPTOR = _VOLUMESNAPSHOTENUMERATEREQUEST,
+  DESCRIPTOR = _SDKVOLUMESNAPSHOTENUMERATEREQUEST,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeSnapshotEnumerateRequest)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeSnapshotEnumerateRequest)
   ))
-_sym_db.RegisterMessage(VolumeSnapshotEnumerateRequest)
-_sym_db.RegisterMessage(VolumeSnapshotEnumerateRequest.LabelsEntry)
+_sym_db.RegisterMessage(SdkVolumeSnapshotEnumerateRequest)
+_sym_db.RegisterMessage(SdkVolumeSnapshotEnumerateRequest.LabelsEntry)
 
-VolumeSnapshotEnumerateResponse = _reflection.GeneratedProtocolMessageType('VolumeSnapshotEnumerateResponse', (_message.Message,), dict(
-  DESCRIPTOR = _VOLUMESNAPSHOTENUMERATERESPONSE,
+SdkVolumeSnapshotEnumerateResponse = _reflection.GeneratedProtocolMessageType('SdkVolumeSnapshotEnumerateResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKVOLUMESNAPSHOTENUMERATERESPONSE,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.VolumeSnapshotEnumerateResponse)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkVolumeSnapshotEnumerateResponse)
   ))
-_sym_db.RegisterMessage(VolumeSnapshotEnumerateResponse)
+_sym_db.RegisterMessage(SdkVolumeSnapshotEnumerateResponse)
 
-ClusterEnumerateRequest = _reflection.GeneratedProtocolMessageType('ClusterEnumerateRequest', (_message.Message,), dict(
-  DESCRIPTOR = _CLUSTERENUMERATEREQUEST,
+SdkClusterEnumerateRequest = _reflection.GeneratedProtocolMessageType('SdkClusterEnumerateRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCLUSTERENUMERATEREQUEST,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.ClusterEnumerateRequest)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkClusterEnumerateRequest)
   ))
-_sym_db.RegisterMessage(ClusterEnumerateRequest)
+_sym_db.RegisterMessage(SdkClusterEnumerateRequest)
 
-ClusterEnumerateResponse = _reflection.GeneratedProtocolMessageType('ClusterEnumerateResponse', (_message.Message,), dict(
-  DESCRIPTOR = _CLUSTERENUMERATERESPONSE,
+SdkClusterEnumerateResponse = _reflection.GeneratedProtocolMessageType('SdkClusterEnumerateResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCLUSTERENUMERATERESPONSE,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.ClusterEnumerateResponse)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkClusterEnumerateResponse)
   ))
-_sym_db.RegisterMessage(ClusterEnumerateResponse)
+_sym_db.RegisterMessage(SdkClusterEnumerateResponse)
 
-ClusterInspectRequest = _reflection.GeneratedProtocolMessageType('ClusterInspectRequest', (_message.Message,), dict(
-  DESCRIPTOR = _CLUSTERINSPECTREQUEST,
+SdkClusterInspectRequest = _reflection.GeneratedProtocolMessageType('SdkClusterInspectRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCLUSTERINSPECTREQUEST,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.ClusterInspectRequest)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkClusterInspectRequest)
   ))
-_sym_db.RegisterMessage(ClusterInspectRequest)
+_sym_db.RegisterMessage(SdkClusterInspectRequest)
 
-ClusterInspectResponse = _reflection.GeneratedProtocolMessageType('ClusterInspectResponse', (_message.Message,), dict(
-  DESCRIPTOR = _CLUSTERINSPECTRESPONSE,
+SdkClusterInspectResponse = _reflection.GeneratedProtocolMessageType('SdkClusterInspectResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCLUSTERINSPECTRESPONSE,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.ClusterInspectResponse)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkClusterInspectResponse)
   ))
-_sym_db.RegisterMessage(ClusterInspectResponse)
+_sym_db.RegisterMessage(SdkClusterInspectResponse)
 
-ClusterAlertEnumerateRequest = _reflection.GeneratedProtocolMessageType('ClusterAlertEnumerateRequest', (_message.Message,), dict(
-  DESCRIPTOR = _CLUSTERALERTENUMERATEREQUEST,
+SdkClusterAlertEnumerateRequest = _reflection.GeneratedProtocolMessageType('SdkClusterAlertEnumerateRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCLUSTERALERTENUMERATEREQUEST,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.ClusterAlertEnumerateRequest)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkClusterAlertEnumerateRequest)
   ))
-_sym_db.RegisterMessage(ClusterAlertEnumerateRequest)
+_sym_db.RegisterMessage(SdkClusterAlertEnumerateRequest)
 
-ClusterAlertEnumerateResponse = _reflection.GeneratedProtocolMessageType('ClusterAlertEnumerateResponse', (_message.Message,), dict(
-  DESCRIPTOR = _CLUSTERALERTENUMERATERESPONSE,
+SdkClusterAlertEnumerateResponse = _reflection.GeneratedProtocolMessageType('SdkClusterAlertEnumerateResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCLUSTERALERTENUMERATERESPONSE,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.ClusterAlertEnumerateResponse)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkClusterAlertEnumerateResponse)
   ))
-_sym_db.RegisterMessage(ClusterAlertEnumerateResponse)
+_sym_db.RegisterMessage(SdkClusterAlertEnumerateResponse)
 
-ClusterAlertClearRequest = _reflection.GeneratedProtocolMessageType('ClusterAlertClearRequest', (_message.Message,), dict(
-  DESCRIPTOR = _CLUSTERALERTCLEARREQUEST,
+SdkClusterAlertClearRequest = _reflection.GeneratedProtocolMessageType('SdkClusterAlertClearRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCLUSTERALERTCLEARREQUEST,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.ClusterAlertClearRequest)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkClusterAlertClearRequest)
   ))
-_sym_db.RegisterMessage(ClusterAlertClearRequest)
+_sym_db.RegisterMessage(SdkClusterAlertClearRequest)
 
-ClusterAlertClearResponse = _reflection.GeneratedProtocolMessageType('ClusterAlertClearResponse', (_message.Message,), dict(
-  DESCRIPTOR = _CLUSTERALERTCLEARRESPONSE,
+SdkClusterAlertClearResponse = _reflection.GeneratedProtocolMessageType('SdkClusterAlertClearResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCLUSTERALERTCLEARRESPONSE,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.ClusterAlertClearResponse)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkClusterAlertClearResponse)
   ))
-_sym_db.RegisterMessage(ClusterAlertClearResponse)
+_sym_db.RegisterMessage(SdkClusterAlertClearResponse)
 
-ClusterAlertEraseRequest = _reflection.GeneratedProtocolMessageType('ClusterAlertEraseRequest', (_message.Message,), dict(
-  DESCRIPTOR = _CLUSTERALERTERASEREQUEST,
+SdkClusterAlertEraseRequest = _reflection.GeneratedProtocolMessageType('SdkClusterAlertEraseRequest', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCLUSTERALERTERASEREQUEST,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.ClusterAlertEraseRequest)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkClusterAlertEraseRequest)
   ))
-_sym_db.RegisterMessage(ClusterAlertEraseRequest)
+_sym_db.RegisterMessage(SdkClusterAlertEraseRequest)
 
-ClusterAlertEraseResponse = _reflection.GeneratedProtocolMessageType('ClusterAlertEraseResponse', (_message.Message,), dict(
-  DESCRIPTOR = _CLUSTERALERTERASERESPONSE,
+SdkClusterAlertEraseResponse = _reflection.GeneratedProtocolMessageType('SdkClusterAlertEraseResponse', (_message.Message,), dict(
+  DESCRIPTOR = _SDKCLUSTERALERTERASERESPONSE,
   __module__ = 'api_pb2'
-  # @@protoc_insertion_point(class_scope:openstorage.api.ClusterAlertEraseResponse)
+  # @@protoc_insertion_point(class_scope:openstorage.api.SdkClusterAlertEraseResponse)
   ))
-_sym_db.RegisterMessage(ClusterAlertEraseResponse)
+_sym_db.RegisterMessage(SdkClusterAlertEraseResponse)
 
 
 DESCRIPTOR.has_options = True
@@ -4925,16 +5823,16 @@ _STORAGENODE_DISKSENTRY.has_options = True
 _STORAGENODE_DISKSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
 _STORAGENODE_NODELABELSENTRY.has_options = True
 _STORAGENODE_NODELABELSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_VOLUMEMOUNTREQUEST_OPTIONSENTRY.has_options = True
-_VOLUMEMOUNTREQUEST_OPTIONSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_VOLUMEUNMOUNTREQUEST_OPTIONSENTRY.has_options = True
-_VOLUMEUNMOUNTREQUEST_OPTIONSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_VOLUMEATTACHREQUEST_OPTIONSENTRY.has_options = True
-_VOLUMEATTACHREQUEST_OPTIONSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_VOLUMESNAPSHOTCREATEREQUEST_LABELSENTRY.has_options = True
-_VOLUMESNAPSHOTCREATEREQUEST_LABELSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
-_VOLUMESNAPSHOTENUMERATEREQUEST_LABELSENTRY.has_options = True
-_VOLUMESNAPSHOTENUMERATEREQUEST_LABELSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
+_SDKVOLUMEMOUNTREQUEST_OPTIONSENTRY.has_options = True
+_SDKVOLUMEMOUNTREQUEST_OPTIONSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
+_SDKVOLUMEUNMOUNTREQUEST_OPTIONSENTRY.has_options = True
+_SDKVOLUMEUNMOUNTREQUEST_OPTIONSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
+_SDKVOLUMEATTACHREQUEST_OPTIONSENTRY.has_options = True
+_SDKVOLUMEATTACHREQUEST_OPTIONSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
+_SDKVOLUMESNAPSHOTCREATEREQUEST_LABELSENTRY.has_options = True
+_SDKVOLUMESNAPSHOTCREATEREQUEST_LABELSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
+_SDKVOLUMESNAPSHOTENUMERATEREQUEST_LABELSENTRY.has_options = True
+_SDKVOLUMESNAPSHOTENUMERATEREQUEST_LABELSENTRY._options = _descriptor._ParseOptions(descriptor_pb2.MessageOptions(), _b('8\001'))
 
 _OPENSTORAGECLUSTER = _descriptor.ServiceDescriptor(
   name='OpenStorageCluster',
@@ -4942,16 +5840,16 @@ _OPENSTORAGECLUSTER = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=0,
   options=None,
-  serialized_start=10680,
-  serialized_end=11387,
+  serialized_start=12348,
+  serialized_end=13086,
   methods=[
   _descriptor.MethodDescriptor(
     name='Enumerate',
     full_name='openstorage.api.OpenStorageCluster.Enumerate',
     index=0,
     containing_service=None,
-    input_type=_CLUSTERENUMERATEREQUEST,
-    output_type=_CLUSTERENUMERATERESPONSE,
+    input_type=_SDKCLUSTERENUMERATEREQUEST,
+    output_type=_SDKCLUSTERENUMERATERESPONSE,
     options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\032\"\025/v1/cluster/enumerate:\001*')),
   ),
   _descriptor.MethodDescriptor(
@@ -4959,8 +5857,8 @@ _OPENSTORAGECLUSTER = _descriptor.ServiceDescriptor(
     full_name='openstorage.api.OpenStorageCluster.Inspect',
     index=1,
     containing_service=None,
-    input_type=_CLUSTERINSPECTREQUEST,
-    output_type=_CLUSTERINSPECTRESPONSE,
+    input_type=_SDKCLUSTERINSPECTREQUEST,
+    output_type=_SDKCLUSTERINSPECTRESPONSE,
     options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\030\"\023/v1/cluster/inspect:\001*')),
   ),
   _descriptor.MethodDescriptor(
@@ -4968,8 +5866,8 @@ _OPENSTORAGECLUSTER = _descriptor.ServiceDescriptor(
     full_name='openstorage.api.OpenStorageCluster.AlertEnumerate',
     index=2,
     containing_service=None,
-    input_type=_CLUSTERALERTENUMERATEREQUEST,
-    output_type=_CLUSTERALERTENUMERATERESPONSE,
+    input_type=_SDKCLUSTERALERTENUMERATEREQUEST,
+    output_type=_SDKCLUSTERALERTENUMERATERESPONSE,
     options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002 \"\033/v1/cluster/alert/enumerate:\001*')),
   ),
   _descriptor.MethodDescriptor(
@@ -4977,8 +5875,8 @@ _OPENSTORAGECLUSTER = _descriptor.ServiceDescriptor(
     full_name='openstorage.api.OpenStorageCluster.AlertClear',
     index=3,
     containing_service=None,
-    input_type=_CLUSTERALERTCLEARREQUEST,
-    output_type=_CLUSTERALERTCLEARRESPONSE,
+    input_type=_SDKCLUSTERALERTCLEARREQUEST,
+    output_type=_SDKCLUSTERALERTCLEARRESPONSE,
     options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\034\"\027/v1/cluster/alert/clear:\001*')),
   ),
   _descriptor.MethodDescriptor(
@@ -4986,8 +5884,8 @@ _OPENSTORAGECLUSTER = _descriptor.ServiceDescriptor(
     full_name='openstorage.api.OpenStorageCluster.AlertErase',
     index=4,
     containing_service=None,
-    input_type=_CLUSTERALERTERASEREQUEST,
-    output_type=_CLUSTERALERTERASERESPONSE,
+    input_type=_SDKCLUSTERALERTERASEREQUEST,
+    output_type=_SDKCLUSTERALERTERASERESPONSE,
     options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\034\"\027/v1/cluster/alert/erase:\001*')),
   ),
 ])
@@ -5002,25 +5900,25 @@ _OPENSTORAGEVOLUME = _descriptor.ServiceDescriptor(
   file=DESCRIPTOR,
   index=1,
   options=None,
-  serialized_start=11390,
-  serialized_end=13013,
+  serialized_start=13089,
+  serialized_end=14762,
   methods=[
   _descriptor.MethodDescriptor(
     name='Create',
     full_name='openstorage.api.OpenStorageVolume.Create',
     index=0,
     containing_service=None,
-    input_type=_OPENSTORAGEVOLUMECREATEREQUEST,
-    output_type=_OPENSTORAGEVOLUMECREATERESPONSE,
+    input_type=_SDKVOLUMECREATEREQUEST,
+    output_type=_SDKVOLUMECREATERESPONSE,
     options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\026\"\021/v1/volume/create:\001*')),
   ),
   _descriptor.MethodDescriptor(
-    name='CreateFromVolumeID',
-    full_name='openstorage.api.OpenStorageVolume.CreateFromVolumeID',
+    name='CreateFromVolumeId',
+    full_name='openstorage.api.OpenStorageVolume.CreateFromVolumeId',
     index=1,
     containing_service=None,
-    input_type=_VOLUMECREATEFROMVOLUMEIDREQUEST,
-    output_type=_VOLUMECREATEFROMVOLUMEIDRESPONSE,
+    input_type=_SDKVOLUMECREATEFROMVOLUMEIDREQUEST,
+    output_type=_SDKVOLUMECREATEFROMVOLUMEIDRESPONSE,
     options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\034\"\027/v1/volume/createfromid:\001*')),
   ),
   _descriptor.MethodDescriptor(
@@ -5028,8 +5926,8 @@ _OPENSTORAGEVOLUME = _descriptor.ServiceDescriptor(
     full_name='openstorage.api.OpenStorageVolume.Delete',
     index=2,
     containing_service=None,
-    input_type=_VOLUMEDELETEREQUEST,
-    output_type=_VOLUMEDELETERESPONSE,
+    input_type=_SDKVOLUMEDELETEREQUEST,
+    output_type=_SDKVOLUMEDELETERESPONSE,
     options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\026\"\021/v1/volume/delete:\001*')),
   ),
   _descriptor.MethodDescriptor(
@@ -5037,8 +5935,8 @@ _OPENSTORAGEVOLUME = _descriptor.ServiceDescriptor(
     full_name='openstorage.api.OpenStorageVolume.Inspect',
     index=3,
     containing_service=None,
-    input_type=_VOLUMEINSPECTREQUEST,
-    output_type=_VOLUMEINSPECTRESPONSE,
+    input_type=_SDKVOLUMEINSPECTREQUEST,
+    output_type=_SDKVOLUMEINSPECTRESPONSE,
     options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\027\"\022/v1/volume/inspect:\001*')),
   ),
   _descriptor.MethodDescriptor(
@@ -5046,8 +5944,8 @@ _OPENSTORAGEVOLUME = _descriptor.ServiceDescriptor(
     full_name='openstorage.api.OpenStorageVolume.Enumerate',
     index=4,
     containing_service=None,
-    input_type=_VOLUMEENUMERATEREQUEST,
-    output_type=_VOLUMEENUMERATERESPONSE,
+    input_type=_SDKVOLUMEENUMERATEREQUEST,
+    output_type=_SDKVOLUMEENUMERATERESPONSE,
     options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\031\"\024/v1/volume/enumerate:\001*')),
   ),
   _descriptor.MethodDescriptor(
@@ -5055,8 +5953,8 @@ _OPENSTORAGEVOLUME = _descriptor.ServiceDescriptor(
     full_name='openstorage.api.OpenStorageVolume.SnapshotCreate',
     index=5,
     containing_service=None,
-    input_type=_VOLUMESNAPSHOTCREATEREQUEST,
-    output_type=_VOLUMESNAPSHOTCREATERESPONSE,
+    input_type=_SDKVOLUMESNAPSHOTCREATEREQUEST,
+    output_type=_SDKVOLUMESNAPSHOTCREATERESPONSE,
     options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\037\"\032/v1/volume/snapshot/create:\001*')),
   ),
   _descriptor.MethodDescriptor(
@@ -5064,8 +5962,8 @@ _OPENSTORAGEVOLUME = _descriptor.ServiceDescriptor(
     full_name='openstorage.api.OpenStorageVolume.SnapshotRestore',
     index=6,
     containing_service=None,
-    input_type=_VOLUMESNAPSHOTRESTOREREQUEST,
-    output_type=_VOLUMESNAPSHOTRESTORERESPONSE,
+    input_type=_SDKVOLUMESNAPSHOTRESTOREREQUEST,
+    output_type=_SDKVOLUMESNAPSHOTRESTORERESPONSE,
     options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002 \"\033/v1/volume/snapshot/restore:\001*')),
   ),
   _descriptor.MethodDescriptor(
@@ -5073,8 +5971,8 @@ _OPENSTORAGEVOLUME = _descriptor.ServiceDescriptor(
     full_name='openstorage.api.OpenStorageVolume.SnapshotEnumerate',
     index=7,
     containing_service=None,
-    input_type=_VOLUMESNAPSHOTENUMERATEREQUEST,
-    output_type=_VOLUMESNAPSHOTENUMERATERESPONSE,
+    input_type=_SDKVOLUMESNAPSHOTENUMERATEREQUEST,
+    output_type=_SDKVOLUMESNAPSHOTENUMERATERESPONSE,
     options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\"\"\035/v1/volume/snapshot/enumerate:\001*')),
   ),
   _descriptor.MethodDescriptor(
@@ -5082,8 +5980,8 @@ _OPENSTORAGEVOLUME = _descriptor.ServiceDescriptor(
     full_name='openstorage.api.OpenStorageVolume.Attach',
     index=8,
     containing_service=None,
-    input_type=_VOLUMEATTACHREQUEST,
-    output_type=_VOLUMEATTACHRESPONSE,
+    input_type=_SDKVOLUMEATTACHREQUEST,
+    output_type=_SDKVOLUMEATTACHRESPONSE,
     options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\026\"\021/v1/volume/attach:\001*')),
   ),
   _descriptor.MethodDescriptor(
@@ -5091,8 +5989,8 @@ _OPENSTORAGEVOLUME = _descriptor.ServiceDescriptor(
     full_name='openstorage.api.OpenStorageVolume.Detach',
     index=9,
     containing_service=None,
-    input_type=_VOLUMEDETACHREQUEST,
-    output_type=_VOLUMEDETACHRESPONSE,
+    input_type=_SDKVOLUMEDETACHREQUEST,
+    output_type=_SDKVOLUMEDETACHRESPONSE,
     options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\026\"\021/v1/volume/detach:\001*')),
   ),
   _descriptor.MethodDescriptor(
@@ -5100,8 +5998,8 @@ _OPENSTORAGEVOLUME = _descriptor.ServiceDescriptor(
     full_name='openstorage.api.OpenStorageVolume.Mount',
     index=10,
     containing_service=None,
-    input_type=_VOLUMEMOUNTREQUEST,
-    output_type=_VOLUMEMOUNTRESPONSE,
+    input_type=_SDKVOLUMEMOUNTREQUEST,
+    output_type=_SDKVOLUMEMOUNTRESPONSE,
     options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\025\"\020/v1/volume/mount:\001*')),
   ),
   _descriptor.MethodDescriptor(
@@ -5109,13 +6007,100 @@ _OPENSTORAGEVOLUME = _descriptor.ServiceDescriptor(
     full_name='openstorage.api.OpenStorageVolume.Unmount',
     index=11,
     containing_service=None,
-    input_type=_VOLUMEUNMOUNTREQUEST,
-    output_type=_VOLUMEUNMOUNTRESPONSE,
+    input_type=_SDKVOLUMEUNMOUNTREQUEST,
+    output_type=_SDKVOLUMEUNMOUNTRESPONSE,
     options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\027\"\022/v1/volume/unmount:\001*')),
   ),
 ])
 _sym_db.RegisterServiceDescriptor(_OPENSTORAGEVOLUME)
 
 DESCRIPTOR.services_by_name['OpenStorageVolume'] = _OPENSTORAGEVOLUME
+
+
+_OPENSTORAGECREDENTIALS = _descriptor.ServiceDescriptor(
+  name='OpenStorageCredentials',
+  full_name='openstorage.api.OpenStorageCredentials',
+  file=DESCRIPTOR,
+  index=2,
+  options=None,
+  serialized_start=14765,
+  serialized_end=16085,
+  methods=[
+  _descriptor.MethodDescriptor(
+    name='CreateForAWS',
+    full_name='openstorage.api.OpenStorageCredentials.CreateForAWS',
+    index=0,
+    containing_service=None,
+    input_type=_SDKCREDENTIALCREATEAWSREQUEST,
+    output_type=_SDKCREDENTIALCREATEAWSRESPONSE,
+    options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\037\"\032/v1/credentials/create/aws:\001*')),
+  ),
+  _descriptor.MethodDescriptor(
+    name='CreateForAzure',
+    full_name='openstorage.api.OpenStorageCredentials.CreateForAzure',
+    index=1,
+    containing_service=None,
+    input_type=_SDKCREDENTIALCREATEAZUREREQUEST,
+    output_type=_SDKCREDENTIALCREATEAZURERESPONSE,
+    options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002!\"\034/v1/credentials/create/azure:\001*')),
+  ),
+  _descriptor.MethodDescriptor(
+    name='CreateForGoogle',
+    full_name='openstorage.api.OpenStorageCredentials.CreateForGoogle',
+    index=2,
+    containing_service=None,
+    input_type=_SDKCREDENTIALCREATEGOOGLEREQUEST,
+    output_type=_SDKCREDENTIALCREATEGOOGLERESPONSE,
+    options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\"\"\035/v1/credentials/create/google:\001*')),
+  ),
+  _descriptor.MethodDescriptor(
+    name='EnumerateForAWS',
+    full_name='openstorage.api.OpenStorageCredentials.EnumerateForAWS',
+    index=3,
+    containing_service=None,
+    input_type=_SDKCREDENTIALENUMERATEAWSREQUEST,
+    output_type=_SDKCREDENTIALENUMERATEAWSRESPONSE,
+    options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\"\"\035/v1/credentials/enumerate/aws:\001*')),
+  ),
+  _descriptor.MethodDescriptor(
+    name='EnumerateForAzure',
+    full_name='openstorage.api.OpenStorageCredentials.EnumerateForAzure',
+    index=4,
+    containing_service=None,
+    input_type=_SDKCREDENTIALENUMERATEAZUREREQUEST,
+    output_type=_SDKCREDENTIALENUMERATEAZURERESPONSE,
+    options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002$\"\037/v1/credentials/enumerate/azure:\001*')),
+  ),
+  _descriptor.MethodDescriptor(
+    name='EnumerateForGoogle',
+    full_name='openstorage.api.OpenStorageCredentials.EnumerateForGoogle',
+    index=5,
+    containing_service=None,
+    input_type=_SDKCREDENTIALENUMERATEGOOGLEREQUEST,
+    output_type=_SDKCREDENTIALENUMERATEGOOGLERESPONSE,
+    options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002%\" /v1/credentials/enumerate/google:\001*')),
+  ),
+  _descriptor.MethodDescriptor(
+    name='CredentialDelete',
+    full_name='openstorage.api.OpenStorageCredentials.CredentialDelete',
+    index=6,
+    containing_service=None,
+    input_type=_SDKCREDENTIALDELETEREQUEST,
+    output_type=_SDKCREDENTIALDELETERESPONSE,
+    options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\033\"\026/v1/credentials/delete:\001*')),
+  ),
+  _descriptor.MethodDescriptor(
+    name='CredentialValidate',
+    full_name='openstorage.api.OpenStorageCredentials.CredentialValidate',
+    index=7,
+    containing_service=None,
+    input_type=_SDKCREDENTIALVALIDATEREQUEST,
+    output_type=_SDKCREDENTIALVALIDATERESPONSE,
+    options=_descriptor._ParseOptions(descriptor_pb2.MethodOptions(), _b('\202\323\344\223\002\035\"\030/v1/credentials/validate:\001*')),
+  ),
+])
+_sym_db.RegisterServiceDescriptor(_OPENSTORAGECREDENTIALS)
+
+DESCRIPTOR.services_by_name['OpenStorageCredentials'] = _OPENSTORAGECREDENTIALS
 
 # @@protoc_insertion_point(module_scope)

--- a/api/client/sdk/python/api_pb2_grpc.py
+++ b/api/client/sdk/python/api_pb2_grpc.py
@@ -16,28 +16,28 @@ class OpenStorageClusterStub(object):
     """
     self.Enumerate = channel.unary_unary(
         '/openstorage.api.OpenStorageCluster/Enumerate',
-        request_serializer=api__pb2.ClusterEnumerateRequest.SerializeToString,
-        response_deserializer=api__pb2.ClusterEnumerateResponse.FromString,
+        request_serializer=api__pb2.SdkClusterEnumerateRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkClusterEnumerateResponse.FromString,
         )
     self.Inspect = channel.unary_unary(
         '/openstorage.api.OpenStorageCluster/Inspect',
-        request_serializer=api__pb2.ClusterInspectRequest.SerializeToString,
-        response_deserializer=api__pb2.ClusterInspectResponse.FromString,
+        request_serializer=api__pb2.SdkClusterInspectRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkClusterInspectResponse.FromString,
         )
     self.AlertEnumerate = channel.unary_unary(
         '/openstorage.api.OpenStorageCluster/AlertEnumerate',
-        request_serializer=api__pb2.ClusterAlertEnumerateRequest.SerializeToString,
-        response_deserializer=api__pb2.ClusterAlertEnumerateResponse.FromString,
+        request_serializer=api__pb2.SdkClusterAlertEnumerateRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkClusterAlertEnumerateResponse.FromString,
         )
     self.AlertClear = channel.unary_unary(
         '/openstorage.api.OpenStorageCluster/AlertClear',
-        request_serializer=api__pb2.ClusterAlertClearRequest.SerializeToString,
-        response_deserializer=api__pb2.ClusterAlertClearResponse.FromString,
+        request_serializer=api__pb2.SdkClusterAlertClearRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkClusterAlertClearResponse.FromString,
         )
     self.AlertErase = channel.unary_unary(
         '/openstorage.api.OpenStorageCluster/AlertErase',
-        request_serializer=api__pb2.ClusterAlertEraseRequest.SerializeToString,
-        response_deserializer=api__pb2.ClusterAlertEraseResponse.FromString,
+        request_serializer=api__pb2.SdkClusterAlertEraseRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkClusterAlertEraseResponse.FromString,
         )
 
 
@@ -85,28 +85,28 @@ def add_OpenStorageClusterServicer_to_server(servicer, server):
   rpc_method_handlers = {
       'Enumerate': grpc.unary_unary_rpc_method_handler(
           servicer.Enumerate,
-          request_deserializer=api__pb2.ClusterEnumerateRequest.FromString,
-          response_serializer=api__pb2.ClusterEnumerateResponse.SerializeToString,
+          request_deserializer=api__pb2.SdkClusterEnumerateRequest.FromString,
+          response_serializer=api__pb2.SdkClusterEnumerateResponse.SerializeToString,
       ),
       'Inspect': grpc.unary_unary_rpc_method_handler(
           servicer.Inspect,
-          request_deserializer=api__pb2.ClusterInspectRequest.FromString,
-          response_serializer=api__pb2.ClusterInspectResponse.SerializeToString,
+          request_deserializer=api__pb2.SdkClusterInspectRequest.FromString,
+          response_serializer=api__pb2.SdkClusterInspectResponse.SerializeToString,
       ),
       'AlertEnumerate': grpc.unary_unary_rpc_method_handler(
           servicer.AlertEnumerate,
-          request_deserializer=api__pb2.ClusterAlertEnumerateRequest.FromString,
-          response_serializer=api__pb2.ClusterAlertEnumerateResponse.SerializeToString,
+          request_deserializer=api__pb2.SdkClusterAlertEnumerateRequest.FromString,
+          response_serializer=api__pb2.SdkClusterAlertEnumerateResponse.SerializeToString,
       ),
       'AlertClear': grpc.unary_unary_rpc_method_handler(
           servicer.AlertClear,
-          request_deserializer=api__pb2.ClusterAlertClearRequest.FromString,
-          response_serializer=api__pb2.ClusterAlertClearResponse.SerializeToString,
+          request_deserializer=api__pb2.SdkClusterAlertClearRequest.FromString,
+          response_serializer=api__pb2.SdkClusterAlertClearResponse.SerializeToString,
       ),
       'AlertErase': grpc.unary_unary_rpc_method_handler(
           servicer.AlertErase,
-          request_deserializer=api__pb2.ClusterAlertEraseRequest.FromString,
-          response_serializer=api__pb2.ClusterAlertEraseResponse.SerializeToString,
+          request_deserializer=api__pb2.SdkClusterAlertEraseRequest.FromString,
+          response_serializer=api__pb2.SdkClusterAlertEraseResponse.SerializeToString,
       ),
   }
   generic_handler = grpc.method_handlers_generic_handler(
@@ -126,63 +126,63 @@ class OpenStorageVolumeStub(object):
     """
     self.Create = channel.unary_unary(
         '/openstorage.api.OpenStorageVolume/Create',
-        request_serializer=api__pb2.OpenStorageVolumeCreateRequest.SerializeToString,
-        response_deserializer=api__pb2.OpenStorageVolumeCreateResponse.FromString,
+        request_serializer=api__pb2.SdkVolumeCreateRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkVolumeCreateResponse.FromString,
         )
-    self.CreateFromVolumeID = channel.unary_unary(
-        '/openstorage.api.OpenStorageVolume/CreateFromVolumeID',
-        request_serializer=api__pb2.VolumeCreateFromVolumeIDRequest.SerializeToString,
-        response_deserializer=api__pb2.VolumeCreateFromVolumeIDResponse.FromString,
+    self.CreateFromVolumeId = channel.unary_unary(
+        '/openstorage.api.OpenStorageVolume/CreateFromVolumeId',
+        request_serializer=api__pb2.SdkVolumeCreateFromVolumeIdRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkVolumeCreateFromVolumeIdResponse.FromString,
         )
     self.Delete = channel.unary_unary(
         '/openstorage.api.OpenStorageVolume/Delete',
-        request_serializer=api__pb2.VolumeDeleteRequest.SerializeToString,
-        response_deserializer=api__pb2.VolumeDeleteResponse.FromString,
+        request_serializer=api__pb2.SdkVolumeDeleteRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkVolumeDeleteResponse.FromString,
         )
     self.Inspect = channel.unary_unary(
         '/openstorage.api.OpenStorageVolume/Inspect',
-        request_serializer=api__pb2.VolumeInspectRequest.SerializeToString,
-        response_deserializer=api__pb2.VolumeInspectResponse.FromString,
+        request_serializer=api__pb2.SdkVolumeInspectRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkVolumeInspectResponse.FromString,
         )
     self.Enumerate = channel.unary_unary(
         '/openstorage.api.OpenStorageVolume/Enumerate',
-        request_serializer=api__pb2.VolumeEnumerateRequest.SerializeToString,
-        response_deserializer=api__pb2.VolumeEnumerateResponse.FromString,
+        request_serializer=api__pb2.SdkVolumeEnumerateRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkVolumeEnumerateResponse.FromString,
         )
     self.SnapshotCreate = channel.unary_unary(
         '/openstorage.api.OpenStorageVolume/SnapshotCreate',
-        request_serializer=api__pb2.VolumeSnapshotCreateRequest.SerializeToString,
-        response_deserializer=api__pb2.VolumeSnapshotCreateResponse.FromString,
+        request_serializer=api__pb2.SdkVolumeSnapshotCreateRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkVolumeSnapshotCreateResponse.FromString,
         )
     self.SnapshotRestore = channel.unary_unary(
         '/openstorage.api.OpenStorageVolume/SnapshotRestore',
-        request_serializer=api__pb2.VolumeSnapshotRestoreRequest.SerializeToString,
-        response_deserializer=api__pb2.VolumeSnapshotRestoreResponse.FromString,
+        request_serializer=api__pb2.SdkVolumeSnapshotRestoreRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkVolumeSnapshotRestoreResponse.FromString,
         )
     self.SnapshotEnumerate = channel.unary_unary(
         '/openstorage.api.OpenStorageVolume/SnapshotEnumerate',
-        request_serializer=api__pb2.VolumeSnapshotEnumerateRequest.SerializeToString,
-        response_deserializer=api__pb2.VolumeSnapshotEnumerateResponse.FromString,
+        request_serializer=api__pb2.SdkVolumeSnapshotEnumerateRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkVolumeSnapshotEnumerateResponse.FromString,
         )
     self.Attach = channel.unary_unary(
         '/openstorage.api.OpenStorageVolume/Attach',
-        request_serializer=api__pb2.VolumeAttachRequest.SerializeToString,
-        response_deserializer=api__pb2.VolumeAttachResponse.FromString,
+        request_serializer=api__pb2.SdkVolumeAttachRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkVolumeAttachResponse.FromString,
         )
     self.Detach = channel.unary_unary(
         '/openstorage.api.OpenStorageVolume/Detach',
-        request_serializer=api__pb2.VolumeDetachRequest.SerializeToString,
-        response_deserializer=api__pb2.VolumeDetachResponse.FromString,
+        request_serializer=api__pb2.SdkVolumeDetachRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkVolumeDetachResponse.FromString,
         )
     self.Mount = channel.unary_unary(
         '/openstorage.api.OpenStorageVolume/Mount',
-        request_serializer=api__pb2.VolumeMountRequest.SerializeToString,
-        response_deserializer=api__pb2.VolumeMountResponse.FromString,
+        request_serializer=api__pb2.SdkVolumeMountRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkVolumeMountResponse.FromString,
         )
     self.Unmount = channel.unary_unary(
         '/openstorage.api.OpenStorageVolume/Unmount',
-        request_serializer=api__pb2.VolumeUnmountRequest.SerializeToString,
-        response_deserializer=api__pb2.VolumeUnmountResponse.FromString,
+        request_serializer=api__pb2.SdkVolumeUnmountRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkVolumeUnmountResponse.FromString,
         )
 
 
@@ -197,8 +197,8 @@ class OpenStorageVolumeServicer(object):
     context.set_details('Method not implemented!')
     raise NotImplementedError('Method not implemented!')
 
-  def CreateFromVolumeID(self, request, context):
-    """CreateFromVolumeID creates a new volume cloned from an existing volume
+  def CreateFromVolumeId(self, request, context):
+    """CreateFromVolumeId creates a new volume cloned from an existing volume
     """
     context.set_code(grpc.StatusCode.UNIMPLEMENTED)
     context.set_details('Method not implemented!')
@@ -280,65 +280,232 @@ def add_OpenStorageVolumeServicer_to_server(servicer, server):
   rpc_method_handlers = {
       'Create': grpc.unary_unary_rpc_method_handler(
           servicer.Create,
-          request_deserializer=api__pb2.OpenStorageVolumeCreateRequest.FromString,
-          response_serializer=api__pb2.OpenStorageVolumeCreateResponse.SerializeToString,
+          request_deserializer=api__pb2.SdkVolumeCreateRequest.FromString,
+          response_serializer=api__pb2.SdkVolumeCreateResponse.SerializeToString,
       ),
-      'CreateFromVolumeID': grpc.unary_unary_rpc_method_handler(
-          servicer.CreateFromVolumeID,
-          request_deserializer=api__pb2.VolumeCreateFromVolumeIDRequest.FromString,
-          response_serializer=api__pb2.VolumeCreateFromVolumeIDResponse.SerializeToString,
+      'CreateFromVolumeId': grpc.unary_unary_rpc_method_handler(
+          servicer.CreateFromVolumeId,
+          request_deserializer=api__pb2.SdkVolumeCreateFromVolumeIdRequest.FromString,
+          response_serializer=api__pb2.SdkVolumeCreateFromVolumeIdResponse.SerializeToString,
       ),
       'Delete': grpc.unary_unary_rpc_method_handler(
           servicer.Delete,
-          request_deserializer=api__pb2.VolumeDeleteRequest.FromString,
-          response_serializer=api__pb2.VolumeDeleteResponse.SerializeToString,
+          request_deserializer=api__pb2.SdkVolumeDeleteRequest.FromString,
+          response_serializer=api__pb2.SdkVolumeDeleteResponse.SerializeToString,
       ),
       'Inspect': grpc.unary_unary_rpc_method_handler(
           servicer.Inspect,
-          request_deserializer=api__pb2.VolumeInspectRequest.FromString,
-          response_serializer=api__pb2.VolumeInspectResponse.SerializeToString,
+          request_deserializer=api__pb2.SdkVolumeInspectRequest.FromString,
+          response_serializer=api__pb2.SdkVolumeInspectResponse.SerializeToString,
       ),
       'Enumerate': grpc.unary_unary_rpc_method_handler(
           servicer.Enumerate,
-          request_deserializer=api__pb2.VolumeEnumerateRequest.FromString,
-          response_serializer=api__pb2.VolumeEnumerateResponse.SerializeToString,
+          request_deserializer=api__pb2.SdkVolumeEnumerateRequest.FromString,
+          response_serializer=api__pb2.SdkVolumeEnumerateResponse.SerializeToString,
       ),
       'SnapshotCreate': grpc.unary_unary_rpc_method_handler(
           servicer.SnapshotCreate,
-          request_deserializer=api__pb2.VolumeSnapshotCreateRequest.FromString,
-          response_serializer=api__pb2.VolumeSnapshotCreateResponse.SerializeToString,
+          request_deserializer=api__pb2.SdkVolumeSnapshotCreateRequest.FromString,
+          response_serializer=api__pb2.SdkVolumeSnapshotCreateResponse.SerializeToString,
       ),
       'SnapshotRestore': grpc.unary_unary_rpc_method_handler(
           servicer.SnapshotRestore,
-          request_deserializer=api__pb2.VolumeSnapshotRestoreRequest.FromString,
-          response_serializer=api__pb2.VolumeSnapshotRestoreResponse.SerializeToString,
+          request_deserializer=api__pb2.SdkVolumeSnapshotRestoreRequest.FromString,
+          response_serializer=api__pb2.SdkVolumeSnapshotRestoreResponse.SerializeToString,
       ),
       'SnapshotEnumerate': grpc.unary_unary_rpc_method_handler(
           servicer.SnapshotEnumerate,
-          request_deserializer=api__pb2.VolumeSnapshotEnumerateRequest.FromString,
-          response_serializer=api__pb2.VolumeSnapshotEnumerateResponse.SerializeToString,
+          request_deserializer=api__pb2.SdkVolumeSnapshotEnumerateRequest.FromString,
+          response_serializer=api__pb2.SdkVolumeSnapshotEnumerateResponse.SerializeToString,
       ),
       'Attach': grpc.unary_unary_rpc_method_handler(
           servicer.Attach,
-          request_deserializer=api__pb2.VolumeAttachRequest.FromString,
-          response_serializer=api__pb2.VolumeAttachResponse.SerializeToString,
+          request_deserializer=api__pb2.SdkVolumeAttachRequest.FromString,
+          response_serializer=api__pb2.SdkVolumeAttachResponse.SerializeToString,
       ),
       'Detach': grpc.unary_unary_rpc_method_handler(
           servicer.Detach,
-          request_deserializer=api__pb2.VolumeDetachRequest.FromString,
-          response_serializer=api__pb2.VolumeDetachResponse.SerializeToString,
+          request_deserializer=api__pb2.SdkVolumeDetachRequest.FromString,
+          response_serializer=api__pb2.SdkVolumeDetachResponse.SerializeToString,
       ),
       'Mount': grpc.unary_unary_rpc_method_handler(
           servicer.Mount,
-          request_deserializer=api__pb2.VolumeMountRequest.FromString,
-          response_serializer=api__pb2.VolumeMountResponse.SerializeToString,
+          request_deserializer=api__pb2.SdkVolumeMountRequest.FromString,
+          response_serializer=api__pb2.SdkVolumeMountResponse.SerializeToString,
       ),
       'Unmount': grpc.unary_unary_rpc_method_handler(
           servicer.Unmount,
-          request_deserializer=api__pb2.VolumeUnmountRequest.FromString,
-          response_serializer=api__pb2.VolumeUnmountResponse.SerializeToString,
+          request_deserializer=api__pb2.SdkVolumeUnmountRequest.FromString,
+          response_serializer=api__pb2.SdkVolumeUnmountResponse.SerializeToString,
       ),
   }
   generic_handler = grpc.method_handlers_generic_handler(
       'openstorage.api.OpenStorageVolume', rpc_method_handlers)
+  server.add_generic_rpc_handlers((generic_handler,))
+
+
+class OpenStorageCredentialsStub(object):
+  # missing associated documentation comment in .proto file
+  pass
+
+  def __init__(self, channel):
+    """Constructor.
+
+    Args:
+      channel: A grpc.Channel.
+    """
+    self.CreateForAWS = channel.unary_unary(
+        '/openstorage.api.OpenStorageCredentials/CreateForAWS',
+        request_serializer=api__pb2.SdkCredentialCreateAWSRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkCredentialCreateAWSResponse.FromString,
+        )
+    self.CreateForAzure = channel.unary_unary(
+        '/openstorage.api.OpenStorageCredentials/CreateForAzure',
+        request_serializer=api__pb2.SdkCredentialCreateAzureRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkCredentialCreateAzureResponse.FromString,
+        )
+    self.CreateForGoogle = channel.unary_unary(
+        '/openstorage.api.OpenStorageCredentials/CreateForGoogle',
+        request_serializer=api__pb2.SdkCredentialCreateGoogleRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkCredentialCreateGoogleResponse.FromString,
+        )
+    self.EnumerateForAWS = channel.unary_unary(
+        '/openstorage.api.OpenStorageCredentials/EnumerateForAWS',
+        request_serializer=api__pb2.SdkCredentialEnumerateAWSRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkCredentialEnumerateAWSResponse.FromString,
+        )
+    self.EnumerateForAzure = channel.unary_unary(
+        '/openstorage.api.OpenStorageCredentials/EnumerateForAzure',
+        request_serializer=api__pb2.SdkCredentialEnumerateAzureRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkCredentialEnumerateAzureResponse.FromString,
+        )
+    self.EnumerateForGoogle = channel.unary_unary(
+        '/openstorage.api.OpenStorageCredentials/EnumerateForGoogle',
+        request_serializer=api__pb2.SdkCredentialEnumerateGoogleRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkCredentialEnumerateGoogleResponse.FromString,
+        )
+    self.CredentialDelete = channel.unary_unary(
+        '/openstorage.api.OpenStorageCredentials/CredentialDelete',
+        request_serializer=api__pb2.SdkCredentialDeleteRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkCredentialDeleteResponse.FromString,
+        )
+    self.CredentialValidate = channel.unary_unary(
+        '/openstorage.api.OpenStorageCredentials/CredentialValidate',
+        request_serializer=api__pb2.SdkCredentialValidateRequest.SerializeToString,
+        response_deserializer=api__pb2.SdkCredentialValidateResponse.FromString,
+        )
+
+
+class OpenStorageCredentialsServicer(object):
+  # missing associated documentation comment in .proto file
+  pass
+
+  def CreateForAWS(self, request, context):
+    """Provide credentials to OpenStorage and if valid,
+    it will return an identifier to the credentials
+
+    Create credential for AWS S3 and if valid ,
+    returns a unique identifier
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def CreateForAzure(self, request, context):
+    """Create credential for Azure and if valid ,
+    returns a unique identifier
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def CreateForGoogle(self, request, context):
+    """Create credential for Google and if valid ,
+    returns a unique identifier
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def EnumerateForAWS(self, request, context):
+    """EnumerateForAWS lists the configured AWS credentials                      
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def EnumerateForAzure(self, request, context):
+    """EnumerateForAzure lists the configured Azure credentials                  
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def EnumerateForGoogle(self, request, context):
+    """EnumerateForGoogle lists the configured Google credentials                
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def CredentialDelete(self, request, context):
+    """Delete a specified credential                                                 
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+  def CredentialValidate(self, request, context):
+    """Validate a specified credential
+    """
+    context.set_code(grpc.StatusCode.UNIMPLEMENTED)
+    context.set_details('Method not implemented!')
+    raise NotImplementedError('Method not implemented!')
+
+
+def add_OpenStorageCredentialsServicer_to_server(servicer, server):
+  rpc_method_handlers = {
+      'CreateForAWS': grpc.unary_unary_rpc_method_handler(
+          servicer.CreateForAWS,
+          request_deserializer=api__pb2.SdkCredentialCreateAWSRequest.FromString,
+          response_serializer=api__pb2.SdkCredentialCreateAWSResponse.SerializeToString,
+      ),
+      'CreateForAzure': grpc.unary_unary_rpc_method_handler(
+          servicer.CreateForAzure,
+          request_deserializer=api__pb2.SdkCredentialCreateAzureRequest.FromString,
+          response_serializer=api__pb2.SdkCredentialCreateAzureResponse.SerializeToString,
+      ),
+      'CreateForGoogle': grpc.unary_unary_rpc_method_handler(
+          servicer.CreateForGoogle,
+          request_deserializer=api__pb2.SdkCredentialCreateGoogleRequest.FromString,
+          response_serializer=api__pb2.SdkCredentialCreateGoogleResponse.SerializeToString,
+      ),
+      'EnumerateForAWS': grpc.unary_unary_rpc_method_handler(
+          servicer.EnumerateForAWS,
+          request_deserializer=api__pb2.SdkCredentialEnumerateAWSRequest.FromString,
+          response_serializer=api__pb2.SdkCredentialEnumerateAWSResponse.SerializeToString,
+      ),
+      'EnumerateForAzure': grpc.unary_unary_rpc_method_handler(
+          servicer.EnumerateForAzure,
+          request_deserializer=api__pb2.SdkCredentialEnumerateAzureRequest.FromString,
+          response_serializer=api__pb2.SdkCredentialEnumerateAzureResponse.SerializeToString,
+      ),
+      'EnumerateForGoogle': grpc.unary_unary_rpc_method_handler(
+          servicer.EnumerateForGoogle,
+          request_deserializer=api__pb2.SdkCredentialEnumerateGoogleRequest.FromString,
+          response_serializer=api__pb2.SdkCredentialEnumerateGoogleResponse.SerializeToString,
+      ),
+      'CredentialDelete': grpc.unary_unary_rpc_method_handler(
+          servicer.CredentialDelete,
+          request_deserializer=api__pb2.SdkCredentialDeleteRequest.FromString,
+          response_serializer=api__pb2.SdkCredentialDeleteResponse.SerializeToString,
+      ),
+      'CredentialValidate': grpc.unary_unary_rpc_method_handler(
+          servicer.CredentialValidate,
+          request_deserializer=api__pb2.SdkCredentialValidateRequest.FromString,
+          response_serializer=api__pb2.SdkCredentialValidateResponse.SerializeToString,
+      ),
+  }
+  generic_handler = grpc.method_handlers_generic_handler(
+      'openstorage.api.OpenStorageCredentials', rpc_method_handlers)
   server.add_generic_rpc_handlers((generic_handler,))

--- a/api/client/sdk/ruby/api_pb.rb
+++ b/api/client/sdk/ruby/api_pb.rb
@@ -124,6 +124,19 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
   add_message "openstorage.api.Alerts" do
     repeated :alert, :message, 1, "openstorage.api.Alert"
   end
+  add_message "openstorage.api.ObjectstoreInfo" do
+    optional :uuid, :string, 1
+    optional :volume_id, :string, 2
+    optional :enabled, :bool, 3
+    optional :status, :string, 4
+    optional :action, :int64, 5
+    optional :access_key, :string, 6
+    optional :secret_key, :string, 7
+    repeated :endpoints, :string, 8
+    optional :current_endPoint, :string, 9
+    optional :access_port, :int64, 10
+    optional :region, :string, 11
+  end
   add_message "openstorage.api.VolumeCreateRequest" do
     optional :locator, :message, 1, "openstorage.api.VolumeLocator"
     optional :source, :message, 2, "openstorage.api.Source"
@@ -216,114 +229,177 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
     optional :node_id, :string, 3
     repeated :nodes, :message, 4, "openstorage.api.StorageNode"
   end
-  add_message "openstorage.api.VolumeMountRequest" do
+  add_message "openstorage.api.SdkCredentialCreateAzureRequest" do
+    optional :credential, :message, 1, "openstorage.api.AzureCredential"
+  end
+  add_message "openstorage.api.SdkCredentialCreateAzureResponse" do
+    optional :credential_id, :string, 1
+  end
+  add_message "openstorage.api.SdkCredentialCreateGoogleRequest" do
+    optional :credential, :message, 1, "openstorage.api.GoogleCredential"
+  end
+  add_message "openstorage.api.SdkCredentialCreateGoogleResponse" do
+    optional :credential_id, :string, 1
+  end
+  add_message "openstorage.api.SdkCredentialCreateAWSRequest" do
+    optional :credential, :message, 1, "openstorage.api.S3Credential"
+  end
+  add_message "openstorage.api.SdkCredentialCreateAWSResponse" do
+    optional :credential_id, :string, 1
+  end
+  add_message "openstorage.api.S3Credential" do
+    optional :credential_id, :string, 1
+    optional :access_key, :string, 2
+    optional :secret_key, :string, 3
+    optional :endpoint, :string, 4
+    optional :region, :string, 5
+  end
+  add_message "openstorage.api.AzureCredential" do
+    optional :credential_id, :string, 1
+    optional :account_name, :string, 2
+    optional :account_key, :string, 3
+  end
+  add_message "openstorage.api.GoogleCredential" do
+    optional :credential_id, :string, 1
+    optional :project_id, :string, 2
+    optional :json_key, :string, 3
+  end
+  add_message "openstorage.api.SdkCredentialEnumerateAWSRequest" do
+    optional :credential_id, :string, 1
+  end
+  add_message "openstorage.api.SdkCredentialEnumerateAWSResponse" do
+    repeated :credential, :message, 1, "openstorage.api.S3Credential"
+  end
+  add_message "openstorage.api.SdkCredentialEnumerateAzureRequest" do
+    optional :credential_id, :string, 1
+  end
+  add_message "openstorage.api.SdkCredentialEnumerateAzureResponse" do
+    repeated :credential, :message, 1, "openstorage.api.AzureCredential"
+  end
+  add_message "openstorage.api.SdkCredentialEnumerateGoogleRequest" do
+    optional :credential_id, :string, 1
+  end
+  add_message "openstorage.api.SdkCredentialEnumerateGoogleResponse" do
+    repeated :credential, :message, 1, "openstorage.api.GoogleCredential"
+  end
+  add_message "openstorage.api.SdkCredentialDeleteRequest" do
+    optional :credential_id, :string, 1
+  end
+  add_message "openstorage.api.SdkCredentialDeleteResponse" do
+  end
+  add_message "openstorage.api.SdkCredentialValidateRequest" do
+    optional :credential_id, :string, 1
+  end
+  add_message "openstorage.api.SdkCredentialValidateResponse" do
+  end
+  add_message "openstorage.api.SdkVolumeMountRequest" do
     optional :volume_id, :string, 1
     optional :mount_path, :string, 2
     map :options, :string, :string, 3
   end
-  add_message "openstorage.api.VolumeMountResponse" do
+  add_message "openstorage.api.SdkVolumeMountResponse" do
   end
-  add_message "openstorage.api.VolumeUnmountRequest" do
+  add_message "openstorage.api.SdkVolumeUnmountRequest" do
     optional :volume_id, :string, 1
     optional :mount_path, :string, 2
     map :options, :string, :string, 3
   end
-  add_message "openstorage.api.VolumeUnmountResponse" do
+  add_message "openstorage.api.SdkVolumeUnmountResponse" do
   end
-  add_message "openstorage.api.VolumeAttachRequest" do
+  add_message "openstorage.api.SdkVolumeAttachRequest" do
     optional :volume_id, :string, 1
     map :options, :string, :string, 2
   end
-  add_message "openstorage.api.VolumeAttachResponse" do
+  add_message "openstorage.api.SdkVolumeAttachResponse" do
     optional :device_path, :string, 1
   end
-  add_message "openstorage.api.VolumeDetachRequest" do
+  add_message "openstorage.api.SdkVolumeDetachRequest" do
     optional :volume_id, :string, 1
   end
-  add_message "openstorage.api.VolumeDetachResponse" do
+  add_message "openstorage.api.SdkVolumeDetachResponse" do
   end
-  add_message "openstorage.api.OpenStorageVolumeCreateRequest" do
+  add_message "openstorage.api.SdkVolumeCreateRequest" do
     optional :name, :string, 1
     optional :spec, :message, 2, "openstorage.api.VolumeSpec"
   end
-  add_message "openstorage.api.OpenStorageVolumeCreateResponse" do
+  add_message "openstorage.api.SdkVolumeCreateResponse" do
     optional :volume_id, :string, 1
   end
-  add_message "openstorage.api.VolumeCreateFromVolumeIDRequest" do
+  add_message "openstorage.api.SdkVolumeCreateFromVolumeIdRequest" do
     optional :name, :string, 1
     optional :parent_id, :string, 2
     optional :spec, :message, 3, "openstorage.api.VolumeSpec"
   end
-  add_message "openstorage.api.VolumeCreateFromVolumeIDResponse" do
+  add_message "openstorage.api.SdkVolumeCreateFromVolumeIdResponse" do
     optional :volume_id, :string, 1
   end
-  add_message "openstorage.api.VolumeDeleteRequest" do
+  add_message "openstorage.api.SdkVolumeDeleteRequest" do
     optional :volume_id, :string, 1
   end
-  add_message "openstorage.api.VolumeDeleteResponse" do
+  add_message "openstorage.api.SdkVolumeDeleteResponse" do
   end
-  add_message "openstorage.api.VolumeInspectRequest" do
+  add_message "openstorage.api.SdkVolumeInspectRequest" do
     optional :volume_id, :string, 1
   end
-  add_message "openstorage.api.VolumeInspectResponse" do
+  add_message "openstorage.api.SdkVolumeInspectResponse" do
     optional :volume, :message, 1, "openstorage.api.Volume"
   end
-  add_message "openstorage.api.VolumeEnumerateRequest" do
+  add_message "openstorage.api.SdkVolumeEnumerateRequest" do
     optional :locator, :message, 1, "openstorage.api.VolumeLocator"
   end
-  add_message "openstorage.api.VolumeEnumerateResponse" do
+  add_message "openstorage.api.SdkVolumeEnumerateResponse" do
     repeated :volumes, :message, 1, "openstorage.api.Volume"
   end
-  add_message "openstorage.api.VolumeSnapshotCreateRequest" do
+  add_message "openstorage.api.SdkVolumeSnapshotCreateRequest" do
     optional :volume_id, :string, 1
     map :labels, :string, :string, 2
   end
-  add_message "openstorage.api.VolumeSnapshotCreateResponse" do
+  add_message "openstorage.api.SdkVolumeSnapshotCreateResponse" do
     optional :snapshot_id, :string, 1
   end
-  add_message "openstorage.api.VolumeSnapshotRestoreRequest" do
+  add_message "openstorage.api.SdkVolumeSnapshotRestoreRequest" do
     optional :volume_id, :string, 1
     optional :snapshot_id, :string, 2
   end
-  add_message "openstorage.api.VolumeSnapshotRestoreResponse" do
+  add_message "openstorage.api.SdkVolumeSnapshotRestoreResponse" do
   end
-  add_message "openstorage.api.VolumeSnapshotEnumerateRequest" do
+  add_message "openstorage.api.SdkVolumeSnapshotEnumerateRequest" do
     optional :volume_id, :string, 1
     map :labels, :string, :string, 2
   end
-  add_message "openstorage.api.VolumeSnapshotEnumerateResponse" do
+  add_message "openstorage.api.SdkVolumeSnapshotEnumerateResponse" do
     repeated :snapshots, :message, 1, "openstorage.api.Volume"
   end
-  add_message "openstorage.api.ClusterEnumerateRequest" do
+  add_message "openstorage.api.SdkClusterEnumerateRequest" do
   end
-  add_message "openstorage.api.ClusterEnumerateResponse" do
+  add_message "openstorage.api.SdkClusterEnumerateResponse" do
     optional :cluster, :message, 1, "openstorage.api.StorageCluster"
   end
-  add_message "openstorage.api.ClusterInspectRequest" do
+  add_message "openstorage.api.SdkClusterInspectRequest" do
     optional :node_id, :string, 1
   end
-  add_message "openstorage.api.ClusterInspectResponse" do
+  add_message "openstorage.api.SdkClusterInspectResponse" do
     optional :node, :message, 1, "openstorage.api.StorageNode"
   end
-  add_message "openstorage.api.ClusterAlertEnumerateRequest" do
+  add_message "openstorage.api.SdkClusterAlertEnumerateRequest" do
     optional :time_start, :message, 1, "google.protobuf.Timestamp"
     optional :time_end, :message, 2, "google.protobuf.Timestamp"
     optional :resource, :enum, 3, "openstorage.api.ResourceType"
   end
-  add_message "openstorage.api.ClusterAlertEnumerateResponse" do
+  add_message "openstorage.api.SdkClusterAlertEnumerateResponse" do
     optional :alerts, :message, 1, "openstorage.api.Alerts"
   end
-  add_message "openstorage.api.ClusterAlertClearRequest" do
+  add_message "openstorage.api.SdkClusterAlertClearRequest" do
     optional :resource, :enum, 1, "openstorage.api.ResourceType"
     optional :alert_id, :int64, 2
   end
-  add_message "openstorage.api.ClusterAlertClearResponse" do
+  add_message "openstorage.api.SdkClusterAlertClearResponse" do
   end
-  add_message "openstorage.api.ClusterAlertEraseRequest" do
+  add_message "openstorage.api.SdkClusterAlertEraseRequest" do
     optional :resource, :enum, 1, "openstorage.api.ResourceType"
     optional :alert_id, :int64, 2
   end
-  add_message "openstorage.api.ClusterAlertEraseResponse" do
+  add_message "openstorage.api.SdkClusterAlertEraseResponse" do
   end
   add_enum "openstorage.api.Status" do
     value :STATUS_NONE, 0
@@ -456,6 +532,7 @@ module Openstorage
     Stats = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.Stats").msgclass
     Alert = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.Alert").msgclass
     Alerts = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.Alerts").msgclass
+    ObjectstoreInfo = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.ObjectstoreInfo").msgclass
     VolumeCreateRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeCreateRequest").msgclass
     VolumeResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeResponse").msgclass
     VolumeCreateResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeCreateResponse").msgclass
@@ -474,40 +551,59 @@ module Openstorage
     GroupSnapCreateResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.GroupSnapCreateResponse").msgclass
     StorageNode = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.StorageNode").msgclass
     StorageCluster = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.StorageCluster").msgclass
-    VolumeMountRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeMountRequest").msgclass
-    VolumeMountResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeMountResponse").msgclass
-    VolumeUnmountRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeUnmountRequest").msgclass
-    VolumeUnmountResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeUnmountResponse").msgclass
-    VolumeAttachRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeAttachRequest").msgclass
-    VolumeAttachResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeAttachResponse").msgclass
-    VolumeDetachRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeDetachRequest").msgclass
-    VolumeDetachResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeDetachResponse").msgclass
-    OpenStorageVolumeCreateRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.OpenStorageVolumeCreateRequest").msgclass
-    OpenStorageVolumeCreateResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.OpenStorageVolumeCreateResponse").msgclass
-    VolumeCreateFromVolumeIDRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeCreateFromVolumeIDRequest").msgclass
-    VolumeCreateFromVolumeIDResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeCreateFromVolumeIDResponse").msgclass
-    VolumeDeleteRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeDeleteRequest").msgclass
-    VolumeDeleteResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeDeleteResponse").msgclass
-    VolumeInspectRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeInspectRequest").msgclass
-    VolumeInspectResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeInspectResponse").msgclass
-    VolumeEnumerateRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeEnumerateRequest").msgclass
-    VolumeEnumerateResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeEnumerateResponse").msgclass
-    VolumeSnapshotCreateRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeSnapshotCreateRequest").msgclass
-    VolumeSnapshotCreateResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeSnapshotCreateResponse").msgclass
-    VolumeSnapshotRestoreRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeSnapshotRestoreRequest").msgclass
-    VolumeSnapshotRestoreResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeSnapshotRestoreResponse").msgclass
-    VolumeSnapshotEnumerateRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeSnapshotEnumerateRequest").msgclass
-    VolumeSnapshotEnumerateResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.VolumeSnapshotEnumerateResponse").msgclass
-    ClusterEnumerateRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.ClusterEnumerateRequest").msgclass
-    ClusterEnumerateResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.ClusterEnumerateResponse").msgclass
-    ClusterInspectRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.ClusterInspectRequest").msgclass
-    ClusterInspectResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.ClusterInspectResponse").msgclass
-    ClusterAlertEnumerateRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.ClusterAlertEnumerateRequest").msgclass
-    ClusterAlertEnumerateResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.ClusterAlertEnumerateResponse").msgclass
-    ClusterAlertClearRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.ClusterAlertClearRequest").msgclass
-    ClusterAlertClearResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.ClusterAlertClearResponse").msgclass
-    ClusterAlertEraseRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.ClusterAlertEraseRequest").msgclass
-    ClusterAlertEraseResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.ClusterAlertEraseResponse").msgclass
+    SdkCredentialCreateAzureRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkCredentialCreateAzureRequest").msgclass
+    SdkCredentialCreateAzureResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkCredentialCreateAzureResponse").msgclass
+    SdkCredentialCreateGoogleRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkCredentialCreateGoogleRequest").msgclass
+    SdkCredentialCreateGoogleResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkCredentialCreateGoogleResponse").msgclass
+    SdkCredentialCreateAWSRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkCredentialCreateAWSRequest").msgclass
+    SdkCredentialCreateAWSResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkCredentialCreateAWSResponse").msgclass
+    S3Credential = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.S3Credential").msgclass
+    AzureCredential = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.AzureCredential").msgclass
+    GoogleCredential = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.GoogleCredential").msgclass
+    SdkCredentialEnumerateAWSRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkCredentialEnumerateAWSRequest").msgclass
+    SdkCredentialEnumerateAWSResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkCredentialEnumerateAWSResponse").msgclass
+    SdkCredentialEnumerateAzureRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkCredentialEnumerateAzureRequest").msgclass
+    SdkCredentialEnumerateAzureResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkCredentialEnumerateAzureResponse").msgclass
+    SdkCredentialEnumerateGoogleRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkCredentialEnumerateGoogleRequest").msgclass
+    SdkCredentialEnumerateGoogleResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkCredentialEnumerateGoogleResponse").msgclass
+    SdkCredentialDeleteRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkCredentialDeleteRequest").msgclass
+    SdkCredentialDeleteResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkCredentialDeleteResponse").msgclass
+    SdkCredentialValidateRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkCredentialValidateRequest").msgclass
+    SdkCredentialValidateResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkCredentialValidateResponse").msgclass
+    SdkVolumeMountRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeMountRequest").msgclass
+    SdkVolumeMountResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeMountResponse").msgclass
+    SdkVolumeUnmountRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeUnmountRequest").msgclass
+    SdkVolumeUnmountResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeUnmountResponse").msgclass
+    SdkVolumeAttachRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeAttachRequest").msgclass
+    SdkVolumeAttachResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeAttachResponse").msgclass
+    SdkVolumeDetachRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeDetachRequest").msgclass
+    SdkVolumeDetachResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeDetachResponse").msgclass
+    SdkVolumeCreateRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeCreateRequest").msgclass
+    SdkVolumeCreateResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeCreateResponse").msgclass
+    SdkVolumeCreateFromVolumeIdRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeCreateFromVolumeIdRequest").msgclass
+    SdkVolumeCreateFromVolumeIdResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeCreateFromVolumeIdResponse").msgclass
+    SdkVolumeDeleteRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeDeleteRequest").msgclass
+    SdkVolumeDeleteResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeDeleteResponse").msgclass
+    SdkVolumeInspectRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeInspectRequest").msgclass
+    SdkVolumeInspectResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeInspectResponse").msgclass
+    SdkVolumeEnumerateRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeEnumerateRequest").msgclass
+    SdkVolumeEnumerateResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeEnumerateResponse").msgclass
+    SdkVolumeSnapshotCreateRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeSnapshotCreateRequest").msgclass
+    SdkVolumeSnapshotCreateResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeSnapshotCreateResponse").msgclass
+    SdkVolumeSnapshotRestoreRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeSnapshotRestoreRequest").msgclass
+    SdkVolumeSnapshotRestoreResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeSnapshotRestoreResponse").msgclass
+    SdkVolumeSnapshotEnumerateRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeSnapshotEnumerateRequest").msgclass
+    SdkVolumeSnapshotEnumerateResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkVolumeSnapshotEnumerateResponse").msgclass
+    SdkClusterEnumerateRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkClusterEnumerateRequest").msgclass
+    SdkClusterEnumerateResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkClusterEnumerateResponse").msgclass
+    SdkClusterInspectRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkClusterInspectRequest").msgclass
+    SdkClusterInspectResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkClusterInspectResponse").msgclass
+    SdkClusterAlertEnumerateRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkClusterAlertEnumerateRequest").msgclass
+    SdkClusterAlertEnumerateResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkClusterAlertEnumerateResponse").msgclass
+    SdkClusterAlertClearRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkClusterAlertClearRequest").msgclass
+    SdkClusterAlertClearResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkClusterAlertClearResponse").msgclass
+    SdkClusterAlertEraseRequest = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkClusterAlertEraseRequest").msgclass
+    SdkClusterAlertEraseResponse = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.SdkClusterAlertEraseResponse").msgclass
     Status = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.Status").enummodule
     DriverType = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.DriverType").enummodule
     FSType = Google::Protobuf::DescriptorPool.generated_pool.lookup("openstorage.api.FSType").enummodule

--- a/api/client/sdk/ruby/api_services_pb.rb
+++ b/api/client/sdk/ruby/api_services_pb.rb
@@ -16,15 +16,15 @@ module Openstorage
         self.service_name = 'openstorage.api.OpenStorageCluster'
 
         # Enumerate lists all the nodes in the cluster.
-        rpc :Enumerate, ClusterEnumerateRequest, ClusterEnumerateResponse
+        rpc :Enumerate, SdkClusterEnumerateRequest, SdkClusterEnumerateResponse
         # Inspect the node given a UUID.
-        rpc :Inspect, ClusterInspectRequest, ClusterInspectResponse
+        rpc :Inspect, SdkClusterInspectRequest, SdkClusterInspectResponse
         # Get a list of alerts from the storage cluster
-        rpc :AlertEnumerate, ClusterAlertEnumerateRequest, ClusterAlertEnumerateResponse
+        rpc :AlertEnumerate, SdkClusterAlertEnumerateRequest, SdkClusterAlertEnumerateResponse
         # Clear the alert for a given resource
-        rpc :AlertClear, ClusterAlertClearRequest, ClusterAlertClearResponse
+        rpc :AlertClear, SdkClusterAlertClearRequest, SdkClusterAlertClearResponse
         # Erases an alert for a given resource
-        rpc :AlertErase, ClusterAlertEraseRequest, ClusterAlertEraseResponse
+        rpc :AlertErase, SdkClusterAlertEraseRequest, SdkClusterAlertEraseResponse
       end
 
       Stub = Service.rpc_stub_class
@@ -39,30 +39,65 @@ module Openstorage
         self.service_name = 'openstorage.api.OpenStorageVolume'
 
         # Creates a new volume
-        rpc :Create, OpenStorageVolumeCreateRequest, OpenStorageVolumeCreateResponse
-        # CreateFromVolumeID creates a new volume cloned from an existing volume
-        rpc :CreateFromVolumeID, VolumeCreateFromVolumeIDRequest, VolumeCreateFromVolumeIDResponse
+        rpc :Create, SdkVolumeCreateRequest, SdkVolumeCreateResponse
+        # CreateFromVolumeId creates a new volume cloned from an existing volume
+        rpc :CreateFromVolumeId, SdkVolumeCreateFromVolumeIdRequest, SdkVolumeCreateFromVolumeIdResponse
         # Delete a volume
-        rpc :Delete, VolumeDeleteRequest, VolumeDeleteResponse
+        rpc :Delete, SdkVolumeDeleteRequest, SdkVolumeDeleteResponse
         # Get information on a volume
-        rpc :Inspect, VolumeInspectRequest, VolumeInspectResponse
+        rpc :Inspect, SdkVolumeInspectRequest, SdkVolumeInspectResponse
         # Get a list of volumes
-        rpc :Enumerate, VolumeEnumerateRequest, VolumeEnumerateResponse
+        rpc :Enumerate, SdkVolumeEnumerateRequest, SdkVolumeEnumerateResponse
         # Create a snapshot of a volume. This creates an immutable (read-only),
         # point-in-time snapshot of a volume.
-        rpc :SnapshotCreate, VolumeSnapshotCreateRequest, VolumeSnapshotCreateResponse
+        rpc :SnapshotCreate, SdkVolumeSnapshotCreateRequest, SdkVolumeSnapshotCreateResponse
         # Restores a volume to a specified snapshot
-        rpc :SnapshotRestore, VolumeSnapshotRestoreRequest, VolumeSnapshotRestoreResponse
+        rpc :SnapshotRestore, SdkVolumeSnapshotRestoreRequest, SdkVolumeSnapshotRestoreResponse
         # List the number of snapshots for a specific volume
-        rpc :SnapshotEnumerate, VolumeSnapshotEnumerateRequest, VolumeSnapshotEnumerateResponse
+        rpc :SnapshotEnumerate, SdkVolumeSnapshotEnumerateRequest, SdkVolumeSnapshotEnumerateResponse
         # Attach device to host                                                      
-        rpc :Attach, VolumeAttachRequest, VolumeAttachResponse
+        rpc :Attach, SdkVolumeAttachRequest, SdkVolumeAttachResponse
         # Detaches the volume from the node.
-        rpc :Detach, VolumeDetachRequest, VolumeDetachResponse
+        rpc :Detach, SdkVolumeDetachRequest, SdkVolumeDetachResponse
         # Attaches the volume to a node.
-        rpc :Mount, VolumeMountRequest, VolumeMountResponse
+        rpc :Mount, SdkVolumeMountRequest, SdkVolumeMountResponse
         # Unmount volume at specified path                                           
-        rpc :Unmount, VolumeUnmountRequest, VolumeUnmountResponse
+        rpc :Unmount, SdkVolumeUnmountRequest, SdkVolumeUnmountResponse
+      end
+
+      Stub = Service.rpc_stub_class
+    end
+    module OpenStorageCredentials
+      class Service
+
+        include GRPC::GenericService
+
+        self.marshal_class_method = :encode
+        self.unmarshal_class_method = :decode
+        self.service_name = 'openstorage.api.OpenStorageCredentials'
+
+        # Provide credentials to OpenStorage and if valid,
+        # it will return an identifier to the credentials
+        #
+        # Create credential for AWS S3 and if valid ,
+        # returns a unique identifier
+        rpc :CreateForAWS, SdkCredentialCreateAWSRequest, SdkCredentialCreateAWSResponse
+        # Create credential for Azure and if valid ,
+        # returns a unique identifier
+        rpc :CreateForAzure, SdkCredentialCreateAzureRequest, SdkCredentialCreateAzureResponse
+        # Create credential for Google and if valid ,
+        # returns a unique identifier
+        rpc :CreateForGoogle, SdkCredentialCreateGoogleRequest, SdkCredentialCreateGoogleResponse
+        # EnumerateForAWS lists the configured AWS credentials                      
+        rpc :EnumerateForAWS, SdkCredentialEnumerateAWSRequest, SdkCredentialEnumerateAWSResponse
+        # EnumerateForAzure lists the configured Azure credentials                  
+        rpc :EnumerateForAzure, SdkCredentialEnumerateAzureRequest, SdkCredentialEnumerateAzureResponse
+        # EnumerateForGoogle lists the configured Google credentials                
+        rpc :EnumerateForGoogle, SdkCredentialEnumerateGoogleRequest, SdkCredentialEnumerateGoogleResponse
+        # Delete a specified credential                                                 
+        rpc :CredentialDelete, SdkCredentialDeleteRequest, SdkCredentialDeleteResponse
+        # Validate a specified credential
+        rpc :CredentialValidate, SdkCredentialValidateRequest, SdkCredentialValidateResponse
       end
 
       Stub = Service.rpc_stub_class

--- a/api/server/sdk/api/api.swagger.json
+++ b/api/server/sdk/api/api.swagger.json
@@ -23,7 +23,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiClusterAlertClearResponse"
+              "$ref": "#/definitions/apiSdkClusterAlertClearResponse"
             }
           }
         },
@@ -33,7 +33,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiClusterAlertClearRequest"
+              "$ref": "#/definitions/apiSdkClusterAlertClearRequest"
             }
           }
         ],
@@ -50,7 +50,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiClusterAlertEnumerateResponse"
+              "$ref": "#/definitions/apiSdkClusterAlertEnumerateResponse"
             }
           }
         },
@@ -60,7 +60,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiClusterAlertEnumerateRequest"
+              "$ref": "#/definitions/apiSdkClusterAlertEnumerateRequest"
             }
           }
         ],
@@ -77,7 +77,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiClusterAlertEraseResponse"
+              "$ref": "#/definitions/apiSdkClusterAlertEraseResponse"
             }
           }
         },
@@ -87,7 +87,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiClusterAlertEraseRequest"
+              "$ref": "#/definitions/apiSdkClusterAlertEraseRequest"
             }
           }
         ],
@@ -104,7 +104,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiClusterEnumerateResponse"
+              "$ref": "#/definitions/apiSdkClusterEnumerateResponse"
             }
           }
         },
@@ -114,7 +114,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiClusterEnumerateRequest"
+              "$ref": "#/definitions/apiSdkClusterEnumerateRequest"
             }
           }
         ],
@@ -131,7 +131,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiClusterInspectResponse"
+              "$ref": "#/definitions/apiSdkClusterInspectResponse"
             }
           }
         },
@@ -141,7 +141,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiClusterInspectRequest"
+              "$ref": "#/definitions/apiSdkClusterInspectRequest"
             }
           }
         ],
@@ -158,7 +158,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiCredentialCreateAWSResponse"
+              "$ref": "#/definitions/apiSdkCredentialCreateAWSResponse"
             }
           }
         },
@@ -168,7 +168,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiCredentialCreateAWSRequest"
+              "$ref": "#/definitions/apiSdkCredentialCreateAWSRequest"
             }
           }
         ],
@@ -185,7 +185,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiCredentialCreateAzureResponse"
+              "$ref": "#/definitions/apiSdkCredentialCreateAzureResponse"
             }
           }
         },
@@ -195,7 +195,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiCredentialCreateAzureRequest"
+              "$ref": "#/definitions/apiSdkCredentialCreateAzureRequest"
             }
           }
         ],
@@ -212,7 +212,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiCredentialCreateGoogleResponse"
+              "$ref": "#/definitions/apiSdkCredentialCreateGoogleResponse"
             }
           }
         },
@@ -222,7 +222,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiCredentialCreateGoogleRequest"
+              "$ref": "#/definitions/apiSdkCredentialCreateGoogleRequest"
             }
           }
         ],
@@ -239,7 +239,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiCredentialDeleteResponse"
+              "$ref": "#/definitions/apiSdkCredentialDeleteResponse"
             }
           }
         },
@@ -249,7 +249,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiCredentialDeleteRequest"
+              "$ref": "#/definitions/apiSdkCredentialDeleteRequest"
             }
           }
         ],
@@ -266,7 +266,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiCredentialEnumerateAWSResponse"
+              "$ref": "#/definitions/apiSdkCredentialEnumerateAWSResponse"
             }
           }
         },
@@ -276,7 +276,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiCredentialEnumerateAWSRequest"
+              "$ref": "#/definitions/apiSdkCredentialEnumerateAWSRequest"
             }
           }
         ],
@@ -293,7 +293,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiCredentialEnumerateAzureResponse"
+              "$ref": "#/definitions/apiSdkCredentialEnumerateAzureResponse"
             }
           }
         },
@@ -303,7 +303,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiCredentialEnumerateAzureRequest"
+              "$ref": "#/definitions/apiSdkCredentialEnumerateAzureRequest"
             }
           }
         ],
@@ -320,7 +320,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiCredentialEnumerateGoogleResponse"
+              "$ref": "#/definitions/apiSdkCredentialEnumerateGoogleResponse"
             }
           }
         },
@@ -330,7 +330,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiCredentialEnumerateGoogleRequest"
+              "$ref": "#/definitions/apiSdkCredentialEnumerateGoogleRequest"
             }
           }
         ],
@@ -347,7 +347,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiCredentialValidateResponse"
+              "$ref": "#/definitions/apiSdkCredentialValidateResponse"
             }
           }
         },
@@ -357,7 +357,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiCredentialValidateRequest"
+              "$ref": "#/definitions/apiSdkCredentialValidateRequest"
             }
           }
         ],
@@ -374,7 +374,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiVolumeAttachResponse"
+              "$ref": "#/definitions/apiSdkVolumeAttachResponse"
             }
           }
         },
@@ -384,7 +384,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiVolumeAttachRequest"
+              "$ref": "#/definitions/apiSdkVolumeAttachRequest"
             }
           }
         ],
@@ -401,7 +401,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiOpenStorageVolumeCreateResponse"
+              "$ref": "#/definitions/apiSdkVolumeCreateResponse"
             }
           }
         },
@@ -411,7 +411,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiOpenStorageVolumeCreateRequest"
+              "$ref": "#/definitions/apiSdkVolumeCreateRequest"
             }
           }
         ],
@@ -422,13 +422,13 @@
     },
     "/v1/volume/createfromid": {
       "post": {
-        "summary": "CreateFromVolumeID creates a new volume cloned from an existing volume",
-        "operationId": "CreateFromVolumeID",
+        "summary": "CreateFromVolumeId creates a new volume cloned from an existing volume",
+        "operationId": "CreateFromVolumeId",
         "responses": {
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiVolumeCreateFromVolumeIDResponse"
+              "$ref": "#/definitions/apiSdkVolumeCreateFromVolumeIdResponse"
             }
           }
         },
@@ -438,7 +438,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiVolumeCreateFromVolumeIDRequest"
+              "$ref": "#/definitions/apiSdkVolumeCreateFromVolumeIdRequest"
             }
           }
         ],
@@ -455,7 +455,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiVolumeDeleteResponse"
+              "$ref": "#/definitions/apiSdkVolumeDeleteResponse"
             }
           }
         },
@@ -465,7 +465,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiVolumeDeleteRequest"
+              "$ref": "#/definitions/apiSdkVolumeDeleteRequest"
             }
           }
         ],
@@ -482,7 +482,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiVolumeDetachResponse"
+              "$ref": "#/definitions/apiSdkVolumeDetachResponse"
             }
           }
         },
@@ -492,7 +492,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiVolumeDetachRequest"
+              "$ref": "#/definitions/apiSdkVolumeDetachRequest"
             }
           }
         ],
@@ -509,7 +509,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiVolumeEnumerateResponse"
+              "$ref": "#/definitions/apiSdkVolumeEnumerateResponse"
             }
           }
         },
@@ -519,7 +519,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiVolumeEnumerateRequest"
+              "$ref": "#/definitions/apiSdkVolumeEnumerateRequest"
             }
           }
         ],
@@ -536,7 +536,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiVolumeInspectResponse"
+              "$ref": "#/definitions/apiSdkVolumeInspectResponse"
             }
           }
         },
@@ -546,7 +546,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiVolumeInspectRequest"
+              "$ref": "#/definitions/apiSdkVolumeInspectRequest"
             }
           }
         ],
@@ -563,7 +563,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiVolumeMountResponse"
+              "$ref": "#/definitions/apiSdkVolumeMountResponse"
             }
           }
         },
@@ -573,7 +573,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiVolumeMountRequest"
+              "$ref": "#/definitions/apiSdkVolumeMountRequest"
             }
           }
         ],
@@ -590,7 +590,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiVolumeSnapshotCreateResponse"
+              "$ref": "#/definitions/apiSdkVolumeSnapshotCreateResponse"
             }
           }
         },
@@ -600,7 +600,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiVolumeSnapshotCreateRequest"
+              "$ref": "#/definitions/apiSdkVolumeSnapshotCreateRequest"
             }
           }
         ],
@@ -617,7 +617,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiVolumeSnapshotEnumerateResponse"
+              "$ref": "#/definitions/apiSdkVolumeSnapshotEnumerateResponse"
             }
           }
         },
@@ -627,7 +627,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiVolumeSnapshotEnumerateRequest"
+              "$ref": "#/definitions/apiSdkVolumeSnapshotEnumerateRequest"
             }
           }
         ],
@@ -644,7 +644,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiVolumeSnapshotRestoreResponse"
+              "$ref": "#/definitions/apiSdkVolumeSnapshotRestoreResponse"
             }
           }
         },
@@ -654,7 +654,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiVolumeSnapshotRestoreRequest"
+              "$ref": "#/definitions/apiSdkVolumeSnapshotRestoreRequest"
             }
           }
         ],
@@ -671,7 +671,7 @@
           "200": {
             "description": "",
             "schema": {
-              "$ref": "#/definitions/apiVolumeUnmountResponse"
+              "$ref": "#/definitions/apiSdkVolumeUnmountResponse"
             }
           }
         },
@@ -681,7 +681,7 @@
             "in": "body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/apiVolumeUnmountRequest"
+              "$ref": "#/definitions/apiSdkVolumeUnmountRequest"
             }
           }
         ],
@@ -782,98 +782,6 @@
         }
       }
     },
-    "apiClusterAlertClearRequest": {
-      "type": "object",
-      "properties": {
-        "resource": {
-          "$ref": "#/definitions/apiResourceType",
-          "title": "Type of resource (required)"
-        },
-        "alert_id": {
-          "type": "string",
-          "format": "int64",
-          "title": "Id of alert as returned by ClusterEnumerateAlertResponse (required)"
-        }
-      }
-    },
-    "apiClusterAlertClearResponse": {
-      "type": "object"
-    },
-    "apiClusterAlertEnumerateRequest": {
-      "type": "object",
-      "properties": {
-        "time_start": {
-          "type": "string",
-          "format": "date-time",
-          "title": "Start time of alerts (required)"
-        },
-        "time_end": {
-          "type": "string",
-          "format": "date-time",
-          "title": "End time of alerts (required)"
-        },
-        "resource": {
-          "$ref": "#/definitions/apiResourceType",
-          "title": "Type of resource (required)"
-        }
-      }
-    },
-    "apiClusterAlertEnumerateResponse": {
-      "type": "object",
-      "properties": {
-        "alerts": {
-          "$ref": "#/definitions/apiAlerts",
-          "title": "Information on the alerts requested"
-        }
-      }
-    },
-    "apiClusterAlertEraseRequest": {
-      "type": "object",
-      "properties": {
-        "resource": {
-          "$ref": "#/definitions/apiResourceType",
-          "title": "Type of resource (required)"
-        },
-        "alert_id": {
-          "type": "string",
-          "format": "int64",
-          "title": "Id of alert as returned by ClusterEnumerateAlertResponse (required)"
-        }
-      }
-    },
-    "apiClusterAlertEraseResponse": {
-      "type": "object"
-    },
-    "apiClusterEnumerateRequest": {
-      "type": "object"
-    },
-    "apiClusterEnumerateResponse": {
-      "type": "object",
-      "properties": {
-        "cluster": {
-          "$ref": "#/definitions/apiStorageCluster",
-          "title": "Cluster information"
-        }
-      }
-    },
-    "apiClusterInspectRequest": {
-      "type": "object",
-      "properties": {
-        "node_id": {
-          "type": "string",
-          "title": "Id of node to inspect (required)"
-        }
-      }
-    },
-    "apiClusterInspectResponse": {
-      "type": "object",
-      "properties": {
-        "node": {
-          "$ref": "#/definitions/apiStorageNode",
-          "title": "Node information"
-        }
-      }
-    },
     "apiCosType": {
       "type": "string",
       "enum": [
@@ -883,146 +791,6 @@
         "HIGH"
       ],
       "default": "NONE"
-    },
-    "apiCredentialCreateAWSRequest": {
-      "type": "object",
-      "properties": {
-        "credential": {
-          "$ref": "#/definitions/apiS3Credential",
-          "title": "AWS S3 Credential"
-        }
-      }
-    },
-    "apiCredentialCreateAWSResponse": {
-      "type": "object",
-      "properties": {
-        "credential_id": {
-          "type": "string",
-          "title": "Id of the credentials"
-        }
-      }
-    },
-    "apiCredentialCreateAzureRequest": {
-      "type": "object",
-      "properties": {
-        "credential": {
-          "$ref": "#/definitions/apiAzureCredential",
-          "title": "Azure Credential"
-        }
-      }
-    },
-    "apiCredentialCreateAzureResponse": {
-      "type": "object",
-      "properties": {
-        "credential_id": {
-          "type": "string",
-          "title": "Id of the credentials"
-        }
-      }
-    },
-    "apiCredentialCreateGoogleRequest": {
-      "type": "object",
-      "properties": {
-        "credential": {
-          "$ref": "#/definitions/apiGoogleCredential",
-          "title": "Google Credential"
-        }
-      }
-    },
-    "apiCredentialCreateGoogleResponse": {
-      "type": "object",
-      "properties": {
-        "credential_id": {
-          "type": "string",
-          "title": "Id of the credentials"
-        }
-      }
-    },
-    "apiCredentialDeleteRequest": {
-      "type": "object",
-      "properties": {
-        "credential_id": {
-          "type": "string",
-          "title": "ID for credentials"
-        }
-      }
-    },
-    "apiCredentialDeleteResponse": {
-      "type": "object"
-    },
-    "apiCredentialEnumerateAWSRequest": {
-      "type": "object",
-      "properties": {
-        "credential_id": {
-          "type": "string",
-          "title": "Id of the credentials"
-        }
-      },
-      "title": "should enumerate accept anything?"
-    },
-    "apiCredentialEnumerateAWSResponse": {
-      "type": "object",
-      "properties": {
-        "credential": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/apiS3Credential"
-          },
-          "title": "Array of Credentials for AWS"
-        }
-      }
-    },
-    "apiCredentialEnumerateAzureRequest": {
-      "type": "object",
-      "properties": {
-        "credential_id": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCredentialEnumerateAzureResponse": {
-      "type": "object",
-      "properties": {
-        "credential": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/apiAzureCredential"
-          },
-          "title": "List of Credentials for Azure"
-        }
-      }
-    },
-    "apiCredentialEnumerateGoogleRequest": {
-      "type": "object",
-      "properties": {
-        "credential_id": {
-          "type": "string"
-        }
-      }
-    },
-    "apiCredentialEnumerateGoogleResponse": {
-      "type": "object",
-      "properties": {
-        "credential": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/apiGoogleCredential"
-          },
-          "title": "List of Credentials for Google"
-        }
-      }
-    },
-    "apiCredentialValidateRequest": {
-      "type": "object",
-      "properties": {
-        "credential_id": {
-          "type": "string",
-          "title": "Id of the credentials"
-        }
-      }
-    },
-    "apiCredentialValidateResponse": {
-      "type": "object"
     },
     "apiFSType": {
       "type": "string",
@@ -1074,28 +842,6 @@
         "IO_PROFILE_CMS"
       ],
       "default": "IO_PROFILE_SEQUENTIAL"
-    },
-    "apiOpenStorageVolumeCreateRequest": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Unique name of the volume. This will be used for idempotency."
-        },
-        "spec": {
-          "$ref": "#/definitions/apiVolumeSpec",
-          "title": "Volume specification"
-        }
-      }
-    },
-    "apiOpenStorageVolumeCreateResponse": {
-      "type": "object",
-      "properties": {
-        "volume_id": {
-          "type": "string",
-          "title": "Id of new volume"
-        }
-      }
     },
     "apiReplicaSet": {
       "type": "object",
@@ -1156,6 +902,489 @@
           "title": "Region"
         }
       }
+    },
+    "apiSdkClusterAlertClearRequest": {
+      "type": "object",
+      "properties": {
+        "resource": {
+          "$ref": "#/definitions/apiResourceType",
+          "title": "Type of resource (required)"
+        },
+        "alert_id": {
+          "type": "string",
+          "format": "int64",
+          "title": "Id of alert as returned by ClusterEnumerateAlertResponse (required)"
+        }
+      }
+    },
+    "apiSdkClusterAlertClearResponse": {
+      "type": "object"
+    },
+    "apiSdkClusterAlertEnumerateRequest": {
+      "type": "object",
+      "properties": {
+        "time_start": {
+          "type": "string",
+          "format": "date-time",
+          "title": "Start time of alerts (required)"
+        },
+        "time_end": {
+          "type": "string",
+          "format": "date-time",
+          "title": "End time of alerts (required)"
+        },
+        "resource": {
+          "$ref": "#/definitions/apiResourceType",
+          "title": "Type of resource (required)"
+        }
+      }
+    },
+    "apiSdkClusterAlertEnumerateResponse": {
+      "type": "object",
+      "properties": {
+        "alerts": {
+          "$ref": "#/definitions/apiAlerts",
+          "title": "Information on the alerts requested"
+        }
+      }
+    },
+    "apiSdkClusterAlertEraseRequest": {
+      "type": "object",
+      "properties": {
+        "resource": {
+          "$ref": "#/definitions/apiResourceType",
+          "title": "Type of resource (required)"
+        },
+        "alert_id": {
+          "type": "string",
+          "format": "int64",
+          "title": "Id of alert as returned by ClusterEnumerateAlertResponse (required)"
+        }
+      }
+    },
+    "apiSdkClusterAlertEraseResponse": {
+      "type": "object"
+    },
+    "apiSdkClusterEnumerateRequest": {
+      "type": "object"
+    },
+    "apiSdkClusterEnumerateResponse": {
+      "type": "object",
+      "properties": {
+        "cluster": {
+          "$ref": "#/definitions/apiStorageCluster",
+          "title": "Cluster information"
+        }
+      }
+    },
+    "apiSdkClusterInspectRequest": {
+      "type": "object",
+      "properties": {
+        "node_id": {
+          "type": "string",
+          "title": "Id of node to inspect (required)"
+        }
+      }
+    },
+    "apiSdkClusterInspectResponse": {
+      "type": "object",
+      "properties": {
+        "node": {
+          "$ref": "#/definitions/apiStorageNode",
+          "title": "Node information"
+        }
+      }
+    },
+    "apiSdkCredentialCreateAWSRequest": {
+      "type": "object",
+      "properties": {
+        "credential": {
+          "$ref": "#/definitions/apiS3Credential",
+          "title": "AWS S3 Credential"
+        }
+      }
+    },
+    "apiSdkCredentialCreateAWSResponse": {
+      "type": "object",
+      "properties": {
+        "credential_id": {
+          "type": "string",
+          "title": "Id of the credentials"
+        }
+      }
+    },
+    "apiSdkCredentialCreateAzureRequest": {
+      "type": "object",
+      "properties": {
+        "credential": {
+          "$ref": "#/definitions/apiAzureCredential",
+          "title": "Azure Credential"
+        }
+      }
+    },
+    "apiSdkCredentialCreateAzureResponse": {
+      "type": "object",
+      "properties": {
+        "credential_id": {
+          "type": "string",
+          "title": "Id of the credentials"
+        }
+      }
+    },
+    "apiSdkCredentialCreateGoogleRequest": {
+      "type": "object",
+      "properties": {
+        "credential": {
+          "$ref": "#/definitions/apiGoogleCredential",
+          "title": "Google Credential"
+        }
+      }
+    },
+    "apiSdkCredentialCreateGoogleResponse": {
+      "type": "object",
+      "properties": {
+        "credential_id": {
+          "type": "string",
+          "title": "Id of the credentials"
+        }
+      }
+    },
+    "apiSdkCredentialDeleteRequest": {
+      "type": "object",
+      "properties": {
+        "credential_id": {
+          "type": "string",
+          "title": "ID for credentials"
+        }
+      }
+    },
+    "apiSdkCredentialDeleteResponse": {
+      "type": "object"
+    },
+    "apiSdkCredentialEnumerateAWSRequest": {
+      "type": "object",
+      "properties": {
+        "credential_id": {
+          "type": "string",
+          "title": "Id of the credentials"
+        }
+      },
+      "title": "should enumerate accept anything?"
+    },
+    "apiSdkCredentialEnumerateAWSResponse": {
+      "type": "object",
+      "properties": {
+        "credential": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/apiS3Credential"
+          },
+          "title": "Array of Credentials for AWS"
+        }
+      }
+    },
+    "apiSdkCredentialEnumerateAzureRequest": {
+      "type": "object",
+      "properties": {
+        "credential_id": {
+          "type": "string"
+        }
+      }
+    },
+    "apiSdkCredentialEnumerateAzureResponse": {
+      "type": "object",
+      "properties": {
+        "credential": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/apiAzureCredential"
+          },
+          "title": "List of Credentials for Azure"
+        }
+      }
+    },
+    "apiSdkCredentialEnumerateGoogleRequest": {
+      "type": "object",
+      "properties": {
+        "credential_id": {
+          "type": "string"
+        }
+      }
+    },
+    "apiSdkCredentialEnumerateGoogleResponse": {
+      "type": "object",
+      "properties": {
+        "credential": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/apiGoogleCredential"
+          },
+          "title": "List of Credentials for Google"
+        }
+      }
+    },
+    "apiSdkCredentialValidateRequest": {
+      "type": "object",
+      "properties": {
+        "credential_id": {
+          "type": "string",
+          "title": "Id of the credentials"
+        }
+      }
+    },
+    "apiSdkCredentialValidateResponse": {
+      "type": "object"
+    },
+    "apiSdkVolumeAttachRequest": {
+      "type": "object",
+      "properties": {
+        "volume_id": {
+          "type": "string",
+          "title": "Id of volume"
+        },
+        "options": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Options for attaching volume, right now only passphrase options is supported"
+        }
+      }
+    },
+    "apiSdkVolumeAttachResponse": {
+      "type": "object",
+      "properties": {
+        "device_path": {
+          "type": "string",
+          "title": "Device path where device is exported"
+        }
+      }
+    },
+    "apiSdkVolumeCreateFromVolumeIdRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique name of the volume. This will be used for idempotency."
+        },
+        "parent_id": {
+          "type": "string",
+          "description": "Parent volume id, if specified will create a new volume as a clone of the parent."
+        },
+        "spec": {
+          "$ref": "#/definitions/apiVolumeSpec",
+          "title": "Volume specification"
+        }
+      }
+    },
+    "apiSdkVolumeCreateFromVolumeIdResponse": {
+      "type": "object",
+      "properties": {
+        "volume_id": {
+          "type": "string",
+          "title": "Id of new volume"
+        }
+      }
+    },
+    "apiSdkVolumeCreateRequest": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Unique name of the volume. This will be used for idempotency."
+        },
+        "spec": {
+          "$ref": "#/definitions/apiVolumeSpec",
+          "title": "Volume specification"
+        }
+      }
+    },
+    "apiSdkVolumeCreateResponse": {
+      "type": "object",
+      "properties": {
+        "volume_id": {
+          "type": "string",
+          "title": "Id of new volume"
+        }
+      }
+    },
+    "apiSdkVolumeDeleteRequest": {
+      "type": "object",
+      "properties": {
+        "volume_id": {
+          "type": "string",
+          "title": "Id of volume to delete"
+        }
+      }
+    },
+    "apiSdkVolumeDeleteResponse": {
+      "type": "object"
+    },
+    "apiSdkVolumeDetachRequest": {
+      "type": "object",
+      "properties": {
+        "volume_id": {
+          "type": "string",
+          "title": "Id of the volume"
+        }
+      }
+    },
+    "apiSdkVolumeDetachResponse": {
+      "type": "object"
+    },
+    "apiSdkVolumeEnumerateRequest": {
+      "type": "object",
+      "properties": {
+        "locator": {
+          "$ref": "#/definitions/apiVolumeLocator",
+          "description": "Volumes to match to this locator.\nIf not provided, all volumes will be returned."
+        }
+      }
+    },
+    "apiSdkVolumeEnumerateResponse": {
+      "type": "object",
+      "properties": {
+        "volumes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/apiVolume"
+          },
+          "title": "List of volumes matching label"
+        }
+      }
+    },
+    "apiSdkVolumeInspectRequest": {
+      "type": "object",
+      "properties": {
+        "volume_id": {
+          "type": "string",
+          "title": "Id of volume to inspect"
+        }
+      }
+    },
+    "apiSdkVolumeInspectResponse": {
+      "type": "object",
+      "properties": {
+        "volume": {
+          "$ref": "#/definitions/apiVolume",
+          "title": "Information about the volume"
+        }
+      }
+    },
+    "apiSdkVolumeMountRequest": {
+      "type": "object",
+      "properties": {
+        "volume_id": {
+          "type": "string",
+          "title": "Id of the volume"
+        },
+        "mount_path": {
+          "type": "string",
+          "description": "Mount path for mounting the volume."
+        },
+        "options": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Additional options"
+        }
+      }
+    },
+    "apiSdkVolumeMountResponse": {
+      "type": "object"
+    },
+    "apiSdkVolumeSnapshotCreateRequest": {
+      "type": "object",
+      "properties": {
+        "volume_id": {
+          "type": "string",
+          "title": "Id of volume to take the snapshot from"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Labels to apply to snapshot"
+        }
+      }
+    },
+    "apiSdkVolumeSnapshotCreateResponse": {
+      "type": "object",
+      "properties": {
+        "snapshot_id": {
+          "type": "string",
+          "title": "Id of immutable snapshot"
+        }
+      }
+    },
+    "apiSdkVolumeSnapshotEnumerateRequest": {
+      "type": "object",
+      "properties": {
+        "volume_id": {
+          "type": "string",
+          "title": "Id of volume"
+        },
+        "labels": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Labels from snapshot"
+        }
+      }
+    },
+    "apiSdkVolumeSnapshotEnumerateResponse": {
+      "type": "object",
+      "properties": {
+        "snapshots": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/apiVolume"
+          },
+          "title": "List of immutable snapshots"
+        }
+      }
+    },
+    "apiSdkVolumeSnapshotRestoreRequest": {
+      "type": "object",
+      "properties": {
+        "volume_id": {
+          "type": "string",
+          "title": "Id of volume"
+        },
+        "snapshot_id": {
+          "type": "string",
+          "title": "Snapshot id to apply to `volume_id`"
+        }
+      }
+    },
+    "apiSdkVolumeSnapshotRestoreResponse": {
+      "type": "object"
+    },
+    "apiSdkVolumeUnmountRequest": {
+      "type": "object",
+      "properties": {
+        "volume_id": {
+          "type": "string",
+          "title": "Id of volume"
+        },
+        "mount_path": {
+          "type": "string",
+          "title": "MountPath for device"
+        },
+        "options": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "title": "Options to unmount device"
+        }
+      }
+    },
+    "apiSdkVolumeUnmountResponse": {
+      "type": "object"
     },
     "apiSeverityType": {
       "type": "string",
@@ -1530,31 +1759,6 @@
       },
       "title": "Volume represents an abstract storage volume.\nVolume represents an abstract storage volume.\nswagger:model"
     },
-    "apiVolumeAttachRequest": {
-      "type": "object",
-      "properties": {
-        "volume_id": {
-          "type": "string",
-          "title": "Id of volume"
-        },
-        "options": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "title": "Options for attaching volume, right now only passphrase options is supported"
-        }
-      }
-    },
-    "apiVolumeAttachResponse": {
-      "type": "object",
-      "properties": {
-        "device_path": {
-          "type": "string",
-          "title": "Device path where device is exported"
-        }
-      }
-    },
     "apiVolumeConsumer": {
       "type": "object",
       "properties": {
@@ -1585,95 +1789,6 @@
       },
       "title": "VolumeConsumer identifies a consumer for a Volume. An example of a VolumeConsumer\nwould be a Pod in Kubernetes who has mounted the PersistentVolumeClaim for the\nVolume\nswagger: model"
     },
-    "apiVolumeCreateFromVolumeIDRequest": {
-      "type": "object",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Unique name of the volume. This will be used for idempotency."
-        },
-        "parent_id": {
-          "type": "string",
-          "description": "Parent volume id, if specified will create a new volume as a clone of the parent."
-        },
-        "spec": {
-          "$ref": "#/definitions/apiVolumeSpec",
-          "title": "Volume specification"
-        }
-      }
-    },
-    "apiVolumeCreateFromVolumeIDResponse": {
-      "type": "object",
-      "properties": {
-        "volume_id": {
-          "type": "string",
-          "title": "Id of new volume"
-        }
-      }
-    },
-    "apiVolumeDeleteRequest": {
-      "type": "object",
-      "properties": {
-        "volume_id": {
-          "type": "string",
-          "title": "Id of volume to delete"
-        }
-      }
-    },
-    "apiVolumeDeleteResponse": {
-      "type": "object"
-    },
-    "apiVolumeDetachRequest": {
-      "type": "object",
-      "properties": {
-        "volume_id": {
-          "type": "string",
-          "title": "Id of the volume"
-        }
-      }
-    },
-    "apiVolumeDetachResponse": {
-      "type": "object"
-    },
-    "apiVolumeEnumerateRequest": {
-      "type": "object",
-      "properties": {
-        "locator": {
-          "$ref": "#/definitions/apiVolumeLocator",
-          "description": "Volumes to match to this locator.\nIf not provided, all volumes will be returned."
-        }
-      }
-    },
-    "apiVolumeEnumerateResponse": {
-      "type": "object",
-      "properties": {
-        "volumes": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/apiVolume"
-          },
-          "title": "List of volumes matching label"
-        }
-      }
-    },
-    "apiVolumeInspectRequest": {
-      "type": "object",
-      "properties": {
-        "volume_id": {
-          "type": "string",
-          "title": "Id of volume to inspect"
-        }
-      }
-    },
-    "apiVolumeInspectResponse": {
-      "type": "object",
-      "properties": {
-        "volume": {
-          "$ref": "#/definitions/apiVolume",
-          "title": "Information about the volume"
-        }
-      }
-    },
     "apiVolumeLocator": {
       "type": "object",
       "properties": {
@@ -1690,98 +1805,6 @@
         }
       },
       "title": "VolumeLocator is a structure that is attached to a volume\nand is used to carry opaque metadata.\nswagger:model"
-    },
-    "apiVolumeMountRequest": {
-      "type": "object",
-      "properties": {
-        "volume_id": {
-          "type": "string",
-          "title": "Id of the volume"
-        },
-        "mount_path": {
-          "type": "string",
-          "description": "Mount path for mounting the volume."
-        },
-        "options": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "title": "Additional options"
-        }
-      }
-    },
-    "apiVolumeMountResponse": {
-      "type": "object"
-    },
-    "apiVolumeSnapshotCreateRequest": {
-      "type": "object",
-      "properties": {
-        "volume_id": {
-          "type": "string",
-          "title": "Id of volume to take the snapshot from"
-        },
-        "labels": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "title": "Labels to apply to snapshot"
-        }
-      }
-    },
-    "apiVolumeSnapshotCreateResponse": {
-      "type": "object",
-      "properties": {
-        "snapshot_id": {
-          "type": "string",
-          "title": "Id of immutable snapshot"
-        }
-      }
-    },
-    "apiVolumeSnapshotEnumerateRequest": {
-      "type": "object",
-      "properties": {
-        "volume_id": {
-          "type": "string",
-          "title": "Id of volume"
-        },
-        "labels": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "title": "Labels from snapshot"
-        }
-      }
-    },
-    "apiVolumeSnapshotEnumerateResponse": {
-      "type": "object",
-      "properties": {
-        "snapshots": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/apiVolume"
-          },
-          "title": "List of immutable snapshots"
-        }
-      }
-    },
-    "apiVolumeSnapshotRestoreRequest": {
-      "type": "object",
-      "properties": {
-        "volume_id": {
-          "type": "string",
-          "title": "Id of volume"
-        },
-        "snapshot_id": {
-          "type": "string",
-          "title": "Snapshot id to apply to `volume_id`"
-        }
-      }
-    },
-    "apiVolumeSnapshotRestoreResponse": {
-      "type": "object"
     },
     "apiVolumeSpec": {
       "type": "object",
@@ -1932,29 +1955,6 @@
       ],
       "default": "VOLUME_STATUS_NONE",
       "description": "VolumeStatus represents a health status for a volume.\n\n - VOLUME_STATUS_NOT_PRESENT: Volume is not present\n - VOLUME_STATUS_UP: Volume is healthy\n - VOLUME_STATUS_DOWN: Volume is in fail mode\n - VOLUME_STATUS_DEGRADED: Volume is up but with degraded performance\nIn a RAID group, this may indicate a problem with one or more drives"
-    },
-    "apiVolumeUnmountRequest": {
-      "type": "object",
-      "properties": {
-        "volume_id": {
-          "type": "string",
-          "title": "Id of volume"
-        },
-        "mount_path": {
-          "type": "string",
-          "title": "MountPath for device"
-        },
-        "options": {
-          "type": "object",
-          "additionalProperties": {
-            "type": "string"
-          },
-          "title": "Options to unmount device"
-        }
-      }
-    },
-    "apiVolumeUnmountResponse": {
-      "type": "object"
     }
   }
 }

--- a/api/server/sdk/cluster.go
+++ b/api/server/sdk/cluster.go
@@ -34,19 +34,19 @@ type ClusterServer struct {
 }
 
 // Enumerate returns information about the cluster
-func (s *ClusterServer) Enumerate(ctx context.Context, req *api.ClusterEnumerateRequest) (*api.ClusterEnumerateResponse, error) {
+func (s *ClusterServer) Enumerate(ctx context.Context, req *api.SdkClusterEnumerateRequest) (*api.SdkClusterEnumerateResponse, error) {
 	c, err := s.cluster.Enumerate()
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	return &api.ClusterEnumerateResponse{
+	return &api.SdkClusterEnumerateResponse{
 		Cluster: c.ToStorageCluster(),
 	}, nil
 }
 
 // Inspect returns information about a specific node
-func (s *ClusterServer) Inspect(ctx context.Context, req *api.ClusterInspectRequest) (*api.ClusterInspectResponse, error) {
+func (s *ClusterServer) Inspect(ctx context.Context, req *api.SdkClusterInspectRequest) (*api.SdkClusterInspectResponse, error) {
 	if len(req.GetNodeId()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Node id must be provided")
 	}
@@ -56,7 +56,7 @@ func (s *ClusterServer) Inspect(ctx context.Context, req *api.ClusterInspectRequ
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	return &api.ClusterInspectResponse{
+	return &api.SdkClusterInspectResponse{
 		Node: node.ToStorageNode(),
 	}, nil
 }
@@ -64,8 +64,8 @@ func (s *ClusterServer) Inspect(ctx context.Context, req *api.ClusterInspectRequ
 // AlertEnumerate returns a list of alerts from the storage cluster
 func (s *ClusterServer) AlertEnumerate(
 	ctx context.Context,
-	req *api.ClusterAlertEnumerateRequest,
-) (*api.ClusterAlertEnumerateResponse, error) {
+	req *api.SdkClusterAlertEnumerateRequest,
+) (*api.SdkClusterAlertEnumerateResponse, error) {
 
 	ts, err := ptypes.Timestamp(req.GetTimeStart())
 	if err != nil {
@@ -92,7 +92,7 @@ func (s *ClusterServer) AlertEnumerate(
 			err.Error())
 	}
 
-	return &api.ClusterAlertEnumerateResponse{
+	return &api.SdkClusterAlertEnumerateResponse{
 		Alerts: alerts,
 	}, nil
 }
@@ -100,8 +100,8 @@ func (s *ClusterServer) AlertEnumerate(
 // AlertClear clears the alert for a given resource
 func (s *ClusterServer) AlertClear(
 	ctx context.Context,
-	req *api.ClusterAlertClearRequest,
-) (*api.ClusterAlertClearResponse, error) {
+	req *api.SdkClusterAlertClearRequest,
+) (*api.SdkClusterAlertClearResponse, error) {
 
 	err := s.cluster.ClearAlert(req.GetResource(), req.GetAlertId())
 	if err != nil {
@@ -113,14 +113,14 @@ func (s *ClusterServer) AlertClear(
 			err.Error())
 	}
 
-	return &api.ClusterAlertClearResponse{}, nil
+	return &api.SdkClusterAlertClearResponse{}, nil
 }
 
 // AlertErase erases an alert for a given resource
 func (s *ClusterServer) AlertErase(
 	ctx context.Context,
-	req *api.ClusterAlertEraseRequest,
-) (*api.ClusterAlertEraseResponse, error) {
+	req *api.SdkClusterAlertEraseRequest,
+) (*api.SdkClusterAlertEraseResponse, error) {
 
 	err := s.cluster.EraseAlert(req.GetResource(), req.GetAlertId())
 	if err != nil {
@@ -132,5 +132,5 @@ func (s *ClusterServer) AlertErase(
 			err.Error())
 	}
 
-	return &api.ClusterAlertEraseResponse{}, nil
+	return &api.SdkClusterAlertEraseResponse{}, nil
 }

--- a/api/server/sdk/cluster_test.go
+++ b/api/server/sdk/cluster_test.go
@@ -107,7 +107,7 @@ func TestSdkEnumerateNoNodes(t *testing.T) {
 	c := api.NewOpenStorageClusterClient(s.Conn())
 
 	// Get info
-	r, err := c.Enumerate(context.Background(), &api.ClusterEnumerateRequest{})
+	r, err := c.Enumerate(context.Background(), &api.SdkClusterEnumerateRequest{})
 	assert.NoError(t, err)
 	assert.NotNil(t, r.GetCluster())
 
@@ -145,7 +145,7 @@ func TestSdkEnumerate(t *testing.T) {
 	c := api.NewOpenStorageClusterClient(s.Conn())
 
 	// Get info
-	r, err := c.Enumerate(context.Background(), &api.ClusterEnumerateRequest{})
+	r, err := c.Enumerate(context.Background(), &api.SdkClusterEnumerateRequest{})
 	assert.NoError(t, err)
 	assert.NotNil(t, r.GetCluster())
 
@@ -178,7 +178,7 @@ func TestSdkEnumerateFail(t *testing.T) {
 	c := api.NewOpenStorageClusterClient(s.Conn())
 
 	// Get info
-	r, err := c.Enumerate(context.Background(), &api.ClusterEnumerateRequest{})
+	r, err := c.Enumerate(context.Background(), &api.SdkClusterEnumerateRequest{})
 	assert.Error(t, err)
 	assert.Nil(t, r.GetCluster())
 
@@ -224,7 +224,7 @@ func TestSdkInspect(t *testing.T) {
 	c := api.NewOpenStorageClusterClient(s.Conn())
 
 	// Get info
-	r, err := c.Inspect(context.Background(), &api.ClusterInspectRequest{
+	r, err := c.Inspect(context.Background(), &api.SdkClusterInspectRequest{
 		NodeId: nodeid,
 	})
 	assert.NoError(t, err)
@@ -262,7 +262,7 @@ func TestSdkInspectFail(t *testing.T) {
 	c := api.NewOpenStorageClusterClient(s.Conn())
 
 	// Get info
-	r, err := c.Inspect(context.Background(), &api.ClusterInspectRequest{
+	r, err := c.Inspect(context.Background(), &api.SdkClusterInspectRequest{
 		NodeId: "mynode",
 	})
 	assert.Error(t, err)
@@ -284,7 +284,7 @@ func TestSdkInspectIdNotPassed(t *testing.T) {
 	c := api.NewOpenStorageClusterClient(s.Conn())
 
 	// Get info
-	r, err := c.Inspect(context.Background(), &api.ClusterInspectRequest{})
+	r, err := c.Inspect(context.Background(), &api.SdkClusterInspectRequest{})
 	assert.Error(t, err)
 	assert.Nil(t, r.GetNode())
 
@@ -304,7 +304,7 @@ func TestSdkAlertEnumerate(t *testing.T) {
 	c := api.NewOpenStorageClusterClient(s.Conn())
 
 	// Create request
-	req := &api.ClusterAlertEnumerateRequest{
+	req := &api.SdkClusterAlertEnumerateRequest{
 		TimeStart: ptypes.TimestampNow(),
 		TimeEnd:   ptypes.TimestampNow(),
 		Resource:  api.ResourceType_RESOURCE_TYPE_DRIVE,
@@ -352,7 +352,7 @@ func TestSdkAlertClear(t *testing.T) {
 	c := api.NewOpenStorageClusterClient(s.Conn())
 
 	// Create request
-	req := &api.ClusterAlertClearRequest{
+	req := &api.SdkClusterAlertClearRequest{
 		AlertId:  1234,
 		Resource: api.ResourceType_RESOURCE_TYPE_DRIVE,
 	}
@@ -379,7 +379,7 @@ func TestSdkAlertErase(t *testing.T) {
 	c := api.NewOpenStorageClusterClient(s.Conn())
 
 	// Create request
-	req := &api.ClusterAlertEraseRequest{
+	req := &api.SdkClusterAlertEraseRequest{
 		AlertId:  1234,
 		Resource: api.ResourceType_RESOURCE_TYPE_DRIVE,
 	}

--- a/api/server/sdk/credentials.go
+++ b/api/server/sdk/credentials.go
@@ -30,8 +30,8 @@ import (
 // CreateForAWS method creates credential for AWS S3.
 func (s *VolumeServer) CreateForAWS(
 	ctx context.Context,
-	req *api.CredentialCreateAWSRequest,
-) (*api.CredentialCreateAWSResponse, error) {
+	req *api.SdkCredentialCreateAWSRequest,
+) (*api.SdkCredentialCreateAWSResponse, error) {
 
 	if len(req.GetCredential().GetAccessKey()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Must supply Access Key")
@@ -71,15 +71,15 @@ func (s *VolumeServer) CreateForAWS(
 	if err != nil {
 		return nil, err
 	}
-	return &api.CredentialCreateAWSResponse{CredentialId: uuid}, nil
+	return &api.SdkCredentialCreateAWSResponse{CredentialId: uuid}, nil
 
 }
 
 // CreateForAzure method creates credential for Azure.
 func (s *VolumeServer) CreateForAzure(
 	ctx context.Context,
-	req *api.CredentialCreateAzureRequest,
-) (*api.CredentialCreateAzureResponse, error) {
+	req *api.SdkCredentialCreateAzureRequest,
+) (*api.SdkCredentialCreateAzureResponse, error) {
 
 	if len(req.GetCredential().GetAccountKey()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Must supply Account Key")
@@ -109,14 +109,14 @@ func (s *VolumeServer) CreateForAzure(
 	if err != nil {
 		return nil, err
 	}
-	return &api.CredentialCreateAzureResponse{CredentialId: uuid}, nil
+	return &api.SdkCredentialCreateAzureResponse{CredentialId: uuid}, nil
 }
 
 // CreateForGoogle method creates credential for Google.
 func (s *VolumeServer) CreateForGoogle(
 	ctx context.Context,
-	req *api.CredentialCreateGoogleRequest,
-) (*api.CredentialCreateGoogleResponse, error) {
+	req *api.SdkCredentialCreateGoogleRequest,
+) (*api.SdkCredentialCreateGoogleResponse, error) {
 
 	if len(req.GetCredential().GetJsonKey()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Must supply JSON Key")
@@ -147,20 +147,20 @@ func (s *VolumeServer) CreateForGoogle(
 		return nil, err
 	}
 
-	return &api.CredentialCreateGoogleResponse{CredentialId: uuid}, nil
+	return &api.SdkCredentialCreateGoogleResponse{CredentialId: uuid}, nil
 }
 
 // CredentialValidate deletes a specified Credential.
 func (s *VolumeServer) CredentialValidate(
 	ctx context.Context,
-	req *api.CredentialValidateRequest,
-) (*api.CredentialValidateResponse, error) {
+	req *api.SdkCredentialValidateRequest,
+) (*api.SdkCredentialValidateResponse, error) {
 
 	if len(req.GetCredentialId()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Must provide credentials uuid")
 	}
 
-	validateReq := &api.CredentialValidateRequest{CredentialId: req.GetCredentialId()}
+	validateReq := &api.SdkCredentialValidateRequest{CredentialId: req.GetCredentialId()}
 
 	err := s.driver.CredsValidate(validateReq.GetCredentialId())
 
@@ -170,15 +170,15 @@ func (s *VolumeServer) CredentialValidate(
 			"failed to validate credentials: %v",
 			err.Error())
 	}
-	return &api.CredentialValidateResponse{}, nil
+	return &api.SdkCredentialValidateResponse{}, nil
 
 }
 
 // CredentialDelete delete a specified credential
 func (s *VolumeServer) CredentialDelete(
 	ctx context.Context,
-	req *api.CredentialDeleteRequest,
-) (*api.CredentialDeleteResponse, error) {
+	req *api.SdkCredentialDeleteRequest,
+) (*api.SdkCredentialDeleteResponse, error) {
 
 	if len(req.GetCredentialId()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Must provide credentials uuid")
@@ -192,14 +192,14 @@ func (s *VolumeServer) CredentialDelete(
 			err.Error())
 	}
 
-	return &api.CredentialDeleteResponse{}, nil
+	return &api.SdkCredentialDeleteResponse{}, nil
 }
 
 // EnumerateForAWS list credentials for AWS
 func (s *VolumeServer) EnumerateForAWS(
 	ctx context.Context,
-	req *api.CredentialEnumerateAWSRequest,
-) (*api.CredentialEnumerateAWSResponse, error) {
+	req *api.SdkCredentialEnumerateAWSRequest,
+) (*api.SdkCredentialEnumerateAWSResponse, error) {
 
 	credList, err := s.driver.CredsEnumerate()
 	if err != nil {
@@ -241,14 +241,14 @@ func (s *VolumeServer) EnumerateForAWS(
 		creds = append(creds, credResp)
 	}
 
-	return &api.CredentialEnumerateAWSResponse{Credential: creds}, nil
+	return &api.SdkCredentialEnumerateAWSResponse{Credential: creds}, nil
 }
 
 // EnumerateForAzure list credentials for AWS
 func (s *VolumeServer) EnumerateForAzure(
 	ctx context.Context,
-	req *api.CredentialEnumerateAzureRequest,
-) (*api.CredentialEnumerateAzureResponse, error) {
+	req *api.SdkCredentialEnumerateAzureRequest,
+) (*api.SdkCredentialEnumerateAzureResponse, error) {
 	credList, err := s.driver.CredsEnumerate()
 	if err != nil {
 		return nil, status.Errorf(
@@ -287,14 +287,14 @@ func (s *VolumeServer) EnumerateForAzure(
 		}
 		creds = append(creds, credResp)
 	}
-	return &api.CredentialEnumerateAzureResponse{Credential: creds}, nil
+	return &api.SdkCredentialEnumerateAzureResponse{Credential: creds}, nil
 }
 
 // EnumerateForGoogle list credentials for Google
 func (s *VolumeServer) EnumerateForGoogle(
 	ctx context.Context,
-	req *api.CredentialEnumerateGoogleRequest,
-) (*api.CredentialEnumerateGoogleResponse, error) {
+	req *api.SdkCredentialEnumerateGoogleRequest,
+) (*api.SdkCredentialEnumerateGoogleResponse, error) {
 	credList, err := s.driver.CredsEnumerate()
 	if err != nil {
 		return nil, status.Errorf(
@@ -333,17 +333,17 @@ func (s *VolumeServer) EnumerateForGoogle(
 		creds = append(creds, credResp)
 	}
 
-	return &api.CredentialEnumerateGoogleResponse{Credential: creds}, nil
+	return &api.SdkCredentialEnumerateGoogleResponse{Credential: creds}, nil
 }
 
 func validateAndDeleteIfInvalid(s *VolumeServer, uuid string) error {
 	// Validate if the credentials provided were correct or not
-	req := &api.CredentialValidateRequest{CredentialId: uuid}
+	req := &api.SdkCredentialValidateRequest{CredentialId: uuid}
 
 	validateErr := s.driver.CredsValidate(req.GetCredentialId())
 
 	if validateErr != nil {
-		deleteCred := &api.CredentialDeleteRequest{CredentialId: uuid}
+		deleteCred := &api.SdkCredentialDeleteRequest{CredentialId: uuid}
 		err := s.driver.CredsDelete(deleteCred.GetCredentialId())
 
 		if err != nil {

--- a/api/server/sdk/credentials_test.go
+++ b/api/server/sdk/credentials_test.go
@@ -34,7 +34,7 @@ func TestSdkAWSCredentialCreateSuccess(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.CredentialCreateAWSRequest{
+	req := &api.SdkCredentialCreateAWSRequest{
 		Credential: &api.S3Credential{
 			AccessKey: "dummy-access",
 			SecretKey: "dummy-secret",
@@ -75,7 +75,7 @@ func TestSdkAWSCredentialCreateFailed(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.CredentialCreateAWSRequest{
+	req := &api.SdkCredentialCreateAWSRequest{
 		Credential: &api.S3Credential{
 			AccessKey: "dummy-access",
 			SecretKey: "dummy-secret",
@@ -127,7 +127,7 @@ func TestSdkAWSCredentialCreateBadArgument(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.CredentialCreateAWSRequest{}
+	req := &api.SdkCredentialCreateAWSRequest{}
 
 	params := make(map[string]string)
 
@@ -156,7 +156,7 @@ func TestSdkAzureCredentialCreateSuccess(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.CredentialCreateAzureRequest{
+	req := &api.SdkCredentialCreateAzureRequest{
 		Credential: &api.AzureCredential{
 			AccountKey:  "dummy-account-key",
 			AccountName: "dummy-account-name",
@@ -193,7 +193,7 @@ func TestSdkAzureCredentialCreateFailed(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.CredentialCreateAzureRequest{
+	req := &api.SdkCredentialCreateAzureRequest{
 		Credential: &api.AzureCredential{
 			AccountKey:  "dummy-account-key",
 			AccountName: "dummy-account-name",
@@ -241,7 +241,7 @@ func TestSdkAzureCredentialCreateBadArgument(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.CredentialCreateAzureRequest{}
+	req := &api.SdkCredentialCreateAzureRequest{}
 
 	params := make(map[string]string)
 
@@ -267,7 +267,7 @@ func TestSdkGoogleCredentialCreateSuccess(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.CredentialCreateGoogleRequest{
+	req := &api.SdkCredentialCreateGoogleRequest{
 		Credential: &api.GoogleCredential{
 			ProjectId: "dummy-project-id",
 			JsonKey:   "dummy-json-key",
@@ -304,7 +304,7 @@ func TestSdkGoogleCredentialCreateFailed(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.CredentialCreateGoogleRequest{
+	req := &api.SdkCredentialCreateGoogleRequest{
 		Credential: &api.GoogleCredential{
 			ProjectId: "dummy-project-id",
 			JsonKey:   "dummy-json-key",
@@ -352,7 +352,7 @@ func TestSdkGoogleCredentialCreateBadArgument(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.CredentialCreateGoogleRequest{}
+	req := &api.SdkCredentialCreateGoogleRequest{}
 
 	params := make(map[string]string)
 
@@ -381,7 +381,7 @@ func TestSdkCredentialValidateSuccess(t *testing.T) {
 
 	uuid := "good-uuid"
 
-	req := &api.CredentialValidateRequest{CredentialId: uuid}
+	req := &api.SdkCredentialValidateRequest{CredentialId: uuid}
 
 	s.MockDriver().
 		EXPECT().
@@ -404,7 +404,7 @@ func TestSdkCredentialValidateFailed(t *testing.T) {
 
 	uuid := "bad-uuid"
 
-	req := &api.CredentialValidateRequest{CredentialId: uuid}
+	req := &api.SdkCredentialValidateRequest{CredentialId: uuid}
 
 	s.MockDriver().
 		EXPECT().
@@ -432,7 +432,7 @@ func TestSdkCredentialValidateBadArgument(t *testing.T) {
 
 	uuid := ""
 
-	req := &api.CredentialValidateRequest{CredentialId: uuid}
+	req := &api.SdkCredentialValidateRequest{CredentialId: uuid}
 
 	// Setup client
 	c := api.NewOpenStorageCredentialsClient(s.Conn())
@@ -454,7 +454,7 @@ func TestSdkCredentialEnumerateAWSSuccess(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.CredentialEnumerateAWSRequest{CredentialId: "test"}
+	req := &api.SdkCredentialEnumerateAWSRequest{CredentialId: "test"}
 
 	enumS3test1 := map[string]interface{}{
 		api.OptCredType:      "s3",
@@ -504,7 +504,7 @@ func TestSdkCredentialEnumerateAWSWithMultipleCredResponseSuccess(t *testing.T) 
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.CredentialEnumerateAWSRequest{CredentialId: "test"}
+	req := &api.SdkCredentialEnumerateAWSRequest{CredentialId: "test"}
 
 	enumS3 := map[string]interface{}{
 		api.OptCredType:      "s3",
@@ -555,7 +555,7 @@ func TestSdkCredentialEnumerateAWSFailed(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.CredentialEnumerateAWSRequest{CredentialId: "test"}
+	req := &api.SdkCredentialEnumerateAWSRequest{CredentialId: "test"}
 
 	s.MockDriver().
 		EXPECT().
@@ -579,7 +579,7 @@ func TestSdkCredentialEnumerateAzureSuccess(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.CredentialEnumerateAzureRequest{CredentialId: "test"}
+	req := &api.SdkCredentialEnumerateAzureRequest{CredentialId: "test"}
 
 	enumAzure := map[string]interface{}{
 		api.OptCredType:             "azure",
@@ -613,7 +613,7 @@ func TestSdkCredentialEnumerateAzureFailed(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.CredentialEnumerateAzureRequest{CredentialId: "test"}
+	req := &api.SdkCredentialEnumerateAzureRequest{CredentialId: "test"}
 
 	s.MockDriver().
 		EXPECT().
@@ -636,7 +636,7 @@ func TestSdkCredentialEnumerateGoogleSuccess(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.CredentialEnumerateGoogleRequest{CredentialId: "test"}
+	req := &api.SdkCredentialEnumerateGoogleRequest{CredentialId: "test"}
 
 	enumGoogle := map[string]interface{}{
 		api.OptCredType:            "google",
@@ -667,7 +667,7 @@ func TestSdkCredentialEnumerateGoogleFailed(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.CredentialEnumerateGoogleRequest{CredentialId: "test"}
+	req := &api.SdkCredentialEnumerateGoogleRequest{CredentialId: "test"}
 
 	s.MockDriver().
 		EXPECT().
@@ -691,7 +691,7 @@ func TestSdkCredentialDeleteSuccess(t *testing.T) {
 	defer s.Stop()
 
 	cred_id := "myid"
-	req := &api.CredentialDeleteRequest{
+	req := &api.SdkCredentialDeleteRequest{
 		CredentialId: cred_id,
 	}
 	s.MockDriver().
@@ -714,7 +714,7 @@ func TestSdkCredentialDeleteBadArgument(t *testing.T) {
 	defer s.Stop()
 
 	cred_id := ""
-	req := &api.CredentialDeleteRequest{
+	req := &api.SdkCredentialDeleteRequest{
 		CredentialId: cred_id,
 	}
 
@@ -735,7 +735,7 @@ func TestSdkCredentialDeleteFailed(t *testing.T) {
 	defer s.Stop()
 
 	cred_id := "myid"
-	req := &api.CredentialDeleteRequest{
+	req := &api.SdkCredentialDeleteRequest{
 		CredentialId: cred_id,
 	}
 	s.MockDriver().

--- a/api/server/sdk/volume_node_ops.go
+++ b/api/server/sdk/volume_node_ops.go
@@ -27,8 +27,8 @@ import (
 // Attach volume to given node
 func (s *VolumeServer) Attach(
 	ctx context.Context,
-	req *api.VolumeAttachRequest,
-) (*api.VolumeAttachResponse, error) {
+	req *api.SdkVolumeAttachRequest,
+) (*api.SdkVolumeAttachResponse, error) {
 
 	if len(req.GetVolumeId()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Must supply volume id")
@@ -42,14 +42,14 @@ func (s *VolumeServer) Attach(
 			err.Error())
 	}
 
-	return &api.VolumeAttachResponse{DevicePath: devPath}, nil
+	return &api.SdkVolumeAttachResponse{DevicePath: devPath}, nil
 }
 
 // Detach function for volume node detach
 func (s *VolumeServer) Detach(
 	ctx context.Context,
-	req *api.VolumeDetachRequest,
-) (*api.VolumeDetachResponse, error) {
+	req *api.SdkVolumeDetachRequest,
+) (*api.SdkVolumeDetachResponse, error) {
 
 	if len(req.GetVolumeId()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Must supply volume id")
@@ -57,14 +57,14 @@ func (s *VolumeServer) Detach(
 
 	err := s.driver.Detach(req.GetVolumeId(), nil)
 
-	return &api.VolumeDetachResponse{}, err
+	return &api.SdkVolumeDetachResponse{}, err
 }
 
 // Mount function for volume node detach
 func (s *VolumeServer) Mount(
 	ctx context.Context,
-	req *api.VolumeMountRequest,
-) (*api.VolumeMountResponse, error) {
+	req *api.SdkVolumeMountRequest,
+) (*api.SdkVolumeMountResponse, error) {
 
 	if len(req.GetVolumeId()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Must supply volume id")
@@ -76,14 +76,14 @@ func (s *VolumeServer) Mount(
 
 	err := s.driver.Mount(req.GetVolumeId(), req.GetMountPath(), req.GetOptions())
 
-	return &api.VolumeMountResponse{}, err
+	return &api.SdkVolumeMountResponse{}, err
 }
 
 // Unmount volume from given node
 func (s *VolumeServer) Unmount(
 	ctx context.Context,
-	req *api.VolumeUnmountRequest,
-) (*api.VolumeUnmountResponse, error) {
+	req *api.SdkVolumeUnmountRequest,
+) (*api.SdkVolumeUnmountResponse, error) {
 
 	if len(req.GetVolumeId()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Must supply volume id")
@@ -101,5 +101,5 @@ func (s *VolumeServer) Unmount(
 			err.Error())
 	}
 
-	return &api.VolumeUnmountResponse{}, nil
+	return &api.SdkVolumeUnmountResponse{}, nil
 }

--- a/api/server/sdk/volume_node_ops_test.go
+++ b/api/server/sdk/volume_node_ops_test.go
@@ -39,7 +39,7 @@ func TestSdkVolumeAttachSuccess(t *testing.T) {
 		"SECRET_NAME": "value1",
 	}
 
-	req := &api.VolumeAttachRequest{
+	req := &api.SdkVolumeAttachRequest{
 		VolumeId: id,
 		Options:  options,
 	}
@@ -67,7 +67,7 @@ func TestSdkVolumeAttachFailed(t *testing.T) {
 		"passphrase": "testval",
 	}
 
-	req := &api.VolumeAttachRequest{
+	req := &api.SdkVolumeAttachRequest{
 		VolumeId: id,
 		Options:  options,
 	}
@@ -101,7 +101,7 @@ func TestSdkVolumeAttachBadArgument(t *testing.T) {
 		"passphrase": "testval",
 	}
 
-	req := &api.VolumeAttachRequest{
+	req := &api.SdkVolumeAttachRequest{
 		VolumeId: id,
 		Options:  options,
 	}
@@ -126,7 +126,7 @@ func TestSdkVolumeDetachSuccess(t *testing.T) {
 	defer s.Stop()
 
 	id := "dummy-volume-id"
-	req := &api.VolumeDetachRequest{
+	req := &api.SdkVolumeDetachRequest{
 		VolumeId: id,
 	}
 	s.MockDriver().
@@ -149,7 +149,7 @@ func TestSdkVolumeDetachFailed(t *testing.T) {
 	defer s.Stop()
 
 	id := "dummy-volume-id"
-	req := &api.VolumeDetachRequest{
+	req := &api.SdkVolumeDetachRequest{
 		VolumeId: id,
 	}
 	s.MockDriver().
@@ -177,7 +177,7 @@ func TestSdkVolumeDetachBadArgument(t *testing.T) {
 	defer s.Stop()
 
 	id := ""
-	req := &api.VolumeDetachRequest{
+	req := &api.SdkVolumeDetachRequest{
 		VolumeId: id,
 	}
 
@@ -207,7 +207,7 @@ func TestSdkVolumeMountSuccess(t *testing.T) {
 	}
 	mountPath := "/dev/real/path"
 
-	req := &api.VolumeMountRequest{
+	req := &api.SdkVolumeMountRequest{
 		VolumeId:  id,
 		MountPath: mountPath,
 		Options:   options,
@@ -237,7 +237,7 @@ func TestSdkVolumeMountFailed(t *testing.T) {
 	}
 	mountPath := "/dev/fake/path"
 
-	req := &api.VolumeMountRequest{
+	req := &api.SdkVolumeMountRequest{
 		VolumeId:  id,
 		MountPath: mountPath,
 		Options:   options,
@@ -273,7 +273,7 @@ func TestSdkVolumeMountBadArgument(t *testing.T) {
 	}
 	mountPath := ""
 
-	req := &api.VolumeMountRequest{
+	req := &api.SdkVolumeMountRequest{
 		VolumeId:  id,
 		MountPath: mountPath,
 		Options:   options,
@@ -305,7 +305,7 @@ func TestSdkVolumeUnmountSuccess(t *testing.T) {
 		"option2": "value2",
 	}
 	mountPath := "/mnt/testmount"
-	req := &api.VolumeUnmountRequest{
+	req := &api.SdkVolumeUnmountRequest{
 		VolumeId:  id,
 		MountPath: mountPath,
 		Options:   options,
@@ -337,7 +337,7 @@ func TestSdkVolumeUnmountFailed(t *testing.T) {
 	}
 	mountPath := "/dev/fake/path"
 
-	req := &api.VolumeUnmountRequest{
+	req := &api.SdkVolumeUnmountRequest{
 		VolumeId:  id,
 		MountPath: mountPath,
 		Options:   options,
@@ -373,7 +373,7 @@ func TestSdkVolumeUnountBadArgument(t *testing.T) {
 	}
 	mountPath := "/mnt/mounttest"
 
-	req := &api.VolumeUnmountRequest{
+	req := &api.SdkVolumeUnmountRequest{
 		VolumeId:  id,
 		MountPath: mountPath,
 		Options:   options,

--- a/api/server/sdk/volume_ops.go
+++ b/api/server/sdk/volume_ops.go
@@ -99,8 +99,8 @@ func (s *VolumeServer) create(
 // Create creates a new volume
 func (s *VolumeServer) Create(
 	ctx context.Context,
-	req *api.OpenStorageVolumeCreateRequest,
-) (*api.OpenStorageVolumeCreateResponse, error) {
+	req *api.SdkVolumeCreateRequest,
+) (*api.SdkVolumeCreateResponse, error) {
 
 	if len(req.GetName()) == 0 {
 		return nil, status.Error(
@@ -123,16 +123,16 @@ func (s *VolumeServer) Create(
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	return &api.OpenStorageVolumeCreateResponse{
+	return &api.SdkVolumeCreateResponse{
 		VolumeId: id,
 	}, nil
 }
 
 // CreateFromVolumeID creates a new volume from an existing volume
-func (s *VolumeServer) CreateFromVolumeID(
+func (s *VolumeServer) CreateFromVolumeId(
 	ctx context.Context,
-	req *api.VolumeCreateFromVolumeIDRequest,
-) (*api.VolumeCreateFromVolumeIDResponse, error) {
+	req *api.SdkVolumeCreateFromVolumeIdRequest,
+) (*api.SdkVolumeCreateFromVolumeIdResponse, error) {
 
 	if len(req.GetName()) == 0 {
 		return nil, status.Error(
@@ -161,7 +161,7 @@ func (s *VolumeServer) CreateFromVolumeID(
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	return &api.VolumeCreateFromVolumeIDResponse{
+	return &api.SdkVolumeCreateFromVolumeIdResponse{
 		VolumeId: id,
 	}, nil
 }
@@ -169,8 +169,8 @@ func (s *VolumeServer) CreateFromVolumeID(
 // Delete deletes a volume
 func (s *VolumeServer) Delete(
 	ctx context.Context,
-	req *api.VolumeDeleteRequest,
-) (*api.VolumeDeleteResponse, error) {
+	req *api.SdkVolumeDeleteRequest,
+) (*api.SdkVolumeDeleteResponse, error) {
 
 	if len(req.GetVolumeId()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Must supply volume id")
@@ -180,7 +180,7 @@ func (s *VolumeServer) Delete(
 	volumes, err := s.driver.Inspect([]string{req.GetVolumeId()})
 	if (err == nil && len(volumes) == 0) ||
 		(err != nil && err == volume.ErrEnoEnt) {
-		return &api.VolumeDeleteResponse{}, nil
+		return &api.SdkVolumeDeleteResponse{}, nil
 	} else if err != nil {
 		return nil, status.Errorf(
 			codes.Internal,
@@ -198,14 +198,14 @@ func (s *VolumeServer) Delete(
 			err.Error())
 	}
 
-	return &api.VolumeDeleteResponse{}, nil
+	return &api.SdkVolumeDeleteResponse{}, nil
 }
 
 // Inspect returns information about a volume
 func (s *VolumeServer) Inspect(
 	ctx context.Context,
-	req *api.VolumeInspectRequest,
-) (*api.VolumeInspectResponse, error) {
+	req *api.SdkVolumeInspectRequest,
+) (*api.SdkVolumeInspectResponse, error) {
 
 	if len(req.GetVolumeId()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Must supply volume id")
@@ -220,7 +220,7 @@ func (s *VolumeServer) Inspect(
 			err.Error())
 	}
 
-	return &api.VolumeInspectResponse{
+	return &api.SdkVolumeInspectResponse{
 		Volume: vols[0],
 	}, nil
 }
@@ -228,8 +228,8 @@ func (s *VolumeServer) Inspect(
 // Enumerate returns a list of volumes
 func (s *VolumeServer) Enumerate(
 	ctx context.Context,
-	req *api.VolumeEnumerateRequest,
-) (*api.VolumeEnumerateResponse, error) {
+	req *api.SdkVolumeEnumerateRequest,
+) (*api.SdkVolumeEnumerateResponse, error) {
 
 	vols, err := s.driver.Enumerate(req.GetLocator(), nil)
 	if err != nil {
@@ -239,7 +239,7 @@ func (s *VolumeServer) Enumerate(
 			err.Error())
 	}
 
-	return &api.VolumeEnumerateResponse{
+	return &api.SdkVolumeEnumerateResponse{
 		Volumes: vols,
 	}, nil
 }

--- a/api/server/sdk/volume_ops_test.go
+++ b/api/server/sdk/volume_ops_test.go
@@ -38,7 +38,7 @@ func TestSdkVolumeCreateCheckIdempotency(t *testing.T) {
 
 	name := "myvol"
 	size := uint64(1234)
-	req := &api.OpenStorageVolumeCreateRequest{
+	req := &api.SdkVolumeCreateRequest{
 		Name: name,
 		Spec: &api.VolumeSpec{
 			Size: size,
@@ -82,7 +82,7 @@ func TestSdkVolumeCreate(t *testing.T) {
 
 	name := "myvol"
 	size := uint64(1234)
-	req := &api.OpenStorageVolumeCreateRequest{
+	req := &api.SdkVolumeCreateRequest{
 		Name: name,
 		Spec: &api.VolumeSpec{
 			Size: size,
@@ -131,7 +131,7 @@ func TestSdkVolumeCreateFromVolumeID(t *testing.T) {
 	name := "myvol"
 	parentid := "myparent"
 	size := uint64(1234)
-	req := &api.VolumeCreateFromVolumeIDRequest{
+	req := &api.SdkVolumeCreateFromVolumeIdRequest{
 		Name:     name,
 		ParentId: parentid,
 		Spec: &api.VolumeSpec{
@@ -175,7 +175,7 @@ func TestSdkVolumeCreateFromVolumeID(t *testing.T) {
 	c := api.NewOpenStorageVolumeClient(s.Conn())
 
 	// Get info
-	r, err := c.CreateFromVolumeID(context.Background(), req)
+	r, err := c.CreateFromVolumeId(context.Background(), req)
 	assert.NoError(t, err)
 	assert.Equal(t, r.GetVolumeId(), "myid")
 }
@@ -186,7 +186,7 @@ func TestSdkVolumeDelete(t *testing.T) {
 	defer s.Stop()
 
 	id := "myvol"
-	req := &api.VolumeDeleteRequest{
+	req := &api.SdkVolumeDeleteRequest{
 		VolumeId: id,
 	}
 
@@ -222,7 +222,7 @@ func TestSdkVolumeDeleteReturnOkWhenVolumeNotFound(t *testing.T) {
 	defer s.Stop()
 
 	id := "myvol"
-	req := &api.VolumeDeleteRequest{
+	req := &api.SdkVolumeDeleteRequest{
 		VolumeId: id,
 	}
 
@@ -247,7 +247,7 @@ func TestSdkVolumeDeleteBadArguments(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.VolumeDeleteRequest{}
+	req := &api.SdkVolumeDeleteRequest{}
 
 	// Setup client
 	c := api.NewOpenStorageVolumeClient(s.Conn())
@@ -269,7 +269,7 @@ func TestSdkVolumeInspect(t *testing.T) {
 	defer s.Stop()
 
 	id := "myid"
-	req := &api.VolumeInspectRequest{
+	req := &api.SdkVolumeInspectRequest{
 		VolumeId: id,
 	}
 
@@ -314,7 +314,7 @@ func TestSdkVolumeEnumerate(t *testing.T) {
 	c := api.NewOpenStorageVolumeClient(s.Conn())
 
 	// Get info
-	r, err := c.Enumerate(context.Background(), &api.VolumeEnumerateRequest{})
+	r, err := c.Enumerate(context.Background(), &api.SdkVolumeEnumerateRequest{})
 	assert.NoError(t, err)
 	assert.NotNil(t, r.GetVolumes())
 	assert.Len(t, r.GetVolumes(), 1)

--- a/api/server/sdk/volume_snapshot.go
+++ b/api/server/sdk/volume_snapshot.go
@@ -28,8 +28,8 @@ import (
 // SnapshotCreate creates a read-only snapshot of a volume
 func (s *VolumeServer) SnapshotCreate(
 	ctx context.Context,
-	req *api.VolumeSnapshotCreateRequest,
-) (*api.VolumeSnapshotCreateResponse, error) {
+	req *api.SdkVolumeSnapshotCreateRequest,
+) (*api.SdkVolumeSnapshotCreateResponse, error) {
 
 	if len(req.GetVolumeId()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Must supply volume id")
@@ -43,7 +43,7 @@ func (s *VolumeServer) SnapshotCreate(
 		return nil, status.Errorf(codes.Internal, "Failed to create snapshot: %v", err.Error())
 	}
 
-	return &api.VolumeSnapshotCreateResponse{
+	return &api.SdkVolumeSnapshotCreateResponse{
 		SnapshotId: snapshotID,
 	}, nil
 }
@@ -51,8 +51,8 @@ func (s *VolumeServer) SnapshotCreate(
 // SnapshotRestore restores a volume to the specified snapshot id
 func (s *VolumeServer) SnapshotRestore(
 	ctx context.Context,
-	req *api.VolumeSnapshotRestoreRequest,
-) (*api.VolumeSnapshotRestoreResponse, error) {
+	req *api.SdkVolumeSnapshotRestoreRequest,
+) (*api.SdkVolumeSnapshotRestoreResponse, error) {
 
 	if len(req.GetVolumeId()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Must supply volume id")
@@ -70,14 +70,14 @@ func (s *VolumeServer) SnapshotRestore(
 			err.Error())
 	}
 
-	return &api.VolumeSnapshotRestoreResponse{}, nil
+	return &api.SdkVolumeSnapshotRestoreResponse{}, nil
 }
 
 // SnapshotEnumerate returns a list of snapshots for the specified volume
 func (s *VolumeServer) SnapshotEnumerate(
 	ctx context.Context,
-	req *api.VolumeSnapshotEnumerateRequest,
-) (*api.VolumeSnapshotEnumerateResponse, error) {
+	req *api.SdkVolumeSnapshotEnumerateRequest,
+) (*api.SdkVolumeSnapshotEnumerateResponse, error) {
 
 	if len(req.GetVolumeId()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Must supply volume id")
@@ -92,7 +92,7 @@ func (s *VolumeServer) SnapshotEnumerate(
 			err.Error())
 	}
 
-	return &api.VolumeSnapshotEnumerateResponse{
+	return &api.SdkVolumeSnapshotEnumerateResponse{
 		Snapshots: snapshots,
 	}, nil
 }

--- a/api/server/sdk/volume_snapshot_test.go
+++ b/api/server/sdk/volume_snapshot_test.go
@@ -33,7 +33,7 @@ func TestSdkVolumeSnapshotCreateBadArguments(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.VolumeSnapshotCreateRequest{}
+	req := &api.SdkVolumeSnapshotCreateRequest{}
 
 	// Setup client
 	c := api.NewOpenStorageVolumeClient(s.Conn())
@@ -57,7 +57,7 @@ func TestSdkVolumeSnapshotCreate(t *testing.T) {
 
 	volid := "volid"
 	snapid := "snapid"
-	req := &api.VolumeSnapshotCreateRequest{
+	req := &api.SdkVolumeSnapshotCreateRequest{
 		VolumeId: volid,
 	}
 
@@ -83,7 +83,7 @@ func TestSdkVolumeSnapshotRestoreBadArguments(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.VolumeSnapshotRestoreRequest{}
+	req := &api.SdkVolumeSnapshotRestoreRequest{}
 
 	// Setup client
 	c := api.NewOpenStorageVolumeClient(s.Conn())
@@ -99,7 +99,7 @@ func TestSdkVolumeSnapshotRestoreBadArguments(t *testing.T) {
 	assert.Contains(t, serverError.Message(), "volume id")
 
 	// Now only provide the volume id
-	req = &api.VolumeSnapshotRestoreRequest{
+	req = &api.SdkVolumeSnapshotRestoreRequest{
 		VolumeId: "volid",
 	}
 
@@ -125,7 +125,7 @@ func TestSdkVolumeSnapshotRestore(t *testing.T) {
 
 	volid := "volid"
 	snapid := "snapid"
-	req := &api.VolumeSnapshotRestoreRequest{
+	req := &api.SdkVolumeSnapshotRestoreRequest{
 		VolumeId:   volid,
 		SnapshotId: snapid,
 	}
@@ -151,7 +151,7 @@ func TestSdkVolumeSnapshotEnumerateBadArguments(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 
-	req := &api.VolumeSnapshotEnumerateRequest{}
+	req := &api.SdkVolumeSnapshotEnumerateRequest{}
 
 	// Setup client
 	c := api.NewOpenStorageVolumeClient(s.Conn())
@@ -175,7 +175,7 @@ func TestSdkVolumeSnapshotEnumerate(t *testing.T) {
 
 	volid := "volid"
 	snapid := "snapid"
-	req := &api.VolumeSnapshotEnumerateRequest{
+	req := &api.SdkVolumeSnapshotEnumerateRequest{
 		VolumeId: volid,
 	}
 

--- a/hack/git-add-proto-generated.sh
+++ b/hack/git-add-proto-generated.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Simple script to add generated files from api.proto into their own commit
+git add api/api.pb.g* api/client/sdk/. api/server/sdk/api/api.swagger.json


### PR DESCRIPTION
**What this PR does / why we need it**:
To avoid collisions with other objects part of the REST and Golang interfaces, we need to prefix the request and response SDK objects. This also unifies the messages as some started with the object name and others started with "OpenStorage" to avoid collisions.

**Which issue(s) this PR fixes** (optional)
Part of #407 

**Special notes for your reviewer**:
Portworx builds passed with this change.
