### PR TITLE
Reenable test-sdk in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
   - make install
   - make vet
   - make docker-test
+  - make test-sdk
   - make docs
   - if [ "${TRAVIS_BRANCH}" == "master" ] && [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
       make docker-build-osd;


### PR DESCRIPTION
**What this PR does / why we need it**:
Need to add test-sdk back once sdk-test (the repo) has been updated to the latest braking changes
