### PR TITLE
Add a new NULL implementation for Cluster interface.

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -29,6 +29,7 @@ var (
 		"could not be found in the cluster map.")
 	ErrNodeDecommissioned   = errors.New("Node is decomissioned.")
 	ErrRemoveCausesDataLoss = errors.New("Cannot remove node without data loss")
+	ErrNotImplemented       = errors.New("Not Implemented")
 )
 
 // ClusterServerConfiguration holds manager implementation

--- a/cluster/cluster_not_supported.go
+++ b/cluster/cluster_not_supported.go
@@ -1,0 +1,255 @@
+package cluster
+
+import (
+	time "time"
+
+	api "github.com/libopenstorage/openstorage/api"
+	osdconfig "github.com/libopenstorage/openstorage/osdconfig"
+	schedpolicy "github.com/libopenstorage/openstorage/schedpolicy"
+)
+
+// ClusterNotSupported is a NULL implementation of the Cluster interface
+// It is primarily used for testing the ClusterManager as well as the
+// ClusterListener interface
+type ClusterNotSupported struct {
+}
+
+// AddEventListener
+func (m *ClusterNotSupported) AddEventListener(arg0 ClusterListener) error {
+	return nil
+}
+
+// ClearAlert
+func (m *ClusterNotSupported) ClearAlert(arg0 api.ResourceType, arg1 int64) error {
+	return nil
+}
+
+// CreatePair
+func (m *ClusterNotSupported) CreatePair(arg0 *api.ClusterPairCreateRequest) (*api.ClusterPairCreateResponse, error) {
+	return nil, nil
+}
+
+// DeleteNodeConf
+func (m *ClusterNotSupported) DeleteNodeConf(arg0 string) error {
+	return nil
+}
+
+// DeletePair
+func (m *ClusterNotSupported) DeletePair(arg0 string) error {
+	return nil
+}
+
+// DisableUpdates
+func (m *ClusterNotSupported) DisableUpdates() error {
+	return nil
+}
+
+// EnableUpdates
+func (m *ClusterNotSupported) EnableUpdates() error {
+	return nil
+}
+
+// Enumerate
+func (m *ClusterNotSupported) Enumerate() (api.Cluster, error) {
+	return api.Cluster{}, nil
+}
+
+// EnumerateAlerts
+func (m *ClusterNotSupported) EnumerateAlerts(arg0, arg1 time.Time, arg2 api.ResourceType) (*api.Alerts, error) {
+	return nil, nil
+}
+
+// EnumerateNodeConf
+func (m *ClusterNotSupported) EnumerateNodeConf() (*osdconfig.NodesConfig, error) {
+	return nil, nil
+}
+
+// EnumeratePairs
+func (m *ClusterNotSupported) EnumeratePairs() (*api.ClusterPairsEnumerateResponse, error) {
+	return nil, nil
+}
+
+// EraseAlert
+func (m *ClusterNotSupported) EraseAlert(arg0 api.ResourceType, arg1 int64) error {
+	return nil
+}
+
+// GetClusterConf
+func (m *ClusterNotSupported) GetClusterConf() (*osdconfig.ClusterConfig, error) {
+	return nil, nil
+}
+
+// GetData
+func (m *ClusterNotSupported) GetData() (map[string]*api.Node, error) {
+	return nil, nil
+}
+
+// GetGossipState
+func (m *ClusterNotSupported) GetGossipState() *ClusterState {
+	return nil
+}
+
+// GetNodeConf
+func (m *ClusterNotSupported) GetNodeConf(arg0 string) (*osdconfig.NodeConfig, error) {
+	return nil, nil
+}
+
+// GetNodeIdFromIp
+func (m *ClusterNotSupported) GetNodeIdFromIp(arg0 string) (string, error) {
+	return "", nil
+}
+
+// GetPair
+func (m *ClusterNotSupported) GetPair(arg0 string) (*api.ClusterPairGetResponse, error) {
+	return nil, nil
+}
+
+// GetPairToken
+func (m *ClusterNotSupported) GetPairToken(arg0 bool) (*api.ClusterPairTokenGetResponse, error) {
+	return nil, nil
+}
+
+// Inspect
+func (m *ClusterNotSupported) Inspect(arg0 string) (api.Node, error) {
+	return api.Node{}, nil
+}
+
+// NodeRemoveDone
+func (m *ClusterNotSupported) NodeRemoveDone(arg0 string, arg1 error) {
+	return
+}
+
+// NodeStatus
+func (m *ClusterNotSupported) NodeStatus() (api.Status, error) {
+	return api.Status_STATUS_NONE, nil
+}
+
+// ObjectStoreCreate
+func (m *ClusterNotSupported) ObjectStoreCreate(arg0 string) (*api.ObjectstoreInfo, error) {
+	return nil, nil
+}
+
+// ObjectStoreDelete
+func (m *ClusterNotSupported) ObjectStoreDelete(arg0 string) error {
+	return nil
+}
+
+// ObjectStoreInspect
+func (m *ClusterNotSupported) ObjectStoreInspect(arg0 string) (*api.ObjectstoreInfo, error) {
+	return nil, nil
+}
+
+// ObjectStoreUpdate
+func (m *ClusterNotSupported) ObjectStoreUpdate(arg0 string, arg1 bool) error {
+	return nil
+}
+
+// PeerStatus
+func (m *ClusterNotSupported) PeerStatus(arg0 string) (map[string]api.Status, error) {
+	return nil, nil
+}
+
+// ProcessPairRequest
+func (m *ClusterNotSupported) ProcessPairRequest(arg0 *api.ClusterPairProcessRequest) (*api.ClusterPairProcessResponse, error) {
+	return nil, nil
+}
+
+// Remove
+func (m *ClusterNotSupported) Remove(arg0 []api.Node, arg1 bool) error {
+	return nil
+}
+
+// SchedPolicyCreate
+func (m *ClusterNotSupported) SchedPolicyCreate(arg0, arg1 string) error {
+	return nil
+}
+
+// SchedPolicyDelete
+func (m *ClusterNotSupported) SchedPolicyDelete(arg0 string) error {
+	return nil
+}
+
+// SchedPolicyEnumerate
+func (m *ClusterNotSupported) SchedPolicyEnumerate() ([]*schedpolicy.SchedPolicy, error) {
+	return nil, nil
+}
+
+// SchedPolicyGet
+func (m *ClusterNotSupported) SchedPolicyGet(arg0 string) (*schedpolicy.SchedPolicy, error) {
+	return nil, nil
+}
+
+// SchedPolicyUpdate
+func (m *ClusterNotSupported) SchedPolicyUpdate(arg0, arg1 string) error {
+	return nil
+}
+
+// SecretCheckLogin
+func (m *ClusterNotSupported) SecretCheckLogin() error {
+	return nil
+}
+
+// SecretGet
+func (m *ClusterNotSupported) SecretGet(arg0 string) (interface{}, error) {
+	return nil, nil
+}
+
+// SecretGetDefaultSecretKey
+func (m *ClusterNotSupported) SecretGetDefaultSecretKey() (interface{}, error) {
+	return nil, nil
+}
+
+// SecretLogin
+func (m *ClusterNotSupported) SecretLogin(arg0 string, arg1 map[string]string) error {
+	return nil
+}
+
+// SecretSet
+func (m *ClusterNotSupported) SecretSet(arg0 string, arg1 interface{}) error {
+	return nil
+}
+
+// SecretSetDefaultSecretKey
+func (m *ClusterNotSupported) SecretSetDefaultSecretKey(arg0 string, arg1 bool) error {
+	return nil
+}
+
+// SetClusterConf
+func (m *ClusterNotSupported) SetClusterConf(arg0 *osdconfig.ClusterConfig) error {
+	return nil
+}
+
+// SetNodeConf
+func (m *ClusterNotSupported) SetNodeConf(arg0 *osdconfig.NodeConfig) error {
+	return nil
+}
+
+// SetSize
+func (m *ClusterNotSupported) SetSize(arg0 int) error {
+	return nil
+}
+
+// Shutdown
+func (m *ClusterNotSupported) Shutdown() error {
+	return nil
+}
+
+// Start
+func (m *ClusterNotSupported) Start(arg0 int, arg1 bool, arg2 string) error {
+	return nil
+}
+
+// StartWithConfiguration
+func (m *ClusterNotSupported) StartWithConfiguration(arg0 int, arg1 bool, arg2 string, arg3 *ClusterServerConfiguration) error {
+	return nil
+}
+
+// UpdateData
+func (m *ClusterNotSupported) UpdateData(arg0 map[string]interface{}) error {
+	return nil
+}
+
+// UpdateLabels
+func (m *ClusterNotSupported) UpdateLabels(arg0 map[string]string) error {
+	return nil
+}

