### PR TITLE
Fix vmware vm uuid parsing and add DeleteFrom and DetachFrom

### DIFF
--- a/pkg/storageops/aws/aws.go
+++ b/pkg/storageops/aws/aws.go
@@ -516,6 +516,10 @@ func (s *ec2Ops) Create(
 	return s.refreshVol(resp.VolumeId)
 }
 
+func (s *ec2Ops) DeleteFrom(id, _ string) error {
+	return s.Delete(id)
+}
+
 func (s *ec2Ops) Delete(id string) error {
 	req := &ec2.DeleteVolumeInput{VolumeId: &id}
 	_, err := s.ec2.DeleteVolume(req)
@@ -560,9 +564,17 @@ func (s *ec2Ops) Attach(volumeID string) (string, error) {
 }
 
 func (s *ec2Ops) Detach(volumeID string) error {
+	return s.detachInternal(volumeID, s.instance)
+}
+
+func (s *ec2Ops) DetachFrom(volumeID, instanceName string) error {
+	return s.detachInternal(volumeID, instanceName)
+}
+
+func (s *ec2Ops) detachInternal(volumeID, instanceName string) error {
 	force := false
 	req := &ec2.DetachVolumeInput{
-		InstanceId: &s.instance,
+		InstanceId: &instanceName,
 		VolumeId:   &volumeID,
 		Force:      &force,
 	}

--- a/pkg/storageops/aws/aws.go
+++ b/pkg/storageops/aws/aws.go
@@ -189,6 +189,8 @@ func (s *ec2Ops) waitAttachmentStatus(
 
 func (s *ec2Ops) Name() string { return "aws" }
 
+func (s *ec2Ops) InstanceID() string { return s.instance }
+
 func (s *ec2Ops) ApplyTags(volumeID string, labels map[string]string) error {
 	req := &ec2.CreateTagsInput{
 		Resources: []*string{&volumeID},

--- a/pkg/storageops/gce/gce.go
+++ b/pkg/storageops/gce/gce.go
@@ -186,6 +186,10 @@ func (s *gceOps) Create(
 	return d, err
 }
 
+func (s *gceOps) DeleteFrom(id, _ string) error {
+	return s.Delete(id)
+}
+
 func (s *gceOps) Delete(id string) error {
 	ctx := context.Background()
 	found := false
@@ -214,10 +218,18 @@ func (s *gceOps) Delete(id string) error {
 }
 
 func (s *gceOps) Detach(devicePath string) error {
+	return s.detachInternal(devicePath, s.inst.Name)
+}
+
+func (s *gceOps) DetachFrom(devicePath, instanceName string) error {
+	return s.detachInternal(devicePath, instanceName)
+}
+
+func (s *gceOps) detachInternal(devicePath, instanceName string) error {
 	_, err := s.service.Instances.DetachDisk(
 		s.inst.Project,
 		s.inst.Zone,
-		s.inst.Name,
+		instanceName,
 		devicePath).Do()
 	if err != nil {
 		return err

--- a/pkg/storageops/gce/gce_test.go
+++ b/pkg/storageops/gce/gce_test.go
@@ -45,7 +45,6 @@ func TestAll(t *testing.T) {
 		d, disks := initGCE(t)
 		drivers[d.Name()] = d
 		diskTemplates[d.Name()] = disks
-
 		test.RunTest(drivers, diskTemplates, t)
 	} else {
 		fmt.Printf("skipping GCE tests as environment is not set...\n")

--- a/pkg/storageops/storageops.go
+++ b/pkg/storageops/storageops.go
@@ -46,8 +46,12 @@ type Ops interface {
 	Attach(volumeID string) (string, error)
 	// Detach volumeID.
 	Detach(volumeID string) error
+	// DetachFrom detaches the disk/volume with given ID from the given instance ID
+	DetachFrom(volumeID, instanceID string) error
 	// Delete volumeID.
 	Delete(volumeID string) error
+	// DeleteFrom deletes the given volume/disk from the given instanceID
+	DeleteFrom(volumeID, instanceID string) error
 	// Desribe an instance
 	Describe() (interface{}, error)
 	// FreeDevices returns free block devices on the instance.

--- a/pkg/storageops/storageops.go
+++ b/pkg/storageops/storageops.go
@@ -37,6 +37,8 @@ type StorageError struct {
 type Ops interface {
 	// Name returns name of the storage operations driver
 	Name() string
+	// InstanceID returns the ID of the instance of the default instance the operations are performed on
+	InstanceID() string
 	// Create volume based on input template volume and also apply given labels.
 	Create(template interface{}, labels map[string]string) (interface{}, error)
 	// GetDeviceID returns ID/Name of the given device/disk or snapshot

--- a/pkg/storageops/test/storageops.go
+++ b/pkg/storageops/test/storageops.go
@@ -17,7 +17,8 @@ var diskLabels = map[string]string{
 	"Test":   "UPPER_CASE",
 }
 
-func RunTest(drivers map[string]storageops.Ops,
+func RunTest(
+	drivers map[string]storageops.Ops,
 	diskTemplates map[string]map[string]interface{},
 	t *testing.T) {
 	for _, d := range drivers {
@@ -136,6 +137,17 @@ func attach(t *testing.T, driver storageops.Ops, diskName string) {
 	require.NotEmpty(t, devPath, "disk attach returned empty devicePath")
 
 	mappings, err := driver.DeviceMappings()
+	require.NoError(t, err, "get device mappings returned error")
+	require.NotEmpty(t, mappings, "received empty device mappings")
+
+	err = driver.DetachFrom(diskName, driver.InstanceID())
+	require.NoError(t, err, "disk DetachFrom returned error")
+
+	devPath, err = driver.Attach(diskName)
+	require.NoError(t, err, "disk attach returned error")
+	require.NotEmpty(t, devPath, "disk attach returned empty devicePath")
+
+	mappings, err = driver.DeviceMappings()
 	require.NoError(t, err, "get device mappings returned error")
 	require.NotEmpty(t, mappings, "received empty device mappings")
 }

--- a/pkg/storageops/vsphere/vsphere.go
+++ b/pkg/storageops/vsphere/vsphere.go
@@ -58,10 +58,9 @@ func NewClient(cfg *VSphereConfig) (storageops.Ops, error) {
 	}, nil
 }
 
-// Name returns name of the storage operations driver
-func (ops *vsphereOps) Name() string {
-	return "vsphere"
-}
+func (ops *vsphereOps) Name() string { return "vsphere" }
+
+func (ops *vsphereOps) InstanceID() string { return ops.cfg.VMUUID }
 
 func (ops *vsphereOps) Create(opts interface{}, labels map[string]string) (interface{}, error) {
 	volumeOptions, ok := opts.(*vclib.VolumeOptions)

--- a/pkg/storageops/vsphere/vsphere_util.go
+++ b/pkg/storageops/vsphere/vsphere_util.go
@@ -80,10 +80,7 @@ func ReadVSphereConfigFromEnv() (*VSphereConfig, error) {
 		cfg.InsecureFlag = true
 	}
 
-	cfg.VMUUID, err = storageops.GetEnvValueStrict("VSPHERE_VM_UUID")
-	if err != nil {
-		return nil, err
-	}
+	cfg.VMUUID, _ = storageops.GetEnvValueStrict("VSPHERE_VM_UUID")
 
 	return &cfg, nil
 }


### PR DESCRIPTION
Signed-off-by: Harsh Desai <harsh@portworx.com>

**What this PR does / why we need it**:  

1. User doesn't need to give vsphere vmuuid from environment. It's optional.
2. Add DeleteFrom and DetachFrom API's to detach and delete if invoked from a different node

