### PR TITLE
sdk: Set mock container cluster name

### DIFF
--- a/etc/config/config-fake.yaml
+++ b/etc/config/config-fake.yaml
@@ -2,6 +2,6 @@
 osd:
   cluster:
     nodeid: "1"
-    clusterid: "deadbeeef"
+    clusterid: "mock"
   drivers:
     fake:


### PR DESCRIPTION
**What this PR does / why we need it**:
Rename the mock-sdk-server cluster from an ugly name like `deadbeeeef` to a simple name like `mock`

