### PR TITLE
Add spec option requested_nodes_options

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -46,6 +46,9 @@ const (
 	SpecLabels               = "labels"
 	SpecPriorityAlias        = "priority_io"
 	SpecIoProfile            = "io_profile"
+	// SpecBestEffortLocationProvisioning default is false. If set provisioning request will succeed
+	// even if specified data location parameters could not be satisfied.
+	SpecBestEffortLocationProvisioning = "best_effort_location_provisioning"
 )
 
 // OptionKey specifies a set of recognized query params.

--- a/api/spec/spec_handler.go
+++ b/api/spec/spec_handler.go
@@ -282,6 +282,8 @@ func (d *specHandler) UpdateSpecFromOpts(opts map[string]string, spec *api.Volum
 			locator.VolumeLabels[k] = v
 		case api.SpecRack:
 			locator.VolumeLabels[api.SpecRacks] = v
+		case api.SpecBestEffortLocationProvisioning:
+			locator.VolumeLabels[k] = "true"
 		case api.SpecCompressed:
 			if compressed, err := strconv.ParseBool(v); err != nil {
 				return nil, nil, nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

add a flag that goes along with zones, nodes, racks which says
that these inputs are only optional.

Signed-off-by: sangleganesh <ganesh@portworx.com>

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
you can suggest some other name too. 