--- a/cluster/cluster_not_supported.go
+++ b/cluster/cluster_not_supported.go
@@ -4,252 +4,214 @@ import (
 	time "time"
 
 	api "github.com/libopenstorage/openstorage/api"
-	osdconfig "github.com/libopenstorage/openstorage/osdconfig"
+	"github.com/libopenstorage/openstorage/objectstore"
+	"github.com/libopenstorage/openstorage/osdconfig"
 	schedpolicy "github.com/libopenstorage/openstorage/schedpolicy"
+	"github.com/libopenstorage/openstorage/secrets"
 )
 
-// nullClusterMgr is a NULL implementation of the Cluster interface
+// NullClusterManager is a NULL implementation of the Cluster interface
 // It is primarily used for testing the ClusterManager as well as the
 // ClusterListener interface
-type NullClusterMgr struct {
+type NullClusterManager struct {
+	NullClusterData
+	NullClusterRemove
+	NullClusterStatus
+	NullClusterAlerts
+	NullClusterPair
+	osdconfig.NullConfigCaller
+	secrets.NullSecrets
+	schedpolicy.NullSchedMgr
+	objectstore.NullObjectStoreMgr
 }
 
-// AddEventListener
-func (m *NullClusterMgr) AddEventListener(arg0 ClusterListener) error {
-	return nil
+func NewDefaultClusterManager() Cluster {
+	return &NullClusterManager{}
 }
 
-// ClearAlert
-func (m *NullClusterMgr) ClearAlert(arg0 api.ResourceType, arg1 int64) error {
-	return ErrNotImplemented
+// NullClusterData is a NULL implementation of the ClusterData interface
+type NullClusterData struct {
 }
 
-// CreatePair
-func (m *NullClusterMgr) CreatePair(arg0 *api.ClusterPairCreateRequest) (*api.ClusterPairCreateResponse, error) {
-	return nil, ErrNotImplemented
+func NewDefaultClusterData() ClusterData {
+	return &NullClusterData{}
 }
 
-// DeleteNodeConf
-func (m *NullClusterMgr) DeleteNodeConf(arg0 string) error {
-	return ErrNotImplemented
+// NullClusterRemove is a NULL implementation of the ClusterRemove interface
+type NullClusterRemove struct {
 }
 
-// DeletePair
-func (m *NullClusterMgr) DeletePair(arg0 string) error {
-	return ErrNotImplemented
+func NewDefaultClusterRemove() ClusterRemove {
+	return &NullClusterRemove{}
 }
 
-// DisableUpdates
-func (m *NullClusterMgr) DisableUpdates() error {
-	return ErrNotImplemented
+// NullClusterStatus is a NULL implementation of the ClusterStatus interface
+type NullClusterStatus struct {
 }
 
-// EnableUpdates
-func (m *NullClusterMgr) EnableUpdates() error {
-	return ErrNotImplemented
+func NewDefaultClusterStatus() ClusterStatus {
+	return &NullClusterStatus{}
 }
 
-// Enumerate
-func (m *NullClusterMgr) Enumerate() (api.Cluster, error) {
-	return api.Cluster{}, ErrNotImplemented
+// NullClusterAlerts is a NULL implementation of the ClusterAlerts interface
+type NullClusterAlerts struct {
 }
 
-// EnumerateAlerts
-func (m *NullClusterMgr) EnumerateAlerts(arg0, arg1 time.Time, arg2 api.ResourceType) (*api.Alerts, error) {
-	return nil, ErrNotImplemented
+func NewDefaultClusterAlerts() ClusterAlerts {
+	return &NullClusterAlerts{}
 }
 
-// EnumerateNodeConf
-func (m *NullClusterMgr) EnumerateNodeConf() (*osdconfig.NodesConfig, error) {
-	return nil, ErrNotImplemented
+// NullClusterPair is a NULL implementation of the ClusterPair interface
+type NullClusterPair struct {
 }
 
-// EnumeratePairs
-func (m *NullClusterMgr) EnumeratePairs() (*api.ClusterPairsEnumerateResponse, error) {
-	return nil, ErrNotImplemented
+func NewDefaultCluterPair() ClusterPair {
+	return &NullClusterPair{}
 }
 
-// EraseAlert
-func (m *NullClusterMgr) EraseAlert(arg0 api.ResourceType, arg1 int64) error {
-	return ErrNotImplemented
-}
-
-// GetClusterConf
-func (m *NullClusterMgr) GetClusterConf() (*osdconfig.ClusterConfig, error) {
-	return nil, ErrNotImplemented
-}
-
-// GetData
-func (m *NullClusterMgr) GetData() (map[string]*api.Node, error) {
-	return nil, ErrNotImplemented
-}
-
-// GetGossipState
-func (m *NullClusterMgr) GetGossipState() *ClusterState {
-	return nil
-}
-
-// GetNodeConf
-func (m *NullClusterMgr) GetNodeConf(arg0 string) (*osdconfig.NodeConfig, error) {
-	return nil, ErrNotImplemented
-}
-
-// GetNodeIdFromIp
-func (m *NullClusterMgr) GetNodeIdFromIp(arg0 string) (string, error) {
-	return "", ErrNotImplemented
-}
-
-// GetPair
-func (m *NullClusterMgr) GetPair(arg0 string) (*api.ClusterPairGetResponse, error) {
-	return nil, ErrNotImplemented
-}
-
-// GetPairToken
-func (m *NullClusterMgr) GetPairToken(arg0 bool) (*api.ClusterPairTokenGetResponse, error) {
-	return nil, ErrNotImplemented
-}
+// NullClusterManager implementations
 
 // Inspect
-func (m *NullClusterMgr) Inspect(arg0 string) (api.Node, error) {
+func (m *NullClusterManager) Inspect(arg0 string) (api.Node, error) {
 	return api.Node{}, ErrNotImplemented
 }
 
-// NodeRemoveDone
-func (m *NullClusterMgr) NodeRemoveDone(arg0 string, arg1 error) {
-	return
+// AddEventListener
+func (m *NullClusterManager) AddEventListener(arg0 ClusterListener) error {
+	return nil
 }
 
-// Nodestatus
-func (m *NullClusterMgr) NodeStatus() (api.Status, error) {
-	return api.Status_STATUS_NONE, ErrNotImplemented
-}
-
-// ObjectStoreCreate
-func (m *NullClusterMgr) ObjectStoreCreate(arg0 string) (*api.ObjectstoreInfo, error) {
-	return nil, ErrNotImplemented
-}
-
-// ObjectStoreDelete
-func (m *NullClusterMgr) ObjectStoreDelete(arg0 string) error {
-	return ErrNotImplemented
-}
-
-// ObjectStoreInspect
-func (m *NullClusterMgr) ObjectStoreInspect(arg0 string) (*api.ObjectstoreInfo, error) {
-	return nil, ErrNotImplemented
-}
-
-// ObjectStoreUpdate
-func (m *NullClusterMgr) ObjectStoreUpdate(arg0 string, arg1 bool) error {
-	return ErrNotImplemented
-}
-
-// PeerStatus
-func (m *NullClusterMgr) PeerStatus(arg0 string) (map[string]api.Status, error) {
-	return nil, ErrNotImplemented
-}
-
-// ProcessPairRequest
-func (m *NullClusterMgr) ProcessPairRequest(arg0 *api.ClusterPairProcessRequest) (*api.ClusterPairProcessResponse, error) {
-	return nil, ErrNotImplemented
-}
-
-// Remove
-func (m *NullClusterMgr) Remove(arg0 []api.Node, arg1 bool) error {
-	return ErrNotImplemented
-}
-
-// SchedPolicyCreate
-func (m *NullClusterMgr) SchedPolicyCreate(arg0, arg1 string) error {
-	return ErrNotImplemented
-}
-
-// SchedPolicyDelete
-func (m *NullClusterMgr) SchedPolicyDelete(arg0 string) error {
-	return ErrNotImplemented
-}
-
-// SchedPolicyEnumerate
-func (m *NullClusterMgr) SchedPolicyEnumerate() ([]*schedpolicy.SchedPolicy, error) {
-	return nil, ErrNotImplemented
-}
-
-// SchedPolicyGet
-func (m *NullClusterMgr) SchedPolicyGet(arg0 string) (*schedpolicy.SchedPolicy, error) {
-	return nil, ErrNotImplemented
-}
-
-// SchedPolicyUpdate
-func (m *NullClusterMgr) SchedPolicyUpdate(arg0, arg1 string) error {
-	return ErrNotImplemented
-}
-
-// SecretCheckLogin
-func (m *NullClusterMgr) SecretCheckLogin() error {
-	return ErrNotImplemented
-}
-
-// SecretGet
-func (m *NullClusterMgr) SecretGet(arg0 string) (interface{}, error) {
-	return nil, ErrNotImplemented
-}
-
-// SecretGetDefaultSecretKey
-func (m *NullClusterMgr) SecretGetDefaultSecretKey() (interface{}, error) {
-	return nil, ErrNotImplemented
-}
-
-// SecretLogin
-func (m *NullClusterMgr) SecretLogin(arg0 string, arg1 map[string]string) error {
-	return ErrNotImplemented
-}
-
-// SecretSet
-func (m *NullClusterMgr) SecretSet(arg0 string, arg1 interface{}) error {
-	return ErrNotImplemented
-}
-
-// SecretSetDefaultSecretKey
-func (m *NullClusterMgr) SecretSetDefaultSecretKey(arg0 string, arg1 bool) error {
-	return ErrNotImplemented
-}
-
-// SetClusterConf
-func (m *NullClusterMgr) SetClusterConf(arg0 *osdconfig.ClusterConfig) error {
-	return ErrNotImplemented
-}
-
-// SetNodeConf
-func (m *NullClusterMgr) SetNodeConf(arg0 *osdconfig.NodeConfig) error {
-	return ErrNotImplemented
+// Enumerate
+func (m *NullClusterManager) Enumerate() (api.Cluster, error) {
+	return api.Cluster{}, ErrNotImplemented
 }
 
 // SetSize
-func (m *NullClusterMgr) SetSize(arg0 int) error {
+func (m *NullClusterManager) SetSize(arg0 int) error {
 	return ErrNotImplemented
 }
 
 // Shutdown
-func (m *NullClusterMgr) Shutdown() error {
+func (m *NullClusterManager) Shutdown() error {
 	return ErrNotImplemented
 }
 
 // Start
-func (m *NullClusterMgr) Start(arg0 int, arg1 bool, arg2 string) error {
+func (m *NullClusterManager) Start(arg0 int, arg1 bool, arg2 string) error {
 	return ErrNotImplemented
 }
 
 // StartWithConfiguration
-func (m *NullClusterMgr) StartWithConfiguration(arg0 int, arg1 bool, arg2 string, arg3 *ClusterServerConfiguration) error {
+func (m *NullClusterManager) StartWithConfiguration(arg0 int, arg1 bool, arg2 string, arg3 *ClusterServerConfiguration) error {
 	return ErrNotImplemented
 }
 
+// NullClusterData implementations
+
 // UpdateData
-func (m *NullClusterMgr) UpdateData(arg0 map[string]interface{}) error {
+func (m *NullClusterData) UpdateData(arg0 map[string]interface{}) error {
 	return ErrNotImplemented
 }
 
 // UpdateLabels
-func (m *NullClusterMgr) UpdateLabels(arg0 map[string]string) error {
+func (m *NullClusterData) UpdateLabels(arg0 map[string]string) error {
 	return ErrNotImplemented
+}
+
+// GetData
+func (m *NullClusterData) GetData() (map[string]*api.Node, error) {
+	return nil, ErrNotImplemented
+}
+
+// GetNodeIdFromIp
+func (m *NullClusterData) GetNodeIdFromIp(arg0 string) (string, error) {
+	return "", ErrNotImplemented
+}
+
+// EnableUpdates
+func (m *NullClusterData) EnableUpdates() error {
+	return ErrNotImplemented
+}
+
+// DisableUpdates
+func (m *NullClusterData) DisableUpdates() error {
+	return ErrNotImplemented
+}
+
+// GetGossipState
+func (m *NullClusterData) GetGossipState() *ClusterState {
+	return nil
+}
+
+// NullClusterRemove implementations
+
+// Remove
+func (m *NullClusterRemove) Remove(arg0 []api.Node, arg1 bool) error {
+	return ErrNotImplemented
+}
+
+// NodeRemoveDone
+func (m *NullClusterRemove) NodeRemoveDone(arg0 string, arg1 error) {
+	return
+}
+
+// NullClusterStatus implementations
+
+// Nodestatus
+func (m *NullClusterStatus) NodeStatus() (api.Status, error) {
+	return api.Status_STATUS_NONE, ErrNotImplemented
+}
+
+// PeerStatus
+func (m *NullClusterStatus) PeerStatus(arg0 string) (map[string]api.Status, error) {
+	return nil, ErrNotImplemented
+}
+
+// NullClusterAlerts implementations
+
+// EnumerateAlerts
+func (m *NullClusterAlerts) EnumerateAlerts(arg0, arg1 time.Time, arg2 api.ResourceType) (*api.Alerts, error) {
+	return nil, ErrNotImplemented
+}
+
+// EraseAlert
+func (m *NullClusterAlerts) EraseAlert(arg0 api.ResourceType, arg1 int64) error {
+	return ErrNotImplemented
+}
+
+// ClearAlert
+func (m *NullClusterAlerts) ClearAlert(arg0 api.ResourceType, arg1 int64) error {
+	return ErrNotImplemented
+}
+
+// NullClusterPair implementations
+
+// CreatePair
+func (m *NullClusterPair) CreatePair(arg0 *api.ClusterPairCreateRequest) (*api.ClusterPairCreateResponse, error) {
+	return nil, ErrNotImplemented
+}
+
+// ProcessPairRequest
+func (m *NullClusterPair) ProcessPairRequest(arg0 *api.ClusterPairProcessRequest) (*api.ClusterPairProcessResponse, error) {
+	return nil, ErrNotImplemented
+}
+
+// GetPair
+func (m *NullClusterPair) GetPair(arg0 string) (*api.ClusterPairGetResponse, error) {
+	return nil, ErrNotImplemented
+}
+
+// EnumeratePairs
+func (m *NullClusterPair) EnumeratePairs() (*api.ClusterPairsEnumerateResponse, error) {
+	return nil, ErrNotImplemented
+}
+
+// DeletePair
+func (m *NullClusterPair) DeletePair(arg0 string) error {
+	return ErrNotImplemented
+}
+
+// GetPairToken
+func (m *NullClusterPair) GetPairToken(arg0 bool) (*api.ClusterPairTokenGetResponse, error) {
+	return nil, ErrNotImplemented
 }

--- a/cluster/cluster_not_supported.go
+++ b/cluster/cluster_not_supported.go
@@ -8,248 +8,248 @@ import (
 	schedpolicy "github.com/libopenstorage/openstorage/schedpolicy"
 )
 
-// ClusterNotSupported is a NULL implementation of the Cluster interface
+// nullClusterMgr is a NULL implementation of the Cluster interface
 // It is primarily used for testing the ClusterManager as well as the
 // ClusterListener interface
-type ClusterNotSupported struct {
+type NullClusterMgr struct {
 }
 
 // AddEventListener
-func (m *ClusterNotSupported) AddEventListener(arg0 ClusterListener) error {
+func (m *NullClusterMgr) AddEventListener(arg0 ClusterListener) error {
 	return nil
 }
 
 // ClearAlert
-func (m *ClusterNotSupported) ClearAlert(arg0 api.ResourceType, arg1 int64) error {
-	return nil
+func (m *NullClusterMgr) ClearAlert(arg0 api.ResourceType, arg1 int64) error {
+	return ErrNotImplemented
 }
 
 // CreatePair
-func (m *ClusterNotSupported) CreatePair(arg0 *api.ClusterPairCreateRequest) (*api.ClusterPairCreateResponse, error) {
-	return nil, nil
+func (m *NullClusterMgr) CreatePair(arg0 *api.ClusterPairCreateRequest) (*api.ClusterPairCreateResponse, error) {
+	return nil, ErrNotImplemented
 }
 
 // DeleteNodeConf
-func (m *ClusterNotSupported) DeleteNodeConf(arg0 string) error {
-	return nil
+func (m *NullClusterMgr) DeleteNodeConf(arg0 string) error {
+	return ErrNotImplemented
 }
 
 // DeletePair
-func (m *ClusterNotSupported) DeletePair(arg0 string) error {
-	return nil
+func (m *NullClusterMgr) DeletePair(arg0 string) error {
+	return ErrNotImplemented
 }
 
 // DisableUpdates
-func (m *ClusterNotSupported) DisableUpdates() error {
-	return nil
+func (m *NullClusterMgr) DisableUpdates() error {
+	return ErrNotImplemented
 }
 
 // EnableUpdates
-func (m *ClusterNotSupported) EnableUpdates() error {
-	return nil
+func (m *NullClusterMgr) EnableUpdates() error {
+	return ErrNotImplemented
 }
 
 // Enumerate
-func (m *ClusterNotSupported) Enumerate() (api.Cluster, error) {
-	return api.Cluster{}, nil
+func (m *NullClusterMgr) Enumerate() (api.Cluster, error) {
+	return api.Cluster{}, ErrNotImplemented
 }
 
 // EnumerateAlerts
-func (m *ClusterNotSupported) EnumerateAlerts(arg0, arg1 time.Time, arg2 api.ResourceType) (*api.Alerts, error) {
-	return nil, nil
+func (m *NullClusterMgr) EnumerateAlerts(arg0, arg1 time.Time, arg2 api.ResourceType) (*api.Alerts, error) {
+	return nil, ErrNotImplemented
 }
 
 // EnumerateNodeConf
-func (m *ClusterNotSupported) EnumerateNodeConf() (*osdconfig.NodesConfig, error) {
-	return nil, nil
+func (m *NullClusterMgr) EnumerateNodeConf() (*osdconfig.NodesConfig, error) {
+	return nil, ErrNotImplemented
 }
 
 // EnumeratePairs
-func (m *ClusterNotSupported) EnumeratePairs() (*api.ClusterPairsEnumerateResponse, error) {
-	return nil, nil
+func (m *NullClusterMgr) EnumeratePairs() (*api.ClusterPairsEnumerateResponse, error) {
+	return nil, ErrNotImplemented
 }
 
 // EraseAlert
-func (m *ClusterNotSupported) EraseAlert(arg0 api.ResourceType, arg1 int64) error {
-	return nil
+func (m *NullClusterMgr) EraseAlert(arg0 api.ResourceType, arg1 int64) error {
+	return ErrNotImplemented
 }
 
 // GetClusterConf
-func (m *ClusterNotSupported) GetClusterConf() (*osdconfig.ClusterConfig, error) {
-	return nil, nil
+func (m *NullClusterMgr) GetClusterConf() (*osdconfig.ClusterConfig, error) {
+	return nil, ErrNotImplemented
 }
 
 // GetData
-func (m *ClusterNotSupported) GetData() (map[string]*api.Node, error) {
-	return nil, nil
+func (m *NullClusterMgr) GetData() (map[string]*api.Node, error) {
+	return nil, ErrNotImplemented
 }
 
 // GetGossipState
-func (m *ClusterNotSupported) GetGossipState() *ClusterState {
+func (m *NullClusterMgr) GetGossipState() *ClusterState {
 	return nil
 }
 
 // GetNodeConf
-func (m *ClusterNotSupported) GetNodeConf(arg0 string) (*osdconfig.NodeConfig, error) {
-	return nil, nil
+func (m *NullClusterMgr) GetNodeConf(arg0 string) (*osdconfig.NodeConfig, error) {
+	return nil, ErrNotImplemented
 }
 
 // GetNodeIdFromIp
-func (m *ClusterNotSupported) GetNodeIdFromIp(arg0 string) (string, error) {
-	return "", nil
+func (m *NullClusterMgr) GetNodeIdFromIp(arg0 string) (string, error) {
+	return "", ErrNotImplemented
 }
 
 // GetPair
-func (m *ClusterNotSupported) GetPair(arg0 string) (*api.ClusterPairGetResponse, error) {
-	return nil, nil
+func (m *NullClusterMgr) GetPair(arg0 string) (*api.ClusterPairGetResponse, error) {
+	return nil, ErrNotImplemented
 }
 
 // GetPairToken
-func (m *ClusterNotSupported) GetPairToken(arg0 bool) (*api.ClusterPairTokenGetResponse, error) {
-	return nil, nil
+func (m *NullClusterMgr) GetPairToken(arg0 bool) (*api.ClusterPairTokenGetResponse, error) {
+	return nil, ErrNotImplemented
 }
 
 // Inspect
-func (m *ClusterNotSupported) Inspect(arg0 string) (api.Node, error) {
-	return api.Node{}, nil
+func (m *NullClusterMgr) Inspect(arg0 string) (api.Node, error) {
+	return api.Node{}, ErrNotImplemented
 }
 
 // NodeRemoveDone
-func (m *ClusterNotSupported) NodeRemoveDone(arg0 string, arg1 error) {
+func (m *NullClusterMgr) NodeRemoveDone(arg0 string, arg1 error) {
 	return
 }
 
-// NodeStatus
-func (m *ClusterNotSupported) NodeStatus() (api.Status, error) {
-	return api.Status_STATUS_NONE, nil
+// Nodestatus
+func (m *NullClusterMgr) NodeStatus() (api.Status, error) {
+	return api.Status_STATUS_NONE, ErrNotImplemented
 }
 
 // ObjectStoreCreate
-func (m *ClusterNotSupported) ObjectStoreCreate(arg0 string) (*api.ObjectstoreInfo, error) {
-	return nil, nil
+func (m *NullClusterMgr) ObjectStoreCreate(arg0 string) (*api.ObjectstoreInfo, error) {
+	return nil, ErrNotImplemented
 }
 
 // ObjectStoreDelete
-func (m *ClusterNotSupported) ObjectStoreDelete(arg0 string) error {
-	return nil
+func (m *NullClusterMgr) ObjectStoreDelete(arg0 string) error {
+	return ErrNotImplemented
 }
 
 // ObjectStoreInspect
-func (m *ClusterNotSupported) ObjectStoreInspect(arg0 string) (*api.ObjectstoreInfo, error) {
-	return nil, nil
+func (m *NullClusterMgr) ObjectStoreInspect(arg0 string) (*api.ObjectstoreInfo, error) {
+	return nil, ErrNotImplemented
 }
 
 // ObjectStoreUpdate
-func (m *ClusterNotSupported) ObjectStoreUpdate(arg0 string, arg1 bool) error {
-	return nil
+func (m *NullClusterMgr) ObjectStoreUpdate(arg0 string, arg1 bool) error {
+	return ErrNotImplemented
 }
 
 // PeerStatus
-func (m *ClusterNotSupported) PeerStatus(arg0 string) (map[string]api.Status, error) {
-	return nil, nil
+func (m *NullClusterMgr) PeerStatus(arg0 string) (map[string]api.Status, error) {
+	return nil, ErrNotImplemented
 }
 
 // ProcessPairRequest
-func (m *ClusterNotSupported) ProcessPairRequest(arg0 *api.ClusterPairProcessRequest) (*api.ClusterPairProcessResponse, error) {
-	return nil, nil
+func (m *NullClusterMgr) ProcessPairRequest(arg0 *api.ClusterPairProcessRequest) (*api.ClusterPairProcessResponse, error) {
+	return nil, ErrNotImplemented
 }
 
 // Remove
-func (m *ClusterNotSupported) Remove(arg0 []api.Node, arg1 bool) error {
-	return nil
+func (m *NullClusterMgr) Remove(arg0 []api.Node, arg1 bool) error {
+	return ErrNotImplemented
 }
 
 // SchedPolicyCreate
-func (m *ClusterNotSupported) SchedPolicyCreate(arg0, arg1 string) error {
-	return nil
+func (m *NullClusterMgr) SchedPolicyCreate(arg0, arg1 string) error {
+	return ErrNotImplemented
 }
 
 // SchedPolicyDelete
-func (m *ClusterNotSupported) SchedPolicyDelete(arg0 string) error {
-	return nil
+func (m *NullClusterMgr) SchedPolicyDelete(arg0 string) error {
+	return ErrNotImplemented
 }
 
 // SchedPolicyEnumerate
-func (m *ClusterNotSupported) SchedPolicyEnumerate() ([]*schedpolicy.SchedPolicy, error) {
-	return nil, nil
+func (m *NullClusterMgr) SchedPolicyEnumerate() ([]*schedpolicy.SchedPolicy, error) {
+	return nil, ErrNotImplemented
 }
 
 // SchedPolicyGet
-func (m *ClusterNotSupported) SchedPolicyGet(arg0 string) (*schedpolicy.SchedPolicy, error) {
-	return nil, nil
+func (m *NullClusterMgr) SchedPolicyGet(arg0 string) (*schedpolicy.SchedPolicy, error) {
+	return nil, ErrNotImplemented
 }
 
 // SchedPolicyUpdate
-func (m *ClusterNotSupported) SchedPolicyUpdate(arg0, arg1 string) error {
-	return nil
+func (m *NullClusterMgr) SchedPolicyUpdate(arg0, arg1 string) error {
+	return ErrNotImplemented
 }
 
 // SecretCheckLogin
-func (m *ClusterNotSupported) SecretCheckLogin() error {
-	return nil
+func (m *NullClusterMgr) SecretCheckLogin() error {
+	return ErrNotImplemented
 }
 
 // SecretGet
-func (m *ClusterNotSupported) SecretGet(arg0 string) (interface{}, error) {
-	return nil, nil
+func (m *NullClusterMgr) SecretGet(arg0 string) (interface{}, error) {
+	return nil, ErrNotImplemented
 }
 
 // SecretGetDefaultSecretKey
-func (m *ClusterNotSupported) SecretGetDefaultSecretKey() (interface{}, error) {
-	return nil, nil
+func (m *NullClusterMgr) SecretGetDefaultSecretKey() (interface{}, error) {
+	return nil, ErrNotImplemented
 }
 
 // SecretLogin
-func (m *ClusterNotSupported) SecretLogin(arg0 string, arg1 map[string]string) error {
-	return nil
+func (m *NullClusterMgr) SecretLogin(arg0 string, arg1 map[string]string) error {
+	return ErrNotImplemented
 }
 
 // SecretSet
-func (m *ClusterNotSupported) SecretSet(arg0 string, arg1 interface{}) error {
-	return nil
+func (m *NullClusterMgr) SecretSet(arg0 string, arg1 interface{}) error {
+	return ErrNotImplemented
 }
 
 // SecretSetDefaultSecretKey
-func (m *ClusterNotSupported) SecretSetDefaultSecretKey(arg0 string, arg1 bool) error {
-	return nil
+func (m *NullClusterMgr) SecretSetDefaultSecretKey(arg0 string, arg1 bool) error {
+	return ErrNotImplemented
 }
 
 // SetClusterConf
-func (m *ClusterNotSupported) SetClusterConf(arg0 *osdconfig.ClusterConfig) error {
-	return nil
+func (m *NullClusterMgr) SetClusterConf(arg0 *osdconfig.ClusterConfig) error {
+	return ErrNotImplemented
 }
 
 // SetNodeConf
-func (m *ClusterNotSupported) SetNodeConf(arg0 *osdconfig.NodeConfig) error {
-	return nil
+func (m *NullClusterMgr) SetNodeConf(arg0 *osdconfig.NodeConfig) error {
+	return ErrNotImplemented
 }
 
 // SetSize
-func (m *ClusterNotSupported) SetSize(arg0 int) error {
-	return nil
+func (m *NullClusterMgr) SetSize(arg0 int) error {
+	return ErrNotImplemented
 }
 
 // Shutdown
-func (m *ClusterNotSupported) Shutdown() error {
-	return nil
+func (m *NullClusterMgr) Shutdown() error {
+	return ErrNotImplemented
 }
 
 // Start
-func (m *ClusterNotSupported) Start(arg0 int, arg1 bool, arg2 string) error {
-	return nil
+func (m *NullClusterMgr) Start(arg0 int, arg1 bool, arg2 string) error {
+	return ErrNotImplemented
 }
 
 // StartWithConfiguration
-func (m *ClusterNotSupported) StartWithConfiguration(arg0 int, arg1 bool, arg2 string, arg3 *ClusterServerConfiguration) error {
-	return nil
+func (m *NullClusterMgr) StartWithConfiguration(arg0 int, arg1 bool, arg2 string, arg3 *ClusterServerConfiguration) error {
+	return ErrNotImplemented
 }
 
 // UpdateData
-func (m *ClusterNotSupported) UpdateData(arg0 map[string]interface{}) error {
-	return nil
+func (m *NullClusterMgr) UpdateData(arg0 map[string]interface{}) error {
+	return ErrNotImplemented
 }
 
 // UpdateLabels
-func (m *ClusterNotSupported) UpdateLabels(arg0 map[string]string) error {
-	return nil
+func (m *NullClusterMgr) UpdateLabels(arg0 map[string]string) error {
+	return ErrNotImplemented
 }

--- a/objectstore/objectstore.go
+++ b/objectstore/objectstore.go
@@ -28,24 +28,24 @@ type ObjectStore interface {
 }
 
 func NewDefaultObjectStore() ObjectStore {
-	return &nullObjectStoreMgr{}
+	return &NullObjectStoreMgr{}
 }
 
-type nullObjectStoreMgr struct {
+type NullObjectStoreMgr struct {
 }
 
-func (n *nullObjectStoreMgr) ObjectStoreInspect(objectstoreID string) (*api.ObjectstoreInfo, error) {
+func (n *NullObjectStoreMgr) ObjectStoreInspect(objectstoreID string) (*api.ObjectstoreInfo, error) {
 	return nil, ErrNotImplemented
 }
 
-func (n *nullObjectStoreMgr) ObjectStoreCreate(volume string) (*api.ObjectstoreInfo, error) {
+func (n *NullObjectStoreMgr) ObjectStoreCreate(volume string) (*api.ObjectstoreInfo, error) {
 	return nil, ErrNotImplemented
 }
 
-func (n *nullObjectStoreMgr) ObjectStoreUpdate(objectstoreID string, enable bool) error {
+func (n *NullObjectStoreMgr) ObjectStoreUpdate(objectstoreID string, enable bool) error {
 	return ErrNotImplemented
 }
 
-func (n *nullObjectStoreMgr) ObjectStoreDelete(objectstoreID string) error {
+func (n *NullObjectStoreMgr) ObjectStoreDelete(objectstoreID string) error {
 	return ErrNotImplemented
 }

--- a/osdconfig/interface_not_supported.go
+++ b/osdconfig/interface_not_supported.go
@@ -1,0 +1,47 @@
+package osdconfig
+
+import "errors"
+
+var (
+	// ErrNotImplemented is returned when any of the ConfigCaller APIs is not
+	// implemented
+	ErrNotImplemented = errors.New("configCaller API not implemented")
+)
+
+// NullConfigCaller is a NULL implementation of the ConfigCaller interface
+type NullConfigCaller struct {
+}
+
+// GetClusterConf fetches cluster configuration data from a backend such as kvdb
+func (n *NullConfigCaller) GetClusterConf() (*ClusterConfig, error) {
+	return nil, ErrNotImplemented
+}
+
+// GetNodeConf fetches node configuration data using node id
+func (n *NullConfigCaller) GetNodeConf(nodeID string) (*NodeConfig, error) {
+	return nil, ErrNotImplemented
+}
+
+// EnumerateNodeConf fetches data for all nodes
+func (n *NullConfigCaller) EnumerateNodeConf() (*NodesConfig, error) {
+	return nil, ErrNotImplemented
+}
+
+// SetClusterConf pushes cluster configuration data to the backend
+// It is assumed that the backend will notify the implementor of this interface
+// when a change is triggered
+func (n *NullConfigCaller) SetClusterConf(config *ClusterConfig) error {
+	return ErrNotImplemented
+}
+
+// SetNodeConf pushes node configuration data to the backend
+// It is assumed that the backend will notify the implementor of this interface
+// when a change is triggered
+func (n *NullConfigCaller) SetNodeConf(config *NodeConfig) error {
+	return ErrNotImplemented
+}
+
+// DeleteNodeConf removes node config for a particular node
+func (n *NullConfigCaller) DeleteNodeConf(nodeID string) error {
+	return ErrNotImplemented
+}

--- a/schedpolicy/sched_policy.go
+++ b/schedpolicy/sched_policy.go
@@ -20,28 +20,28 @@ type SchedulePolicyProvider interface {
 }
 
 func NewDefaultSchedulePolicy() SchedulePolicyProvider {
-	return &nullSchedMgr{}
+	return &NullSchedMgr{}
 }
 
-type nullSchedMgr struct {
+type NullSchedMgr struct {
 }
 
-func (sp *nullSchedMgr) SchedPolicyCreate(name, sched string) error {
+func (sp *NullSchedMgr) SchedPolicyCreate(name, sched string) error {
 	return ErrNotImplemented
 }
 
-func (sp *nullSchedMgr) SchedPolicyUpdate(name, sched string) error {
+func (sp *NullSchedMgr) SchedPolicyUpdate(name, sched string) error {
 	return ErrNotImplemented
 }
 
-func (sp *nullSchedMgr) SchedPolicyDelete(name string) error {
+func (sp *NullSchedMgr) SchedPolicyDelete(name string) error {
 	return ErrNotImplemented
 }
 
-func (sp *nullSchedMgr) SchedPolicyEnumerate() ([]*SchedPolicy, error) {
+func (sp *NullSchedMgr) SchedPolicyEnumerate() ([]*SchedPolicy, error) {
 	return nil, ErrNotImplemented
 }
 
-func (sp *nullSchedMgr) SchedPolicyGet(name string) (*SchedPolicy, error) {
+func (sp *NullSchedMgr) SchedPolicyGet(name string) (*SchedPolicy, error) {
 	return nil, ErrNotImplemented
 }

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -34,34 +34,34 @@ type Secrets interface {
 	SecretGet(key string) (interface{}, error)
 }
 
-type nullSecrets struct {
+type NullSecrets struct {
 }
 
 // New returns null secrets implementation
 func NewDefaultSecrets() Secrets {
-	return &nullSecrets{}
+	return &NullSecrets{}
 }
 
-func (f *nullSecrets) SecretLogin(secretType string, secretConfig map[string]string) error {
+func (f *NullSecrets) SecretLogin(secretType string, secretConfig map[string]string) error {
 	return ErrNotImplemented
 }
 
-func (f *nullSecrets) SecretSetDefaultSecretKey(secretKey string, override bool) error {
+func (f *NullSecrets) SecretSetDefaultSecretKey(secretKey string, override bool) error {
 	return ErrNotImplemented
 }
 
-func (f *nullSecrets) SecretGetDefaultSecretKey() (interface{}, error) {
+func (f *NullSecrets) SecretGetDefaultSecretKey() (interface{}, error) {
 	return nil, ErrNotImplemented
 }
 
-func (f *nullSecrets) SecretCheckLogin() error {
+func (f *NullSecrets) SecretCheckLogin() error {
 	return ErrNotImplemented
 }
 
-func (f *nullSecrets) SecretSet(secretKey string, secretValue interface{}) error {
+func (f *NullSecrets) SecretSet(secretKey string, secretValue interface{}) error {
 	return ErrNotImplemented
 }
 
-func (f *nullSecrets) SecretGet(secretKey string) (interface{}, error) {
+func (f *NullSecrets) SecretGet(secretKey string) (interface{}, error) {
 	return nil, ErrNotImplemented
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
The cluster pkg has two primary interfaces
- Cluster
- ClusterListener

The ClusterManger in openstorage implements the Cluster interface. It also invokes the APIs
from the ClusterListener interface. Whoever implements the ClusterListener interface will get
events from the ClusterManager. By adding a NULL implementation we would be able to write tests
for the implementors for ClusterListener interface.

Signed-off-by: Aditya Dani <aditya@portworx.com>
