### PR TITLE
sdk:Allow bucket not to be set in credentials

### DIFF
--- a/api/server/sdk/credentials.go
+++ b/api/server/sdk/credentials.go
@@ -288,7 +288,8 @@ func (s *CredentialServer) Inspect(
 	}
 	bucket, ok := info[api.OptCredBucket].(string)
 	if !ok {
-		return nil, status.Error(codes.Internal, "Unable to get bucket name")
+		// The code to support bucket may not be available
+		bucket = ""
 	}
 
 	resp := &api.SdkCredentialInspectResponse{


### PR DESCRIPTION
**What this PR does / why we need it**:
If the code did hot have `bucket` set in the map, the SDK would fail. It should allow for `bucket` not be set in credentials.

**Which issue(s) this PR fixes** (optional)
Closes #611
