### PR TITLE
AWS: Add a reliable way to determine nvme drive names

### DIFF
--- a/pkg/exec/bin.go
+++ b/pkg/exec/bin.go
@@ -1,0 +1,17 @@
+package exec
+
+import (
+	"os"
+	"path"
+)
+
+// Which returns absolute path for specified bin.
+func Which(bin string) string {
+	pathList := []string{"/usr/bin", "/sbin", "/usr/sbin", "/usr/local/bin"}
+	for _, p := range pathList {
+		if _, err := os.Stat(path.Join(p, bin)); err == nil {
+			return path.Join(p, bin)
+		}
+	}
+	return bin
+}

--- a/vendor/github.com/codegangsta/inject/LICENSE
+++ b/vendor/github.com/codegangsta/inject/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Jeremy Saenz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/codegangsta/inject/README.md
+++ b/vendor/github.com/codegangsta/inject/README.md
@@ -1,0 +1,92 @@
+# inject
+--
+    import "github.com/codegangsta/inject"
+
+Package inject provides utilities for mapping and injecting dependencies in
+various ways.
+
+Language Translations:
+* [简体中文](translations/README_zh_cn.md)
+
+## Usage
+
+#### func  InterfaceOf
+
+```go
+func InterfaceOf(value interface{}) reflect.Type
+```
+InterfaceOf dereferences a pointer to an Interface type. It panics if value is
+not an pointer to an interface.
+
+#### type Applicator
+
+```go
+type Applicator interface {
+	// Maps dependencies in the Type map to each field in the struct
+	// that is tagged with 'inject'. Returns an error if the injection
+	// fails.
+	Apply(interface{}) error
+}
+```
+
+Applicator represents an interface for mapping dependencies to a struct.
+
+#### type Injector
+
+```go
+type Injector interface {
+	Applicator
+	Invoker
+	TypeMapper
+	// SetParent sets the parent of the injector. If the injector cannot find a
+	// dependency in its Type map it will check its parent before returning an
+	// error.
+	SetParent(Injector)
+}
+```
+
+Injector represents an interface for mapping and injecting dependencies into
+structs and function arguments.
+
+#### func  New
+
+```go
+func New() Injector
+```
+New returns a new Injector.
+
+#### type Invoker
+
+```go
+type Invoker interface {
+	// Invoke attempts to call the interface{} provided as a function,
+	// providing dependencies for function arguments based on Type. Returns
+	// a slice of reflect.Value representing the returned values of the function.
+	// Returns an error if the injection fails.
+	Invoke(interface{}) ([]reflect.Value, error)
+}
+```
+
+Invoker represents an interface for calling functions via reflection.
+
+#### type TypeMapper
+
+```go
+type TypeMapper interface {
+	// Maps the interface{} value based on its immediate type from reflect.TypeOf.
+	Map(interface{}) TypeMapper
+	// Maps the interface{} value based on the pointer of an Interface provided.
+	// This is really only useful for mapping a value as an interface, as interfaces
+	// cannot at this time be referenced directly without a pointer.
+	MapTo(interface{}, interface{}) TypeMapper
+	// Provides a possibility to directly insert a mapping based on type and value.
+	// This makes it possible to directly map type arguments not possible to instantiate
+	// with reflect like unidirectional channels.
+	Set(reflect.Type, reflect.Value) TypeMapper
+	// Returns the Value that is mapped to the current type. Returns a zeroed Value if
+	// the Type has not been mapped.
+	Get(reflect.Type) reflect.Value
+}
+```
+
+TypeMapper represents an interface for mapping interface{} values based on type.

