### PR TITLE
Remove silent handler from cluster object

### DIFF
--- a/api/client/cluster/client.go
+++ b/api/client/cluster/client.go
@@ -145,6 +145,10 @@ func (c *clusterClient) Start(int, bool, string) error {
 	return nil
 }
 
+func (c *clusterClient) StartWithConfiguration(int, bool, string, *cluster.ClusterServerConfiguration) error {
+	return nil
+}
+
 func (c *clusterClient) DisableUpdates() error {
 	c.c.Put().Resource(clusterPath + "/disablegossip").Do()
 	return nil

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -261,7 +261,11 @@ type Cluster interface {
 	// It also causes this node to join the cluster.
 	// nodeInitialized indicates if the caller of this method expects the node
 	// to have been in an already-initialized state.
+	// All managers will default returning NotSupported.
 	Start(clusterSize int, nodeInitialized bool, gossipPort string) error
+
+	// Like Start, but have the ability to pass in managers to the cluster object
+	StartWithConfiguration(clusterMaxSize int, nodeInitialized bool, gossipPort string, config *ClusterServerConfiguration) error
 
 	ClusterData
 	ClusterRemove

--- a/cluster/manager.go
+++ b/cluster/manager.go
@@ -1062,9 +1062,11 @@ func (c *ClusterManager) initializeAndStartHeartbeat(
 	return lastIndex, nil
 }
 
-func (c *ClusterManager) setupDefaultManagers(config *ClusterServerConfiguration) {
+func (c *ClusterManager) setupManagers(config *ClusterServerConfiguration) {
 	if config.ConfigSchedManager == nil {
 		c.schedManager = sched.NewDefaultSchedulePolicy()
+	} else {
+		c.schedManager = config.ConfigSchedManager
 	}
 }
 
@@ -1101,7 +1103,7 @@ func (c *ClusterManager) StartWithConfiguration(
 	}
 
 	// Setup any default managers if none were provided
-	c.setupDefaultManagers(config)
+	c.setupManagers(config)
 
 	c.gEnabled = true
 	c.selfNode = api.Node{}

--- a/cluster/mock/cluster.mock.go
+++ b/cluster/mock/cluster.mock.go
@@ -519,6 +519,18 @@ func (mr *MockClusterMockRecorder) Start(arg0, arg1, arg2 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockCluster)(nil).Start), arg0, arg1, arg2)
 }
 
+// StartWithConfiguration mocks base method
+func (m *MockCluster) StartWithConfiguration(arg0 int, arg1 bool, arg2 string, arg3 *cluster.ClusterServerConfiguration) error {
+	ret := m.ctrl.Call(m, "StartWithConfiguration", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// StartWithConfiguration indicates an expected call of StartWithConfiguration
+func (mr *MockClusterMockRecorder) StartWithConfiguration(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWithConfiguration", reflect.TypeOf((*MockCluster)(nil).StartWithConfiguration), arg0, arg1, arg2, arg3)
+}
+
 // UpdateData mocks base method
 func (m *MockCluster) UpdateData(arg0 map[string]interface{}) error {
 	ret := m.ctrl.Call(m, "UpdateData", arg0)

--- a/cmd/osd/main.go
+++ b/cmd/osd/main.go
@@ -43,6 +43,7 @@ import (
 	"github.com/libopenstorage/openstorage/config"
 	"github.com/libopenstorage/openstorage/csi"
 	"github.com/libopenstorage/openstorage/graph/drivers"
+	"github.com/libopenstorage/openstorage/schedpolicy"
 	"github.com/libopenstorage/openstorage/volume"
 	"github.com/libopenstorage/openstorage/volume/drivers"
 	"github.com/portworx/kvdb"
@@ -298,7 +299,14 @@ func start(c *cli.Context) error {
 		if err != nil {
 			return fmt.Errorf("Unable to find cluster instance: %v", err)
 		}
-		if err := cm.Start(0, false, "9002"); err != nil {
+		if err := cm.StartWithConfiguration(
+			0,
+			false,
+			"9002",
+			&cluster.ClusterServerConfiguration{
+				ConfigSchedManager: schedpolicy.NewFakeScheduler(),
+			},
+		); err != nil {
 			return fmt.Errorf("Unable to start cluster manager: %v", err)
 		}
 	}

--- a/schedpolicy/fake.go
+++ b/schedpolicy/fake.go
@@ -31,11 +31,7 @@ type fakeSchedMgr struct {
 	kv kvdb.Kvdb
 }
 
-func NewDefaultSchedulePolicy() SchedulePolicyProvider {
-	return newFakeSchedManager()
-}
-
-func newFakeSchedManager() *fakeSchedMgr {
+func NewFakeScheduler() *fakeSchedMgr {
 	// This instance of the KVDB is Always in memory and created for each instance of the fake driver
 	// It is not necessary to run a single instance, and it helps tests create a new kvdb on each test
 	kv, err := kvdb.New(mem.Name, "fake_sched", []string{}, nil, logrus.Panicf)

--- a/schedpolicy/fake_test.go
+++ b/schedpolicy/fake_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestFakeSchedule(t *testing.T) {
-	f := newFakeSchedManager()
+	f := NewFakeScheduler()
 	err := f.SchedPolicyCreate("hello", "world")
 	assert.NoError(t, err)
 	err = f.SchedPolicyCreate("name", "sched")

--- a/schedpolicy/sched_policy.go
+++ b/schedpolicy/sched_policy.go
@@ -19,3 +19,30 @@ type SchedulePolicyProvider interface {
 	// SchedPolicyGet returns schedule policy matching given name.
 	SchedPolicyGet(name string) (*SchedPolicy, error)
 }
+
+func NewDefaultSchedulePolicy() SchedulePolicyProvider {
+	return &nullSchedMgr{}
+}
+
+type nullSchedMgr struct {
+}
+
+func (sp *nullSchedMgr) SchedPolicyCreate(name, sched string) error {
+	return ErrNotImplemented
+}
+
+func (sp *nullSchedMgr) SchedPolicyUpdate(name, sched string) error {
+	return ErrNotImplemented
+}
+
+func (sp *nullSchedMgr) SchedPolicyDelete(name string) error {
+	return ErrNotImplemented
+}
+
+func (sp *nullSchedMgr) SchedPolicyEnumerate() ([]*SchedPolicy, error) {
+	return nil, ErrNotImplemented
+}
+
+func (sp *nullSchedMgr) SchedPolicyGet(name string) (*SchedPolicy, error) {
+	return nil, ErrNotImplemented
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
PR #489 fixed the issue where any Golang function request to the
cluster object would be handled by an in-memory implementation instead
of having the system panic due to having no implementation available.

This could introduce another issue in that it could have a 'silent'
handler which could be unexpected. Instead, this fix makes it so
that the cluster object has a handler which always returns error
on default, removing the silent handler.


