### PR TITLE
Add optional parameter key for specifying bucket when creating creden…

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -82,6 +82,8 @@ const (
 	OptCredAccessKey = "CredAccessKey"
 	// OptCredSecretKey for s3
 	OptCredSecretKey = "CredSecretKey"
+	// OptCredBucket is the optional bucket name
+	OptCredBucket = "CredBucket"
 	// OptCredGoogleProjectID projectID for google cloud
 	OptCredGoogleProjectID = "CredProjectID"
 	// OptCredGoogleJsonKey for google cloud


### PR DESCRIPTION
…tials.

This allows users to optionally specify a bucket to upload CloudBackups to.

Signed-off-by: veda <veda@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Allows Users to specify bucket name while creating credential for cloud backups
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