--- a/vendor/github.com/codegangsta/inject/inject.go
+++ b/vendor/github.com/codegangsta/inject/inject.go
@@ -1,0 +1,187 @@
+// Package inject provides utilities for mapping and injecting dependencies in various ways.
+package inject
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// Injector represents an interface for mapping and injecting dependencies into structs
+// and function arguments.
+type Injector interface {
+	Applicator
+	Invoker
+	TypeMapper
+	// SetParent sets the parent of the injector. If the injector cannot find a
+	// dependency in its Type map it will check its parent before returning an
+	// error.
+	SetParent(Injector)
+}
+
+// Applicator represents an interface for mapping dependencies to a struct.
+type Applicator interface {
+	// Maps dependencies in the Type map to each field in the struct
+	// that is tagged with 'inject'. Returns an error if the injection
+	// fails.
+	Apply(interface{}) error
+}
+
+// Invoker represents an interface for calling functions via reflection.
+type Invoker interface {
+	// Invoke attempts to call the interface{} provided as a function,
+	// providing dependencies for function arguments based on Type. Returns
+	// a slice of reflect.Value representing the returned values of the function.
+	// Returns an error if the injection fails.
+	Invoke(interface{}) ([]reflect.Value, error)
+}
+
+// TypeMapper represents an interface for mapping interface{} values based on type.
+type TypeMapper interface {
+	// Maps the interface{} value based on its immediate type from reflect.TypeOf.
+	Map(interface{}) TypeMapper
+	// Maps the interface{} value based on the pointer of an Interface provided.
+	// This is really only useful for mapping a value as an interface, as interfaces
+	// cannot at this time be referenced directly without a pointer.
+	MapTo(interface{}, interface{}) TypeMapper
+	// Provides a possibility to directly insert a mapping based on type and value.
+	// This makes it possible to directly map type arguments not possible to instantiate
+	// with reflect like unidirectional channels.
+	Set(reflect.Type, reflect.Value) TypeMapper
+	// Returns the Value that is mapped to the current type. Returns a zeroed Value if
+	// the Type has not been mapped.
+	Get(reflect.Type) reflect.Value
+}
+
+type injector struct {
+	values map[reflect.Type]reflect.Value
+	parent Injector
+}
+
+// InterfaceOf dereferences a pointer to an Interface type.
+// It panics if value is not an pointer to an interface.
+func InterfaceOf(value interface{}) reflect.Type {
+	t := reflect.TypeOf(value)
+
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+
+	if t.Kind() != reflect.Interface {
+		panic("Called inject.InterfaceOf with a value that is not a pointer to an interface. (*MyInterface)(nil)")
+	}
+
+	return t
+}
+
+// New returns a new Injector.
+func New() Injector {
+	return &injector{
+		values: make(map[reflect.Type]reflect.Value),
+	}
+}
+
+// Invoke attempts to call the interface{} provided as a function,
+// providing dependencies for function arguments based on Type.
+// Returns a slice of reflect.Value representing the returned values of the function.
+// Returns an error if the injection fails.
+// It panics if f is not a function
+func (inj *injector) Invoke(f interface{}) ([]reflect.Value, error) {
+	t := reflect.TypeOf(f)
+
+	var in = make([]reflect.Value, t.NumIn()) //Panic if t is not kind of Func
+	for i := 0; i < t.NumIn(); i++ {
+		argType := t.In(i)
+		val := inj.Get(argType)
+		if !val.IsValid() {
+			return nil, fmt.Errorf("Value not found for type %v", argType)
+		}
+
+		in[i] = val
+	}
+
+	return reflect.ValueOf(f).Call(in), nil
+}
+
+// Maps dependencies in the Type map to each field in the struct
+// that is tagged with 'inject'.
+// Returns an error if the injection fails.
+func (inj *injector) Apply(val interface{}) error {
+	v := reflect.ValueOf(val)
+
+	for v.Kind() == reflect.Ptr {
+		v = v.Elem()
+	}
+
+	if v.Kind() != reflect.Struct {
+		return nil // Should not panic here ?
+	}
+
+	t := v.Type()
+
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		structField := t.Field(i)
+		if f.CanSet() && (structField.Tag == "inject" || structField.Tag.Get("inject") != "") {
+			ft := f.Type()
+			v := inj.Get(ft)
+			if !v.IsValid() {
+				return fmt.Errorf("Value not found for type %v", ft)
+			}
+
+			f.Set(v)
+		}
+
+	}
+
+	return nil
+}
+
+// Maps the concrete value of val to its dynamic type using reflect.TypeOf,
+// It returns the TypeMapper registered in.
+func (i *injector) Map(val interface{}) TypeMapper {
+	i.values[reflect.TypeOf(val)] = reflect.ValueOf(val)
+	return i
+}
+
+func (i *injector) MapTo(val interface{}, ifacePtr interface{}) TypeMapper {
+	i.values[InterfaceOf(ifacePtr)] = reflect.ValueOf(val)
+	return i
+}
+
+// Maps the given reflect.Type to the given reflect.Value and returns
+// the Typemapper the mapping has been registered in.
+func (i *injector) Set(typ reflect.Type, val reflect.Value) TypeMapper {
+	i.values[typ] = val
+	return i
+}
+
+func (i *injector) Get(t reflect.Type) reflect.Value {
+	val := i.values[t]
+
+	if val.IsValid() {
+		return val
+	}
+
+	// no concrete types found, try to find implementors
+	// if t is an interface
+	if t.Kind() == reflect.Interface {
+		for k, v := range i.values {
+			if k.Implements(t) {
+				val = v
+				break
+			}
+		}
+	}
+
+	// Still no type found, try to look it up on the parent
+	if !val.IsValid() && i.parent != nil {
+		val = i.parent.Get(t)
+	}
+
+	return val
+
+}
+
+func (i *injector) SetParent(parent Injector) {
+	i.parent = parent
+}

