### PR TITLE
Add storage pod/datastore cluster support

### DIFF
--- a/pkg/storageops/vsphere/README.md
+++ b/pkg/storageops/vsphere/README.md
@@ -15,6 +15,8 @@ export VSPHERE_INSECURE=true
 export VSPHERE_VM_UUID=42124a20-d049-9c0a-0094-1552b320fb18
 export VSPHERE_TEST_DATASTORE=<test-datastore-to-use>
 
+# VSPHERE_TEST_DATASTORE above can be a vSphere datastore or datastore cluster name. When testing changes, it is recommended to test with both.
+
 go test -v
 ```
 

--- a/pkg/storageops/vsphere/vsphere_util.go
+++ b/pkg/storageops/vsphere/vsphere_util.go
@@ -8,6 +8,11 @@ import (
 	"strings"
 
 	"github.com/libopenstorage/openstorage/pkg/storageops"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/types"
 	"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere/vclib"
 )
 
@@ -159,4 +164,22 @@ func setdatastoreFolderIDMap(
 		datastoreFolderIDMap[datastore] = folderNameIDMap
 	}
 	folderNameIDMap[folderName] = folderID
+}
+
+// GetStoragePodMoList fetches the managed storage pod objects for the given references
+//		Only the properties is the given property list will be populated in the response
+func GetStoragePodMoList(
+	ctx context.Context,
+	client *vim25.Client,
+	storagepodRefs []types.ManagedObjectReference,
+	properties []string) ([]mo.StoragePod, error) {
+	var storagepodMoList []mo.StoragePod
+	pc := property.DefaultCollector(client)
+	err := pc.Retrieve(ctx, storagepodRefs, properties, &storagepodMoList)
+	if err != nil {
+		logrus.Errorf("Failed to get Storagepod managed objects from storage pod refs: %+v, properties: %+v, err: %v",
+			storagepodRefs, properties, err)
+		return nil, err
+	}
+	return storagepodMoList, nil
 }

--- a/pkg/storageops/vsphere/vsphere_util.go
+++ b/pkg/storageops/vsphere/vsphere_util.go
@@ -171,15 +171,15 @@ func setdatastoreFolderIDMap(
 func GetStoragePodMoList(
 	ctx context.Context,
 	client *vim25.Client,
-	storagepodRefs []types.ManagedObjectReference,
+	storagePodRefs []types.ManagedObjectReference,
 	properties []string) ([]mo.StoragePod, error) {
-	var storagepodMoList []mo.StoragePod
+	var storagePodMoList []mo.StoragePod
 	pc := property.DefaultCollector(client)
-	err := pc.Retrieve(ctx, storagepodRefs, properties, &storagepodMoList)
+	err := pc.Retrieve(ctx, storagePodRefs, properties, &storagePodMoList)
 	if err != nil {
 		logrus.Errorf("Failed to get Storagepod managed objects from storage pod refs: %+v, properties: %+v, err: %v",
-			storagepodRefs, properties, err)
+			storagePodRefs, properties, err)
 		return nil, err
 	}
-	return storagepodMoList, nil
+	return storagePodMoList, nil
 }


### PR DESCRIPTION
Signed-off-by: Harsh Desai <harsh@portworx.com>

**What this PR does / why we need it**: This PR adds support for creating vmdks on vSphere datastore clusters (https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.resmgmt.doc/GUID-A2294106-A2B5-4AE4-8F45-9D22B20B5146.html)


References followed: 

- https://github.com/vmware/govmomi/issues/740#issuecomment-416443117
- https://github.com/vmware/govmomi/blob/master/govc/vm/create.go#L331
