### PR TITLE
Add policy name as part of Instance() to keep it case-sensitive

### DIFF
--- a/api/client/cluster/client.go
+++ b/api/client/cluster/client.go
@@ -327,7 +327,7 @@ func (c *clusterClient) SchedPolicyUpdate(name, schedule string) error {
 
 // SchedPolicyDelete deletes a policy with given name
 func (c *clusterClient) SchedPolicyDelete(name string) error {
-	req := c.c.Delete().Resource(clusterPath + SchedPath + "/" + name)
+	req := c.c.Delete().Resource(clusterPath + SchedPath).Instance(name)
 	res := req.Do()
 
 	if res.Error() != nil {
@@ -344,7 +344,7 @@ func (c *clusterClient) SchedPolicyGet(name string) (*sched.SchedPolicy, error) 
 		return nil, errors.New("Missing policy name")
 	}
 
-	req := c.c.Get().Resource(clusterPath + SchedPath + "/" + name)
+	req := c.c.Get().Resource(clusterPath + SchedPath).Instance(name)
 
 	if err := req.Do().Unmarshal(policy); err != nil {
 		return nil, err

--- a/api/server/schedpolicy_test.go
+++ b/api/server/schedpolicy_test.go
@@ -140,6 +140,32 @@ func TestSchedPolicyDeleteSuccess(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestSchedPolicyDeleteWithCaseSensitiveName(t *testing.T) {
+
+	// Create a new global test cluster
+	ts, tc := testClusterServer(t)
+	defer ts.Close()
+	defer tc.Finish()
+
+	name := "TestSchedPolicy1"
+	// mock the cluster schedulePolicy response
+	// this should be recived it as "TestSchedPolicy1" only
+	tc.MockClusterSchedPolicy().
+		EXPECT().
+		SchedPolicyDelete(name).
+		Return(nil)
+
+	// create a cluster client to make the REST call
+	c, err := clusterclient.NewClusterClient(ts.URL, "v1")
+	assert.NoError(t, err)
+
+	// make the REST call
+	restClient := clusterclient.ClusterManager(c)
+	err = restClient.SchedPolicyDelete(name)
+
+	assert.NoError(t, err)
+}
+
 func TestSchedPolicyDeleteFailed(t *testing.T) {
 
 	// Create a new global test cluster
@@ -239,6 +265,36 @@ func TestSchedPolicyGetSuccess(t *testing.T) {
 		Return(&sched.SchedPolicy{
 			Name:     name,
 			Schedule: "testsched:test",
+		}, nil)
+
+	// create a cluster client to make the REST call
+	c, err := clusterclient.NewClusterClient(ts.URL, "v1")
+	assert.NoError(t, err)
+
+	// make the REST call
+	restClient := clusterclient.ClusterManager(c)
+	schedPolicy, err := restClient.SchedPolicyGet(name)
+
+	assert.NotNil(t, schedPolicy)
+	assert.EqualValues(t, schedPolicy.Name, name)
+	assert.NoError(t, err)
+}
+
+func TestSchedPolicyGetSuccessWithSensitiveName(t *testing.T) {
+
+	// Create a new global test cluster
+	ts, tc := testClusterServer(t)
+	defer ts.Close()
+	defer tc.Finish()
+
+	name := "testSchedPolicy@Periodic1"
+	// mock the cluster schedulePolicy response
+	tc.MockClusterSchedPolicy().
+		EXPECT().
+		SchedPolicyGet(name).
+		Return(&sched.SchedPolicy{
+			Name:     name,
+			Schedule: "freq:periodic\nperiod:120000\n",
 		}, nil)
 
 	// create a cluster client to make the REST call


### PR DESCRIPTION
Signed-off-by: Ram Suradkar <ram.suradkar@portworx.com>

**What this PR does / why we need it**:
This PR chane URI path for schedule Name from resource to instance. If we keep policy name as part of Resource() url request, it will be converted to lowercase by restclient. We need to add URI path as Instance() so that restclient will treat it as it is

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
