### PR TITLE
Add retry loop to Request if Service Unavailable. Default wait is 1 second

### DIFF
--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -1,0 +1,30 @@
+package client
+
+import (
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestRetryClient(t *testing.T) {
+	count := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if count == 0 {
+			count++
+			w.Header().Add("Retry-After", "5")
+			http.Error(w, "Unavailable", http.StatusServiceUnavailable)
+		}
+	}))
+
+	defer ts.Close()
+
+	clnt, _ := NewClient(ts.URL, "pxd", "")
+
+	start := time.Now()
+	clnt.Get().Resource("").Do()
+	now := time.Now()
+	elapsed := now.Sub(start)
+	require.True(t, elapsed >= time.Duration(5*time.Second))
+}


### PR DESCRIPTION
Signed-off-by: Paul <paul@portworx.com>

**What this PR does / why we need it**:
Currently, the client always exits upon receiving service unavailable.
This code change will retry until success and wait for 1 second or amount of seconds suggested in the Retry-After header

This way we can limit the number of connections on the server and ask the client to retry if the queue is full.

