### PR TITLE
Fake driver needs to update spec

### DIFF
--- a/volume/drivers/fake/fake.go
+++ b/volume/drivers/fake/fake.go
@@ -322,6 +322,7 @@ func (d *driver) Set(volumeID string, locator *api.VolumeLocator, spec *api.Volu
 		v.Spec.Journal = spec.Journal
 		v.Spec.SnapshotInterval = spec.SnapshotInterval
 		v.Spec.IoProfile = spec.IoProfile
+		v.Spec.SnapshotSchedule = spec.SnapshotSchedule
 	}
 
 	return d.UpdateVol(v)


### PR DESCRIPTION
**What this PR does / why we need it**:
The fake driver needs to make sure to copy the snapshot schedule


