### PR TITLE
Fake driver does not accept ha level of 0

### DIFF
--- a/volume/drivers/fake/fake.go
+++ b/volume/drivers/fake/fake.go
@@ -148,6 +148,8 @@ func (d *driver) Create(
 
 	if spec.Size == 0 {
 		return "", fmt.Errorf("Volume size cannot be zero")
+	} else if spec.GetHaLevel() == 0 {
+		return "", fmt.Errorf("HA level cannot be zero")
 	}
 
 	volumeID := strings.TrimSuffix(uuid.New(), "\n")

--- a/volume/drivers/fake/fake_test.go
+++ b/volume/drivers/fake/fake_test.go
@@ -89,6 +89,15 @@ func TestFakeCreateVolume(t *testing.T) {
 	}, &api.Source{}, &api.VolumeSpec{
 		Size: 1234,
 	})
+	assert.Error(t, err)
+	assert.Empty(t, vid)
+
+	vid, err = d.Create(&api.VolumeLocator{
+		Name: "myvol",
+	}, &api.Source{}, &api.VolumeSpec{
+		Size:    1234,
+		HaLevel: 1,
+	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, vid)
 
@@ -128,7 +137,8 @@ func TestFakeCloudBackupCreate(t *testing.T) {
 	name := "myvol"
 	size := uint64(1234)
 	volid, err := d.Create(&api.VolumeLocator{Name: name}, &api.Source{}, &api.VolumeSpec{
-		Size: size,
+		Size:    size,
+		HaLevel: 1,
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, volid)
@@ -156,7 +166,8 @@ func testInitForCloudBackups(t *testing.T, d *driver) (string, *api.CloudBackupC
 	name := "myvol"
 	size := uint64(1234)
 	volid, err := d.Create(&api.VolumeLocator{Name: name}, &api.Source{}, &api.VolumeSpec{
-		Size: size,
+		Size:    size,
+		HaLevel: 1,
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, volid)
@@ -636,7 +647,8 @@ func TestFakeSet(t *testing.T) {
 	name := "myvol"
 	size := uint64(1234)
 	volid, err := d.Create(&api.VolumeLocator{Name: name}, &api.Source{}, &api.VolumeSpec{
-		Size: size,
+		Size:    size,
+		HaLevel: 1,
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, volid)


### PR DESCRIPTION
**What this PR does / why we need it**:
To behave more like the px driver, the fake driver should not allow creation requests with ha level of 0

**Which issue(s) this PR fixes** (optional)
Closes #538
