### PR TITLE
Add support for forcing fs to spec_handler.go

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -50,6 +50,10 @@ const (
 	// SpecBestEffortLocationProvisioning default is false. If set provisioning request will succeed
 	// even if specified data location parameters could not be satisfied.
 	SpecBestEffortLocationProvisioning = "best_effort_location_provisioning"
+	// SpecForceUnsuppportedFsType is of type boolean and if true it sets
+	// the VolumeSpec.force_unsupported_fs_type. When set to true it asks
+	// the driver to use an unsupported value of VolumeSpec.format if possible
+	SpecForceUnsupportedFsType = "force_unsupported_fs_type"
 )
 
 // OptionKey specifies a set of recognized query params.

--- a/api/spec/spec_handler.go
+++ b/api/spec/spec_handler.go
@@ -311,6 +311,12 @@ func (d *specHandler) UpdateSpecFromOpts(opts map[string]string, spec *api.Volum
 			} else {
 				spec.IoProfile = ioProfile
 			}
+		case api.SpecForceUnsupportedFsType:
+			if forceFs, err := strconv.ParseBool(v); err != nil {
+				return nil, nil, nil, err
+			} else {
+				spec.ForceUnsupportedFsType = forceFs
+			}
 		default:
 			spec.VolumeLabels[k] = v
 		}

--- a/api/spec/spec_handler_test.go
+++ b/api/spec/spec_handler_test.go
@@ -83,3 +83,27 @@ func TestOptNodes(t *testing.T) {
 func TestQueueDepth(t *testing.T) {
 	testSpecOptString(t, api.SpecQueueDepth, "10")
 }
+
+func TestForceUnsupportedFsType(t *testing.T) {
+	s := NewSpecHandler()
+	spec, _, _, err := s.SpecFromOpts(map[string]string{
+		api.SpecForceUnsupportedFsType: "true",
+	})
+	require.True(t, spec.GetForceUnsupportedFsType())
+	require.NoError(t, err)
+
+	spec, _, _, err = s.SpecFromOpts(map[string]string{
+		api.SpecForceUnsupportedFsType: "false",
+	})
+	require.False(t, spec.GetForceUnsupportedFsType())
+	require.NoError(t, err)
+
+	spec, _, _, err = s.SpecFromOpts(map[string]string{})
+	require.False(t, spec.GetForceUnsupportedFsType())
+	require.NoError(t, err)
+
+	_, _, _, err = s.SpecFromOpts(map[string]string{
+		api.SpecForceUnsupportedFsType: "blah",
+	})
+	require.Error(t, err)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This change is needed to allow the value to be set from
a StorageClass in K8S. Forcing the unsupported fs type
will allow callers to ask the driver to use an unsupported
fs type if possible. For example, using the Portworx driver,
the administrator can force XFS as the file system of the
volume if this setting is set to true.

**Which issue(s) this PR fixes** (optional)
Closes #633

**Special notes for your reviewer**:

