### PR TITLE
sdk: Fix launch-sdk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ generate-mockfiles:
 
 generate: docs generate-mockfiles
 
-sdk: proto docker-build-mock-sdk-server
+sdk: docker-proto docker-build-mock-sdk-server
 
 docker-build-mock-sdk-server: packr
 	rm -rf _tmp


### PR DESCRIPTION
**What this PR does / why we need it**:
The rule `sdk-launch` in the Makefile needs to use `docker-proto`
