### PR TITLE
Remove extra string and just return the error

### DIFF
--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -745,8 +745,7 @@ func (vd *volAPI) stats(w http.ResponseWriter, r *http.Request) {
 
 	stats, err := d.Stats(volumeID, cumulative)
 	if err != nil {
-		e := fmt.Errorf("Failed to get stats: %s", err.Error())
-		http.Error(w, e.Error(), http.StatusBadRequest)
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	json.NewEncoder(w).Encode(stats)


### PR DESCRIPTION
Signed-off-by: Paul <paul@portworx.com>

**What this PR does / why we need it**:
Remove extra error messages it's causing issues when calling multiple times and aggregating the error message.


