### PR TITLE
Add in-memory schedule policy to cluster

### DIFF
--- a/api/server/cluster.go
+++ b/api/server/cluster.go
@@ -24,23 +24,11 @@ const (
 type clusterApi struct {
 	restBase
 	SecretManager      secrets.Secrets
-	SchedPolicyManager sched.SchedulePolicy
+	SchedPolicyManager sched.SchedulePolicyProvider
 	ObjectStoreManager objectstore.ObjectStore
 }
 
-// ClusterServerConfiguration holds manager implementation
-// Caller has to create the manager and passes it in
-// StartClusterAPIWithConfiguration() to override with his own implementation
-type ClusterServerConfiguration struct {
-	// holds implementation to Secrets interface
-	ConfigSecretManager secrets.Secrets
-	// holds implementeation to SchedulePolicy interface
-	ConfigSchedManager sched.SchedulePolicy
-	// holds implementation to ObjectStore interface
-	ConfigObjectStoreManager objectstore.ObjectStore
-}
-
-func newClusterAPI(config ClusterServerConfiguration) restServer {
+func newClusterAPI(config cluster.ClusterServerConfiguration) restServer {
 	return &clusterApi{
 		restBase: restBase{
 			version: cluster.APIVersion,

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/gorilla/mux"
+	"github.com/libopenstorage/openstorage/cluster"
 	"github.com/libopenstorage/openstorage/objectstore"
 	sched "github.com/libopenstorage/openstorage/schedpolicy"
 	"github.com/libopenstorage/openstorage/secrets"
@@ -114,7 +115,7 @@ func StartVolumePluginAPI(
 	return nil
 }
 
-func CheckNullClusterServerConfiguration(config *ClusterServerConfiguration) {
+func CheckNullClusterServerConfiguration(config *cluster.ClusterServerConfiguration) {
 
 	// Set config managers to null/generic implementation if passed as null
 	if config.ConfigSecretManager == nil {
@@ -132,7 +133,7 @@ func CheckNullClusterServerConfiguration(config *ClusterServerConfiguration) {
 }
 
 func StartClusterApiWithConfiguration(
-	config ClusterServerConfiguration,
+	config cluster.ClusterServerConfiguration,
 	clusterApiBase string,
 	clusterPort uint16,
 ) error {
@@ -157,7 +158,7 @@ func StartClusterApiWithConfiguration(
 // from the CLI/UX to control the OSD cluster.
 func StartClusterAPI(clusterApiBase string, clusterPort uint16) error {
 	return StartClusterApiWithConfiguration(
-		ClusterServerConfiguration{},
+		cluster.ClusterServerConfiguration{},
 		clusterApiBase,
 		clusterPort,
 	)
@@ -166,11 +167,11 @@ func StartClusterAPI(clusterApiBase string, clusterPort uint16) error {
 //old version compatible
 func GetClusterAPIRoutes() []*Route {
 	return GetClusterAPIRoutesWithConfiguration(
-		ClusterServerConfiguration{},
+		cluster.ClusterServerConfiguration{},
 	)
 }
 
-func GetClusterAPIRoutesWithConfiguration(config ClusterServerConfiguration) []*Route {
+func GetClusterAPIRoutesWithConfiguration(config cluster.ClusterServerConfiguration) []*Route {
 	CheckNullClusterServerConfiguration(&config)
 	clusterApi := newClusterAPI(config)
 	return clusterApi.Routes()

--- a/api/server/testutils_test.go
+++ b/api/server/testutils_test.go
@@ -121,7 +121,7 @@ func testRestServer(t *testing.T) (*httptest.Server, *testServer) {
 
 func testClusterServer(t *testing.T) (*httptest.Server, *testCluster) {
 	tc := newTestCluster(t)
-	capi := newClusterAPI(ClusterServerConfiguration{
+	capi := newClusterAPI(cluster.ClusterServerConfiguration{
 		ConfigSecretManager:      tc.sm,
 		ConfigSchedManager:       tc.sp,
 		ConfigObjectStoreManager: tc.os,

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -36,6 +36,17 @@ const (
 	APIBase = "/var/lib/osd/cluster/"
 )
 
+// ClusterServerConfiguration holds manager implementation
+// Caller has to create the manager and passes it in
+type ClusterServerConfiguration struct {
+	// holds implementation to Secrets interface
+	ConfigSecretManager secrets.Secrets
+	// holds implementeation to SchedulePolicy interface
+	ConfigSchedManager sched.SchedulePolicyProvider
+	// holds implementation to ObjectStore interface
+	ConfigObjectStoreManager objectstore.ObjectStore
+}
+
 // NodeEntry is used to discover other nodes in the cluster
 // and setup the gossip protocol with them.
 type NodeEntry struct {
@@ -258,7 +269,7 @@ type Cluster interface {
 	ClusterAlerts
 	osdconfig.ConfigCaller
 	secrets.Secrets
-	sched.SchedulePolicy
+	sched.SchedulePolicyProvider
 	objectstore.ObjectStore
 }
 

--- a/schedpolicy/fake.go
+++ b/schedpolicy/fake.go
@@ -1,0 +1,93 @@
+/*
+Package fake provides an in-memory fake implementation of the Scheduler
+Copyright 2018 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package schedpolicy
+
+import (
+	"github.com/portworx/kvdb"
+	"github.com/portworx/kvdb/mem"
+	"github.com/sirupsen/logrus"
+	"path"
+)
+
+const (
+	fakeSchedPrefix = "/fake/sched"
+)
+
+type fakeSchedMgr struct {
+	kv kvdb.Kvdb
+}
+
+func NewDefaultSchedulePolicy() SchedulePolicyProvider {
+	return newFakeSchedManager()
+}
+
+func newFakeSchedManager() *fakeSchedMgr {
+	// This instance of the KVDB is Always in memory and created for each instance of the fake driver
+	// It is not necessary to run a single instance, and it helps tests create a new kvdb on each test
+	kv, err := kvdb.New(mem.Name, "fake_sched", []string{}, nil, logrus.Panicf)
+	if err != nil {
+		logrus.Fatalf("Failed to create kv: %v", err)
+		return nil
+	}
+	return &fakeSchedMgr{
+		kv: kv,
+	}
+}
+
+func (s *fakeSchedMgr) SchedPolicyCreate(name, sched string) error {
+	_, err := s.kv.Create(fakeSchedPrefix+"/"+name, sched, 0)
+	return err
+}
+
+func (s *fakeSchedMgr) SchedPolicyUpdate(name, sched string) error {
+	_, err := s.kv.Update(fakeSchedPrefix+"/"+name, sched, 0)
+	return err
+}
+
+func (s *fakeSchedMgr) SchedPolicyDelete(name string) error {
+	s.kv.Delete(fakeSchedPrefix + "/" + name)
+	return nil
+}
+
+func (s *fakeSchedMgr) SchedPolicyEnumerate() ([]*SchedPolicy, error) {
+	kvp, err := s.kv.Enumerate(fakeSchedPrefix)
+	if err != nil {
+		return nil, err
+	}
+
+	list := make([]*SchedPolicy, len(kvp))
+	for i, kv := range kvp {
+		list[i] = &SchedPolicy{
+			Name:     path.Base(kv.Key),
+			Schedule: string(kv.Value),
+		}
+	}
+
+	return list, nil
+}
+
+func (s *fakeSchedMgr) SchedPolicyGet(name string) (*SchedPolicy, error) {
+	kvp, err := s.kv.Get(fakeSchedPrefix + "/" + name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SchedPolicy{
+		Name:     name,
+		Schedule: string(kvp.Value),
+	}, nil
+}

--- a/schedpolicy/fake_test.go
+++ b/schedpolicy/fake_test.go
@@ -1,0 +1,67 @@
+/*
+Package fake provides an in-memory fake implementation of the Scheduler
+Copyright 2018 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schedpolicy
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFakeSchedule(t *testing.T) {
+	f := newFakeSchedManager()
+	err := f.SchedPolicyCreate("hello", "world")
+	assert.NoError(t, err)
+	err = f.SchedPolicyCreate("name", "sched")
+	assert.NoError(t, err)
+
+	// Update
+	err = f.SchedPolicyUpdate("hello", "universe")
+	assert.NoError(t, err)
+
+	// Enumerate
+	list, err := f.SchedPolicyEnumerate()
+	assert.NoError(t, err)
+	assert.Len(t, list, 2)
+	assert.Contains(t, list, &SchedPolicy{
+		Name:     "hello",
+		Schedule: "universe",
+	})
+	assert.Contains(t, list, &SchedPolicy{
+		Name:     "name",
+		Schedule: "sched",
+	})
+
+	// Delete
+	err = f.SchedPolicyDelete("hello")
+	assert.NoError(t, err)
+
+	list, err = f.SchedPolicyEnumerate()
+	assert.NoError(t, err)
+	assert.Len(t, list, 1)
+	assert.Contains(t, list, &SchedPolicy{
+		Name:     "name",
+		Schedule: "sched",
+	})
+
+	// Inspect
+	policy, err := f.SchedPolicyGet("name")
+	assert.NoError(t, err)
+	assert.NotNil(t, policy)
+	assert.Equal(t, policy.Name, "name")
+	assert.Equal(t, policy.Schedule, "sched")
+}

--- a/schedpolicy/sched_policy.go
+++ b/schedpolicy/sched_policy.go
@@ -7,7 +7,7 @@ var (
 	ErrNotImplemented = errors.New("Not Implemented")
 )
 
-type SchedulePolicy interface {
+type SchedulePolicyProvider interface {
 	// SchedPolicyCreate creates a policy with given name and schedule.
 	SchedPolicyCreate(name, sched string) error
 	// SchedPolicyUpdate updates a policy with given name and schedule.
@@ -18,31 +18,4 @@ type SchedulePolicy interface {
 	SchedPolicyEnumerate() ([]*SchedPolicy, error)
 	// SchedPolicyGet returns schedule policy matching given name.
 	SchedPolicyGet(name string) (*SchedPolicy, error)
-}
-
-func NewDefaultSchedulePolicy() SchedulePolicy {
-	return &nullSchedMgr{}
-}
-
-type nullSchedMgr struct {
-}
-
-func (sp *nullSchedMgr) SchedPolicyCreate(name, sched string) error {
-	return ErrNotImplemented
-}
-
-func (sp *nullSchedMgr) SchedPolicyUpdate(name, sched string) error {
-	return ErrNotImplemented
-}
-
-func (sp *nullSchedMgr) SchedPolicyDelete(name string) error {
-	return ErrNotImplemented
-}
-
-func (sp *nullSchedMgr) SchedPolicyEnumerate() ([]*SchedPolicy, error) {
-	return nil, ErrNotImplemented
-}
-
-func (sp *nullSchedMgr) SchedPolicyGet(name string) (*SchedPolicy, error) {
-	return nil, ErrNotImplemented
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The issue is that even though it compiled, the current cluster.Cluster
instance in osd did not have an implementation of the schedulerpolicy.
This would cause panics when the SDK would try to use the functions.
Instead it was in the REST server.

**Which issue(s) this PR fixes** (optional)
Closes #487

**Special notes for your reviewer**:
* Move the configuration struct to cluster/ from api/server
* Add an in-memory implementation of the SchedulePolicy implementation
* Change the interface name from SchedulePolicy to
SchedulePolicyProvider so that it does not conflict with the struct in
schedpolicy/ of the same name.


