### PR TITLE
sdk: Docker proto builder

### DIFF
--- a/Dockerfile.proto
+++ b/Dockerfile.proto
@@ -1,0 +1,51 @@
+#
+# Do not use directly, use `make docker-proto` instead
+#
+FROM fedora
+MAINTAINER luis@portworx.com
+
+ENV GOPATH=/go
+RUN dnf -y update
+RUN dnf -y install \
+	golang-bin \
+	python \
+	python-pip \
+	gem \
+	npm \
+	make \
+	git \
+	protobuf-compiler \
+	protobuf-devel
+RUN pip install virtualenv
+RUN gem install grpc && gem install grpc-tools
+RUN go get -u github.com/golang/protobuf/protoc-gen-go && \
+	go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger && \
+	go get -u github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
+
+# Lock protoc-gen-go version to v1.1.0.
+#
+# NOTE:
+# The latest uses new Invoke api which needs updates on:
+# $ go get -u google.golang.org/grpc/...
+# $ go get -u golang.org/x/sys/unix/...
+# $ govendor remove google.golang.org/grpc/...
+# $ govendor add +external google.golang.org/grpc/...
+# $ govendor update +external golang.org/x/sys/unix/...
+# Which may apply to project depending on OpenStorage.
+#
+WORKDIR /go/src/github.com/golang/protobuf
+RUN git checkout v1.1.0 && go install github.com/golang/protobuf/protoc-gen-go
+
+
+# Lock protoc-gen-swagger to v1.4.1
+# The swagger output in the latest version seems to be incorrect
+# See: https://github.com/grpc-ecosystem/grpc-gateway/issues/688
+#
+WORKDIR /go/src/github.com/grpc-ecosystem/grpc-gateway
+RUN git checkout v1.4.1 && \
+    go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger && \
+	go install github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway
+
+# Finally, set working directory to the openstorage project
+RUN mkdir -p /go/src/github.com/libopenstorage/openstorage
+WORKDIR /go/src/github.com/libopenstorage/openstorage

--- a/Makefile
+++ b/Makefile
@@ -82,6 +82,18 @@ $(OSDSANITY)-install:
 $(OSDSANITY)-clean:
 	@$(MAKE) -C cmd/osd-sanity clean
 
+docker-build-proto:
+	docker build -t openstorage/osd-proto -f Dockerfile.proto .
+
+docker-proto: docker-build-proto
+	docker run \
+		--privileged \
+		-v $(shell pwd):/go/src/github.com/libopenstorage/openstorage \
+		-e "GOPATH=/go" \
+		-e "PATH=/bin:/usr/bin:/usr/local/bin:/go/bin" \
+		openstorage/osd-proto \
+			make proto
+
 proto:
 ifndef HAS_PROTOC_GEN_GO
 	@echo "Installing protoc-gen-go"

--- a/docs/dev-sdk.md
+++ b/docs/dev-sdk.md
@@ -42,7 +42,7 @@ To add an API, follow the following steps:
 
 * Create a new API in a service proto file and create its messages.
     * It is **HIGHLY** recommended that you have these messages reviewed _first_ before sending your PR. The easiest way is to create an [Issue](https://github.com/libopenstorage/openstorage/issues/new) with the description of the plan and the proto file API and messages. If not you may have to change all your code in case their is a suggestion on changes to your proto file.
-* Generate the Golang bindings by running: `make proto`.
+* Generate the Golang bindings by running: `make docker-proto`.
 * Add the implementation of the API server interface to the appropriate service file in `api/server/sdk`. You are also welcomed to create new files in that directory which are prefixed by the service name, here is an example: [volume_node_ops.go](https://github.com/libopenstorage/openstorage/blob/master/api/server/sdk/volume_node_ops.go)
 * The implementation should only communicate with the OpenStorage golang interfaces, never the REST API.
 * You _must_ provide unit tests for your changes which utilize either a mock cluster or a mock driver.


### PR DESCRIPTION
**What this PR does / why we need it**:

* No need for developers to install the tools. 
* Now all output of the generated files are generated using the same versions of the tools.

Developers just need to type: `make docker-proto`

**Which issue(s) this PR fixes** (optional)
Closes #510 

**Special notes for your reviewer**:
This docker file forces certain versions of the tools due to the following issues:

* https://github.com/golang/protobuf/issues/625
* https://github.com/grpc-ecosystem/grpc-gateway/issues/688