--- a/vendor/github.com/codegangsta/inject/update_readme.sh
+++ b/vendor/github.com/codegangsta/inject/update_readme.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+go get github.com/robertkrimen/godocdown/godocdown
+godocdown > README.md

--- a/vendor/github.com/codeskyblue/go-sh/LICENSE
+++ b/vendor/github.com/codeskyblue/go-sh/LICENSE
@@ -1,0 +1,202 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/vendor/github.com/codeskyblue/go-sh/OLD_README.md
+++ b/vendor/github.com/codeskyblue/go-sh/OLD_README.md
@@ -1,0 +1,69 @@
+## OLD README
+First give you a full example, I will explain every command below.
+
+	session := sh.NewSession()
+	session.Env["PATH"] = "/usr/bin:/bin"
+	session.Stdout = os.Stdout
+	session.Stderr = os.Stderr
+	session.Alias("ll", "ls", "-l")
+	session.ShowCMD = true // enable for debug
+	var err error
+	err = session.Call("ll", "/")
+	if err != nil {
+		log.Fatal(err)
+	}
+	ret, err := session.Capture("pwd", sh.Dir("/home")) # wraper of session.Call
+	if err != nil {
+		log.Fatal(err)
+	}
+	# ret is "/home\n"
+	fmt.Println(ret)
+
+create a new Session
+
+	session := sh.NewSession()
+
+use alias like this
+
+	session.Alias("ll", "ls", "-l") # like alias ll='ls -l'
+
+set current env like this
+
+	session.Env["BUILD_ID"] = "123" # like export BUILD_ID=123
+
+set current directory
+
+	session.Set(sh.Dir("/")) # like cd /
+
+pipe is also supported
+
+	session.Command("echo", "hello\tworld").Command("cut", "-f2")
+	// output should be "world"
+	session.Run()
+
+test, the build in command support
+
+	session.Test("d", "dir") // test dir
+	session.Test("f", "file) // test regular file
+
+with `Alias Env Set Call Capture Command` a shell scripts can be easily converted into golang program. below is a shell script.
+
+	#!/bin/bash -
+	#
+	export PATH=/usr/bin:/bin
+	alias ll='ls -l'
+	cd /usr
+	if test -d "local"
+	then
+		ll local | awk '{print $1, $NF}'
+	fi
+
+convert to golang, will be
+
+	s := sh.NewSession()
+	s.Env["PATH"] = "/usr/bin:/bin"
+	s.Set(sh.Dir("/usr"))
+	s.Alias("ll", "ls", "-l")
+	if s.Test("d", "local") {
+		s.Command("ll", "local").Command("awk", "{print $1, $NF}").Run()
+	}

--- a/vendor/github.com/codeskyblue/go-sh/README.md
+++ b/vendor/github.com/codeskyblue/go-sh/README.md
@@ -1,0 +1,88 @@
+## go-sh
+[![wercker status](https://app.wercker.com/status/009acbd4f00ccc6de7e2554e12a50d84/s "wercker status")](https://app.wercker.com/project/bykey/009acbd4f00ccc6de7e2554e12a50d84)
+[![Go Walker](http://gowalker.org/api/v1/badge)](http://gowalker.org/github.com/codeskyblue/go-sh)
+
+*If you depend on the old api, see tag: v.0.1*
+
+install: `go get github.com/codeskyblue/go-sh`
+
+Pipe Example:
+
+	package main
+
+	import "github.com/codeskyblue/go-sh"
+
+	func main() {
+		sh.Command("echo", "hello\tworld").Command("cut", "-f2").Run()
+	}
+
+Because I like os/exec, `go-sh` is very much modelled after it. However, `go-sh` provides a better experience.
+
+These are some of its features:
+
+* keep the variable environment (e.g. export)
+* alias support (e.g. alias in shell)
+* remember current dir
+* pipe command
+* shell build-in commands echo & test
+* timeout support
+
+Examples are important:
+
+	sh: echo hello
+	go: sh.Command("echo", "hello").Run()
+
+	sh: export BUILD_ID=123
+	go: s = sh.NewSession().SetEnv("BUILD_ID", "123")
+
+	sh: alias ll='ls -l'
+	go: s = sh.NewSession().Alias('ll', 'ls', '-l')
+
+	sh: (cd /; pwd)
+	go: sh.Command("pwd", sh.Dir("/")).Run()
+
+	sh: test -d data || mkdir data
+	go: if ! sh.Test("dir", "data") { sh.Command("mkdir", "data").Run() }
+
+	sh: cat first second | awk '{print $1}'
+	go: sh.Command("cat", "first", "second").Command("awk", "{print $1}").Run()
+
+	sh: count=$(echo "one two three" | wc -w)
+	go: count, err := sh.Echo("one two three").Command("wc", "-w").Output()
+
+	sh(in ubuntu): timeout 1s sleep 3
+	go: c := sh.Command("sleep", "3"); c.Start(); c.WaitTimeout(time.Second) # default SIGKILL
+	go: out, err := sh.Command("sleep", "3").SetTimeout(time.Second).Output() # set session timeout and get output)
+
+	sh: echo hello | cat
+	go: out, err := sh.Command("cat").SetInput("hello").Output()
+
+	sh: cat # read from stdin
+	go: out, err := sh.Command("cat").SetStdin(os.Stdin).Output()
+
+	sh: ls -l > /tmp/listing.txt # write stdout to file
+	go: err := sh.Command("ls", "-l").WriteStdout("/tmp/listing.txt")
+
+If you need to keep env and dir, it is better to create a session
+
+	session := sh.NewSession()
+	session.SetEnv("BUILD_ID", "123")
+	session.SetDir("/")
+	# then call cmd
+	session.Command("echo", "hello").Run()
+	# set ShowCMD to true for easily debug
+	session.ShowCMD = true
+
+for more information, it better to see docs.
+[![Go Walker](http://gowalker.org/api/v1/badge)](http://gowalker.org/github.com/codeskyblue/go-sh)
+
+### contribute
+If you love this project, starring it will encourage the coder. Pull requests are welcome.
+
+support the author: [alipay](https://me.alipay.com/goskyblue)
+
+### thanks
+this project is based on <http://github.com/codegangsta/inject>. thanks for the author.
+
+# the reason to use Go shell
+Sometimes we need to write shell scripts, but shell scripts are not good at working cross platform,  Go, on the other hand, is good at that. Is there a good way to use Go to write shell like scripts? Using go-sh we can do this now.

--- a/vendor/github.com/codeskyblue/go-sh/pipe.go
+++ b/vendor/github.com/codeskyblue/go-sh/pipe.go
@@ -1,0 +1,163 @@
+package sh
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"syscall"
+	"time"
+)
+
+var ErrExecTimeout = errors.New("execute timeout")
+
+// unmarshal shell output to decode json
+func (s *Session) UnmarshalJSON(data interface{}) (err error) {
+	bufrw := bytes.NewBuffer(nil)
+	s.Stdout = bufrw
+	if err = s.Run(); err != nil {
+		return
+	}
+	return json.NewDecoder(bufrw).Decode(data)
+}
+
+// unmarshal command output into xml
+func (s *Session) UnmarshalXML(data interface{}) (err error) {
+	bufrw := bytes.NewBuffer(nil)
+	s.Stdout = bufrw
+	if err = s.Run(); err != nil {
+		return
+	}
+	return xml.NewDecoder(bufrw).Decode(data)
+}
+
+// start command
+func (s *Session) Start() (err error) {
+	s.started = true
+	var rd *io.PipeReader
+	var wr *io.PipeWriter
+	var length = len(s.cmds)
+	if s.ShowCMD {
+		var cmds = make([]string, 0, 4)
+		for _, cmd := range s.cmds {
+			cmds = append(cmds, strings.Join(cmd.Args, " "))
+		}
+		s.writePrompt(strings.Join(cmds, " | "))
+	}
+	for index, cmd := range s.cmds {
+		if index == 0 {
+			cmd.Stdin = s.Stdin
+		} else {
+			cmd.Stdin = rd
+		}
+		if index != length {
+			rd, wr = io.Pipe() // create pipe
+			cmd.Stdout = wr
+			cmd.Stderr = os.Stderr
+		}
+		if index == length-1 {
+			cmd.Stdout = s.Stdout
+			cmd.Stderr = s.Stderr
+		}
+		err = cmd.Start()
+		if err != nil {
+			return
+		}
+	}
+	return
+}
+
+// Should be call after Start()
+// only catch the last command error
+func (s *Session) Wait() (err error) {
+	for _, cmd := range s.cmds {
+		err = cmd.Wait()
+		wr, ok := cmd.Stdout.(*io.PipeWriter)
+		if ok {
+			wr.Close()
+		}
+	}
+	return err
+}
+
+func (s *Session) Kill(sig os.Signal) {
+	for _, cmd := range s.cmds {
+		if cmd.Process != nil {
+			cmd.Process.Signal(sig)
+		}
+	}
+}
+
+func (s *Session) WaitTimeout(timeout time.Duration) (err error) {
+	select {
+	case <-time.After(timeout):
+		s.Kill(syscall.SIGKILL)
+		return ErrExecTimeout
+	case err = <-Go(s.Wait):
+		return err
+	}
+}
+
+func Go(f func() error) chan error {
+	ch := make(chan error, 1)
+	go func() {
+		ch <- f()
+	}()
+	return ch
+}
+
+func (s *Session) Run() (err error) {
+	if err = s.Start(); err != nil {
+		return
+	}
+	if s.timeout != time.Duration(0) {
+		return s.WaitTimeout(s.timeout)
+	}
+	return s.Wait()
+}
+
+func (s *Session) Output() (out []byte, err error) {
+	oldout := s.Stdout
+	defer func() {
+		s.Stdout = oldout
+	}()
+	stdout := bytes.NewBuffer(nil)
+	s.Stdout = stdout
+	err = s.Run()
+	out = stdout.Bytes()
+	return
+}
+
+func (s *Session) WriteStdout(f string) error {
+	oldout := s.Stdout
+	defer func() {
+		s.Stdout = oldout
+	}()
+
+	out, err := os.Create(f)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	s.Stdout = out
+	return s.Run()
+}
+
+func (s *Session) CombinedOutput() (out []byte, err error) {
+	oldout := s.Stdout
+	olderr := s.Stderr
+	defer func() {
+		s.Stdout = oldout
+		s.Stderr = olderr
+	}()
+	stdout := bytes.NewBuffer(nil)
+	s.Stdout = stdout
+	s.Stderr = stdout
+
+	err = s.Run()
+	out = stdout.Bytes()
+	return
+}

--- a/vendor/github.com/codeskyblue/go-sh/sh.go
+++ b/vendor/github.com/codeskyblue/go-sh/sh.go
@@ -1,0 +1,200 @@
+/*
+Package go-sh is intended to make shell call with golang more easily.
+Some usage is more similar to os/exec, eg: Run(), Output(), Command(name, args...)
+
+But with these similar function, pipe is added in and this package also got shell-session support.
+
+Why I love golang so much, because the usage of golang is simple, but the power is unlimited. I want to make this pakcage got the sample style like golang.
+
+	// just like os/exec
+	sh.Command("echo", "hello").Run()
+
+	// support pipe
+	sh.Command("echo", "hello").Command("wc", "-c").Run()
+
+	// create a session to store dir and env
+	sh.NewSession().SetDir("/").Command("pwd")
+
+	// shell buildin command - "test"
+	sh.Test("dir", "mydir")
+
+	// like shell call: (cd /; pwd)
+	sh.Command("pwd", sh.Dir("/")) same with sh.Command(sh.Dir("/"), "pwd")
+
+	// output to json and xml easily
+	v := map[string] int {}
+	err = sh.Command("echo", `{"number": 1}`).UnmarshalJSON(&v)
+*/
+package sh
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/codegangsta/inject"
+)
+
+type Dir string
+
+type Session struct {
+	inj     inject.Injector
+	alias   map[string][]string
+	cmds    []*exec.Cmd
+	dir     Dir
+	started bool
+	Env     map[string]string
+	Stdin   io.Reader
+	Stdout  io.Writer
+	Stderr  io.Writer
+	ShowCMD bool // enable for debug
+	timeout time.Duration
+}
+
+func (s *Session) writePrompt(args ...interface{}) {
+	var ps1 = fmt.Sprintf("[golang-sh]$")
+	args = append([]interface{}{ps1}, args...)
+	fmt.Fprintln(s.Stderr, args...)
+}
+
+func NewSession() *Session {
+	env := make(map[string]string)
+	for _, key := range []string{"PATH"} {
+		env[key] = os.Getenv(key)
+	}
+	s := &Session{
+		inj:    inject.New(),
+		alias:  make(map[string][]string),
+		dir:    Dir(""),
+		Stdin:  strings.NewReader(""),
+		Stdout: os.Stdout,
+		Stderr: os.Stderr,
+		Env:    env,
+	}
+	return s
+}
+
+func InteractiveSession() *Session {
+	s := NewSession()
+	s.SetStdin(os.Stdin)
+	return s
+}
+
+func Command(name string, a ...interface{}) *Session {
+	s := NewSession()
+	return s.Command(name, a...)
+}
+
+func Echo(in string) *Session {
+	s := NewSession()
+	return s.SetInput(in)
+}
+
+func (s *Session) Alias(alias, cmd string, args ...string) {
+	v := []string{cmd}
+	v = append(v, args...)
+	s.alias[alias] = v
+}
+
+func (s *Session) Command(name string, a ...interface{}) *Session {
+	var args = make([]string, 0)
+	var sType = reflect.TypeOf("")
+
+	// init cmd, args, dir, envs
+	// if not init, program may panic
+	s.inj.Map(name).Map(args).Map(s.dir).Map(map[string]string{})
+	for _, v := range a {
+		switch reflect.TypeOf(v) {
+		case sType:
+			args = append(args, v.(string))
+		default:
+			s.inj.Map(v)
+		}
+	}
+	if len(args) != 0 {
+		s.inj.Map(args)
+	}
+	s.inj.Invoke(s.appendCmd)
+	return s
+}
+
+// combine Command and Run
+func (s *Session) Call(name string, a ...interface{}) error {
+	return s.Command(name, a...).Run()
+}
+
+/*
+func (s *Session) Exec(cmd string, args ...string) error {
+	return s.Call(cmd, args)
+}
+*/
+
+func (s *Session) SetEnv(key, value string) *Session {
+	s.Env[key] = value
+	return s
+}
+
+func (s *Session) SetDir(dir string) *Session {
+	s.dir = Dir(dir)
+	return s
+}
+
+func (s *Session) SetInput(in string) *Session {
+	s.Stdin = strings.NewReader(in)
+	return s
+}
+
+func (s *Session) SetStdin(r io.Reader) *Session {
+	s.Stdin = r
+	return s
+}
+
+func (s *Session) SetTimeout(d time.Duration) *Session {
+	s.timeout = d
+	return s
+}
+
+func newEnviron(env map[string]string, inherit bool) []string { //map[string]string {
+	environ := make([]string, 0, len(env))
+	if inherit {
+		for _, line := range os.Environ() {
+			for k, _ := range env {
+				if strings.HasPrefix(line, k+"=") {
+					goto CONTINUE
+				}
+			}
+			environ = append(environ, line)
+		CONTINUE:
+		}
+	}
+	for k, v := range env {
+		environ = append(environ, k+"="+v)
+	}
+	return environ
+}
+
+func (s *Session) appendCmd(cmd string, args []string, cwd Dir, env map[string]string) {
+	if s.started {
+		s.started = false
+		s.cmds = make([]*exec.Cmd, 0)
+	}
+	for k, v := range s.Env {
+		if _, ok := env[k]; !ok {
+			env[k] = v
+		}
+	}
+	environ := newEnviron(s.Env, true) // true: inherit sys-env
+	v, ok := s.alias[cmd]
+	if ok {
+		cmd = v[0]
+		args = append(v[1:], args...)
+	}
+	c := exec.Command(cmd, args...)
+	c.Env = environ
+	c.Dir = string(cwd)
+	s.cmds = append(s.cmds, c)
+}

--- a/vendor/github.com/codeskyblue/go-sh/test.go
+++ b/vendor/github.com/codeskyblue/go-sh/test.go
@@ -1,0 +1,64 @@
+package sh
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func filetest(name string, modemask os.FileMode) (match bool, err error) {
+	fi, err := os.Stat(name)
+	if err != nil {
+		return
+	}
+	match = (fi.Mode() & modemask) == modemask
+	return
+}
+
+func (s *Session) pwd() string {
+	dir := string(s.dir)
+	if dir == "" {
+		dir, _ = os.Getwd()
+	}
+	return dir
+}
+
+func (s *Session) abspath(name string) string {
+	if filepath.IsAbs(name) {
+		return name
+	}
+	return filepath.Join(s.pwd(), name)
+}
+
+func init() {
+	//log.SetFlags(log.Lshortfile | log.LstdFlags)
+}
+
+// expression can be dir, file, link
+func (s *Session) Test(expression string, argument string) bool {
+	var err error
+	var fi os.FileInfo
+	fi, err = os.Lstat(s.abspath(argument))
+	switch expression {
+	case "d", "dir":
+		return err == nil && fi.IsDir()
+	case "f", "file":
+		return err == nil && fi.Mode().IsRegular()
+	case "x", "executable":
+		/*
+			fmt.Println(expression, argument)
+			if err == nil {
+				fmt.Println(fi.Mode())
+			}
+		*/
+		return err == nil && fi.Mode()&os.FileMode(0100) != 0
+	case "L", "link":
+		return err == nil && fi.Mode()&os.ModeSymlink != 0
+	}
+	return false
+}
+
+// expression can be d,dir, f,file, link
+func Test(exp string, arg string) bool {
+	s := NewSession()
+	return s.Test(exp, arg)
+}

--- a/vendor/github.com/codeskyblue/go-sh/wercker.yml
+++ b/vendor/github.com/codeskyblue/go-sh/wercker.yml
@@ -1,0 +1,28 @@
+box: wercker/golang
+# Build definition
+build:
+  # The steps that will be executed on build
+  steps:
+    # Sets the go workspace and places you package
+    # at the right place in the workspace tree
+    - setup-go-workspace
+
+    # Gets the dependencies
+    - script:
+        name: go get
+        code: |
+          cd $WERCKER_SOURCE_DIR
+          go version
+          go get -t .
+
+    # Build the project
+    - script:
+        name: go build
+        code: |
+          go build .
+
+    # Test the project
+    - script:
+        name: go test
+        code: |
+          go test -v ./...

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -207,6 +207,18 @@
 			"revisionTime": "2016-03-26T22:39:47Z"
 		},
 		{
+			"checksumSHA1": "fcfxNsCuheCrubAAl6zWgimCnLY=",
+			"path": "github.com/codegangsta/inject",
+			"revision": "33e0aa1cb7c019ccc3fbe049a8262a6403d30504",
+			"revisionTime": "2015-01-14T23:56:00Z"
+		},
+		{
+			"checksumSHA1": "6OZKBZbJ2yrRjgS3cb9hICh7w5M=",
+			"path": "github.com/codeskyblue/go-sh",
+			"revision": "cf804ac79dffabb6b16342e24362cc744afc144f",
+			"revisionTime": "2017-12-28T01:44:52Z"
+		},
+		{
 			"checksumSHA1": "BKQRkbPMH3shDkfWGs+sx07n0gI=",
 			"path": "github.com/container-storage-interface/spec/lib/go/csi",
 			"revision": "35d9f9d77954980e449e52c3f3e43c21bd8171f5",


### PR DESCRIPTION
**What this PR does / why we need it**:

Use `nvme list` command to fetch the nvme drives.

- The current way of determining the nvme drive name is not reliable as
  the drive names might change due to different AMI types. Also the current logic
  breaks if an existing drive on the instance has a non-standard names such as /dev/xvdcn
- Instead use `nvme list` command to reliably get the mapping between EBS volumeID and a nvme drive.


Here is a sample output of `nvme list` command.

```
root@ip-172-20-52-215:/# nvme list
Node             SN                   Model                                    Namespace Usage                      Format           FW Rev
---------------- -------------------- ---------------------------------------- --------- -------------------------- ---------------- --------
/dev/nvme0n1     vol05ce9829d6b2d3a21 Amazon Elastic Block Store               1           0.00   B / 137.44  GB    512   B +  0 B   1.0
/dev/nvme3n1     vol055b3ae393bfc407b Amazon Elastic Block Store               1           0.00   B /  17.18  GB    512   B +  0 B   1.0
/dev/nvme2n1     vol0401d9e335cae567d Amazon Elastic Block Store               1           0.00   B /   8.59  GB    512   B +  0 B   1.0
/dev/nvme1n1     vol067baf02ad3ecd9fd Amazon Elastic Block Store               1           0.00   B / 107.37  GB    512   B +  0 B   1.0
```
**Special notes for your reviewer**:

