### PR TITLE
travis: Add sdk-test back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
   - make install
   - make vet
   - make docker-test
+  - make test-sdk
   - make docs
   - if [ "${TRAVIS_BRANCH}" == "master" ] && [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
       make docker-build-osd;


### PR DESCRIPTION
sdk-test had to be removed to allow for a SDK braking change.
Now that the sdk-test repo has been update, we can add it back to
Travis.
