### PR TITLE
sdk: Support for credentials in Fake driver

### DIFF
--- a/api/server/sdk/credentials.go
+++ b/api/server/sdk/credentials.go
@@ -19,7 +19,7 @@ package sdk
 
 import (
 	"context"
-	"errors"
+	"fmt"
 	"reflect"
 
 	"github.com/libopenstorage/openstorage/api"
@@ -223,20 +223,12 @@ func (s *VolumeServer) EnumerateForAWS(
 
 	// Fill up s3 credential resonse
 	creds := []*api.S3Credential{}
-	for k, v := range s3Creds {
-		cred, ok := v.(map[string]interface{})
-		if !ok {
-			return nil, status.Errorf(
-				codes.Internal,
-				"Unable to enumerate credentials AWS: %v",
-				reflect.TypeOf(v).String())
-		}
-
+	for id, cred := range s3Creds {
 		credResp := &api.S3Credential{
-			CredentialId: k,
-			AccessKey:    cred[api.OptCredAccessKey].(string),
-			Endpoint:     cred[api.OptCredEndpoint].(string),
-			Region:       cred[api.OptCredRegion].(string),
+			CredentialId: id,
+			AccessKey:    cred[api.OptCredAccessKey],
+			Endpoint:     cred[api.OptCredEndpoint],
+			Region:       cred[api.OptCredRegion],
 		}
 		creds = append(creds, credResp)
 	}
@@ -271,19 +263,11 @@ func (s *VolumeServer) EnumerateForAzure(
 
 	// Fill up azure credential resonse
 	creds := []*api.AzureCredential{}
-	for k, v := range azureCreds {
-		cred, ok := v.(map[string]interface{})
-		if !ok {
-			return nil, status.Errorf(
-				codes.Internal,
-				"Unable to enumerate credentials AWS: %v",
-				reflect.TypeOf(v).String())
-		}
-
+	for id, cred := range azureCreds {
 		credResp := &api.AzureCredential{
-			CredentialId: k,
-			AccountName:  cred[api.OptCredAzureAccountName].(string),
-			AccountKey:   cred[api.OptCredAzureAccountKey].(string),
+			CredentialId: id,
+			AccountName:  cred[api.OptCredAzureAccountName],
+			AccountKey:   cred[api.OptCredAzureAccountKey],
 		}
 		creds = append(creds, credResp)
 	}
@@ -317,18 +301,10 @@ func (s *VolumeServer) EnumerateForGoogle(
 
 	// Fill up google credential resonse
 	creds := []*api.GoogleCredential{}
-	for k, v := range googleCreds {
-		cred, ok := v.(map[string]interface{})
-		if !ok {
-			return nil, status.Errorf(
-				codes.Internal,
-				"Unable to enumerate credentials AWS: %v",
-				reflect.TypeOf(v).String())
-		}
-
+	for id, cred := range googleCreds {
 		credResp := &api.GoogleCredential{
-			CredentialId: k,
-			ProjectId:    cred[api.OptCredGoogleProjectID].(string),
+			CredentialId: id,
+			ProjectId:    cred[api.OptCredGoogleProjectID],
 		}
 		creds = append(creds, credResp)
 	}
@@ -362,22 +338,21 @@ func validateAndDeleteIfInvalid(s *VolumeServer, uuid string) error {
 	return nil
 }
 
-func getCredentialMap(credList map[string]interface{}, credType string) (map[string]interface{}, error) {
-	creds := make(map[string]interface{})
+func getCredentialMap(credList map[string]interface{}, credType string) (map[string]map[string]string, error) {
+	filtered := make(map[string]map[string]string)
 
 	for k, v := range credList {
-		c, ok := v.(map[string]interface{})
+		c, ok := v.(map[string]string)
 		if !ok {
-			return nil, errors.New("Error parsing credentials %v" +
+			return nil, fmt.Errorf("Error parsing credentials of type %v",
 				reflect.TypeOf(v).String())
 		}
 
 		// Look for only one type, fill up creds with same type array
-		switch c[api.OptCredType] {
-		case credType:
-			creds[k] = v
+		if c[api.OptCredType] == credType {
+			filtered[k] = c
 		}
 	}
 
-	return creds, nil
+	return filtered, nil
 }

--- a/api/server/sdk/credentials_test.go
+++ b/api/server/sdk/credentials_test.go
@@ -456,7 +456,7 @@ func TestSdkCredentialEnumerateAWSSuccess(t *testing.T) {
 
 	req := &api.SdkCredentialEnumerateAWSRequest{CredentialId: "test"}
 
-	enumS3test1 := map[string]interface{}{
+	enumS3test1 := map[string]string{
 		api.OptCredType:      "s3",
 		api.OptCredAccessKey: "test-access",
 		api.OptCredSecretKey: "test-secret",
@@ -464,7 +464,7 @@ func TestSdkCredentialEnumerateAWSSuccess(t *testing.T) {
 		api.OptCredRegion:    "test-region",
 	}
 
-	enumS3test2 := map[string]interface{}{
+	enumS3test2 := map[string]string{
 		api.OptCredType:      "s3",
 		api.OptCredAccessKey: "test-access1",
 		api.OptCredSecretKey: "test-secret1",
@@ -472,7 +472,7 @@ func TestSdkCredentialEnumerateAWSSuccess(t *testing.T) {
 		api.OptCredRegion:    "test-region1",
 	}
 
-	enumAzure := map[string]interface{}{
+	enumAzure := map[string]string{
 		api.OptCredType:             "azure",
 		api.OptCredAzureAccountName: "test-azure-account",
 		api.OptCredAzureAccountKey:  "test-azure-account",
@@ -506,7 +506,7 @@ func TestSdkCredentialEnumerateAWSWithMultipleCredResponseSuccess(t *testing.T) 
 
 	req := &api.SdkCredentialEnumerateAWSRequest{CredentialId: "test"}
 
-	enumS3 := map[string]interface{}{
+	enumS3 := map[string]string{
 		api.OptCredType:      "s3",
 		api.OptCredAccessKey: "test-access",
 		api.OptCredSecretKey: "test-secret",
@@ -514,13 +514,13 @@ func TestSdkCredentialEnumerateAWSWithMultipleCredResponseSuccess(t *testing.T) 
 		api.OptCredRegion:    "test-region",
 	}
 
-	enumAzure := map[string]interface{}{
+	enumAzure := map[string]string{
 		api.OptCredType:             "azure",
 		api.OptCredAzureAccountName: "test-azure-account",
 		api.OptCredAzureAccountKey:  "test-azure-account",
 	}
 
-	enumGoogle := map[string]interface{}{
+	enumGoogle := map[string]string{
 		api.OptCredType:            "google",
 		api.OptCredGoogleProjectID: "test-google-project-id",
 	}
@@ -581,7 +581,7 @@ func TestSdkCredentialEnumerateAzureSuccess(t *testing.T) {
 
 	req := &api.SdkCredentialEnumerateAzureRequest{CredentialId: "test"}
 
-	enumAzure := map[string]interface{}{
+	enumAzure := map[string]string{
 		api.OptCredType:             "azure",
 		api.OptCredAzureAccountName: "test-azure-account",
 		api.OptCredAzureAccountKey:  "test-azure-account",
@@ -638,7 +638,7 @@ func TestSdkCredentialEnumerateGoogleSuccess(t *testing.T) {
 
 	req := &api.SdkCredentialEnumerateGoogleRequest{CredentialId: "test"}
 
-	enumGoogle := map[string]interface{}{
+	enumGoogle := map[string]string{
 		api.OptCredType:            "google",
 		api.OptCredGoogleProjectID: "test-google-project-id",
 	}

--- a/volume/drivers/fake/fake_test.go
+++ b/volume/drivers/fake/fake_test.go
@@ -1,0 +1,71 @@
+/*
+Package fake provides an in-memory fake driver implementation
+Copyright 2018 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package fake
+
+import (
+	"testing"
+
+	"github.com/portworx/kvdb"
+	"github.com/portworx/kvdb/mem"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	kv, err := kvdb.New(mem.Name, "fake_test", []string{}, nil, logrus.Panicf)
+	if err != nil {
+		logrus.Panicf("Failed to initialize KVDB")
+	}
+	if err := kvdb.SetInstance(kv); err != nil {
+		logrus.Panicf("Failed to set KVDB instance")
+	}
+}
+
+func TestFakeName(t *testing.T) {
+	d, err := Init(map[string]string{})
+	assert.NoError(t, err)
+	assert.Equal(t, Name, d.Name())
+}
+
+func TestFakeCredentials(t *testing.T) {
+	d, err := Init(map[string]string{})
+	assert.NoError(t, err)
+
+	id, err := d.CredsCreate(map[string]string{
+		"hello": "world",
+	})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, id)
+
+	creds, err := d.CredsEnumerate()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, creds)
+	assert.Len(t, creds, 1)
+
+	data := creds[id]
+	value, ok := data.(map[string]string)
+	assert.True(t, ok)
+	assert.NotEmpty(t, value)
+	assert.Equal(t, value["hello"], "world")
+
+	err = d.CredsDelete(id)
+	assert.NoError(t, err)
+
+	creds, err = d.CredsEnumerate()
+	assert.NoError(t, err)
+	assert.Empty(t, creds)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
To make the fake driver return valueable data to the SDK, the SDK
implementation (not the API) had to be updated to solve #461
from the SDK side.

Issue #461 next needs the Golang interface to change to return
map[string]map[string]string instead of map[string]interface{}

**Which issue(s) this PR fixes** (optional)
Part of #407 
Part of #461 

