### PR TITLE
Add EmitDefualt flag while starting grpc server.

### DIFF
--- a/api/server/sdk/server.go
+++ b/api/server/sdk/server.go
@@ -205,7 +205,10 @@ func (s *Server) restServerSetupHandlers() (*http.ServeMux, error) {
 		http.StripPrefix(prefix, http.FileServer(swaggerUIBox)))
 
 	// Create a router just for HTTP REST gRPC Server Gateway
-	gmux := runtime.NewServeMux()
+	gmux := runtime.NewServeMux(
+		runtime.WithMarshalerOption(
+			runtime.MIMEWildcard,
+			&runtime.JSONPb{OrigName: true, EmitDefaults: true}))
 	err := api.RegisterOpenStorageClusterHandlerFromEndpoint(
 		context.Background(),
 		gmux,


### PR DESCRIPTION

**What this PR does / why we need it**:
This PR fixes bug, where  zero integer value fields were omitted in REST responses.  Added JsonPb's EmitDefault flag so that fields such as `hour:0` treated as it is.

**Which issue(s) this PR fixes** (optional)
Closes #
zero integer value fields are omitted in REST responses
**Special notes for your reviewer**:

