### PR TITLE
travis: Add SDK tests to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 language: go
 go:
-  - 1.9.5
+  - 1.9.7
   - 1.10.3
 before_install:
   - sudo apt-get update -yq
@@ -21,6 +21,7 @@ script:
   - make install
   - make vet
   - make docker-test
+  - make test-sdk
   - make docs
   - if [ "${TRAVIS_BRANCH}" == "master" ] && [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
       make docker-build-osd;


### PR DESCRIPTION
**What this PR does / why we need it**:
Provides tests for the SDK api as expected by [sdk-test](https://github.com/libopenstorage/sdk-test). Since sdk-test has been compiled with a previous version of the `api.proto`, it ensures that any changes to the current API does not break previous clients.


