### PR TITLE
Fix mount trash dir cleanup

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -621,22 +621,20 @@ func (m *Mounter) EmptyTrashDir() error {
 		return err
 	}
 
-	for _, file := range files {
-		if _, err := sched.Instance().Schedule(
-			func(sched.Interval) {
+	if _, err := sched.Instance().Schedule(
+		func(sched.Interval) {
+			for _, file := range files {
 				e := m.removeSoftlinkAndTarget(path.Join(m.trashLocation, file.Name()))
 				if e != nil {
 					logrus.Errorf("failed to remove link: %s. Err: %v", path.Join(m.trashLocation, file.Name()), e)
-					err = e
-					// continue with other directories
 				}
-			},
-			sched.Periodic(time.Second),
-			time.Now().Add(mountPathRemoveDelay),
-			true /* run only once */); err != nil {
-			logrus.Errorf("Failed to cleanup of trash dir. Err: %v", err)
-			return err
-		}
+			}
+		},
+		sched.Periodic(time.Second),
+		time.Now().Add(mountPathRemoveDelay),
+		true /* run only once */); err != nil {
+		logrus.Errorf("Failed to cleanup of trash dir. Err: %v", err)
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Harsh Desai <harsh@portworx.com>

**What this PR does / why we need it**: When scheduling removal of trash dir softlink and their targets, the caller was passing references to the file objects to the sched package. Hence go routines would end up using file objects from the caller and 2 go routines (sched pkg tasks) would try to `removeSoftlinkAndTarget` the same file and skip subsequent ones.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

