### PR TITLE
Return VolNotFound if disk in not present in gcloud

### DIFF
--- a/pkg/storageops/storageops.go
+++ b/pkg/storageops/storageops.go
@@ -18,6 +18,8 @@ const (
 	// ErrVolAttachedOnRemoteNode is code when a volume is not attached locally
 	// but attached on a remote node
 	ErrVolAttachedOnRemoteNode
+	// ErrVolNotFound is code when a volume is not found
+	ErrVolNotFound
 )
 
 // ErrNotSupported is returned when a particular operation is not supported


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Need to handle NotFound error explicitly,
so that client know that the drive is not present.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

