### PR TITLE
sdk: Credentials now use map[string]interface{}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   - git-validation -run DCO,short-subject
   - go fmt $(go list ./... | grep -v vendor) | wc -l | grep 0
   - make docker-proto
-  - git diff $(find . -name "*.pb.*go" | grep -v vendor) | wc -l | grep "^0"
+  - git diff $(find . -name "*.pb.*go" -o -name "api.swagger.json" | grep -v vendor) | wc -l | grep "^0"
   - make install
   - make vet
   - make docker-test

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ endif
 
 test-sdk: install-sdk-test launch-sdk
 	timeout 30 sh -c 'until curl --silent -X GET -d {} http://localhost:9110/v1/clusters/current | grep STATUS_OK; do sleep 1; done'
-	sdk-test -ginkgo.noColor -ginkgo.noisySkippings=false -sdk.endpoint=localhost:9100
+	sdk-test -ginkgo.noColor -ginkgo.noisySkippings=false -sdk.endpoint=localhost:9100 -sdk.cpg=$(GOPATH)/src/github.com/libopenstorage/sdk-test/cmd/sdk-test/cb.yaml
 
 test: packr
 	go test -tags "$(TAGS)" $(TESTFLAGS) $(PKGS)

--- a/api/server/sdk/api/api.swagger.json
+++ b/api/server/sdk/api/api.swagger.json
@@ -1482,7 +1482,8 @@
         "FS_TYPE_NFS",
         "FS_TYPE_VFS",
         "FS_TYPE_XFS",
-        "FS_TYPE_ZFS"
+        "FS_TYPE_ZFS",
+        "FS_TYPE_XFSv2"
       ],
       "default": "FS_TYPE_NONE"
     },

--- a/api/server/sdk/credentials_test.go
+++ b/api/server/sdk/credentials_test.go
@@ -502,7 +502,7 @@ func TestSdkCredentialEnumerate(t *testing.T) {
 
 	req := &api.SdkCredentialEnumerateRequest{}
 
-	enumS3test1 := map[string]string{
+	enumS3test1 := map[string]interface{}{
 		api.OptCredType:      "s3",
 		api.OptCredAccessKey: "test-access",
 		api.OptCredSecretKey: "test-secret",
@@ -510,7 +510,7 @@ func TestSdkCredentialEnumerate(t *testing.T) {
 		api.OptCredRegion:    "test-region",
 	}
 
-	enumS3test2 := map[string]string{
+	enumS3test2 := map[string]interface{}{
 		api.OptCredType:      "s3",
 		api.OptCredAccessKey: "test-access1",
 		api.OptCredSecretKey: "test-secret1",
@@ -518,7 +518,7 @@ func TestSdkCredentialEnumerate(t *testing.T) {
 		api.OptCredRegion:    "test-region1",
 	}
 
-	enumAzure := map[string]string{
+	enumAzure := map[string]interface{}{
 		api.OptCredType:             "azure",
 		api.OptCredAzureAccountName: "test-azure-account",
 		api.OptCredAzureAccountKey:  "test-azure-account",
@@ -557,7 +557,7 @@ func TestSdkCredentialInspectIdNotFound(t *testing.T) {
 		CredentialId: "test",
 	}
 
-	enumS3 := map[string]string{
+	enumS3 := map[string]interface{}{
 		api.OptCredType:      "s3",
 		api.OptCredAccessKey: "test-access",
 		api.OptCredSecretKey: "test-secret",
@@ -565,13 +565,13 @@ func TestSdkCredentialInspectIdNotFound(t *testing.T) {
 		api.OptCredRegion:    "test-region",
 	}
 
-	enumAzure := map[string]string{
+	enumAzure := map[string]interface{}{
 		api.OptCredType:             "azure",
 		api.OptCredAzureAccountName: "test-azure-account",
 		api.OptCredAzureAccountKey:  "test-azure-account",
 	}
 
-	enumGoogle := map[string]string{
+	enumGoogle := map[string]interface{}{
 		api.OptCredType:            "google",
 		api.OptCredGoogleProjectID: "test-google-project-id",
 	}
@@ -631,7 +631,7 @@ func TestSdkCredentialInspect(t *testing.T) {
 		CredentialId: uuid,
 	}
 
-	enumAzure := map[string]string{
+	enumAzure := map[string]interface{}{
 		api.OptCredType:             "azure",
 		api.OptCredName:             "test",
 		api.OptCredAzureAccountName: "test-azure-account",

--- a/volume/drivers/fake/fake.go
+++ b/volume/drivers/fake/fake.go
@@ -59,7 +59,7 @@ type driver struct {
 
 type fakeCred struct {
 	Id     string
-	Params map[string]string
+	Params map[string]interface{}
 }
 
 type fakeBackups struct {
@@ -357,10 +357,15 @@ func (d *driver) CredsCreate(
 	params map[string]string,
 ) (string, error) {
 
+	// Convert types
+	converted := make(map[string]interface{})
+	for k, v := range params {
+		converted[k] = v
+	}
 	id := uuid.New()
 	_, err := d.kv.Put(credsKeyPrefix+"/"+id, &fakeCred{
 		Id:     id,
-		Params: params,
+		Params: converted,
 	}, 0)
 	if err != nil {
 		return "", err

--- a/volume/drivers/fake/fake_test.go
+++ b/volume/drivers/fake/fake_test.go
@@ -67,10 +67,10 @@ func TestFakeCredentials(t *testing.T) {
 	assert.Len(t, creds, 1)
 
 	data := creds[id]
-	value, ok := data.(map[string]string)
+	value, ok := data.(map[string]interface{})
 	assert.True(t, ok)
 	assert.NotEmpty(t, value)
-	assert.Equal(t, value["hello"], "world")
+	assert.Equal(t, value["hello"].(string), "world")
 
 	err = d.CredsDelete(id)
 	assert.NoError(t, err)


### PR DESCRIPTION
**What this PR does / why we need it**:
SDK was incorrectly using map[string]string when it should be using map[string]interface{}

**Which issue(s) this PR fixes** (optional)
Closes #583


**Special notes for your reviewer**:
api.swagger.json needed to be rebuilt to make sure it is at the latest. I also added a test for this in travis to check this from now on.
