### PR TITLE
sdk: Fixes weekly schedules

### DIFF
--- a/api/server/sdk/utils.go
+++ b/api/server/sdk/utils.go
@@ -113,8 +113,8 @@ func sdkSchedToRetainInternalSpec(
 		}
 		spec = sched.Weekly(
 			sdkWeekdayToTimeWeekday(weekly.GetDay()),
-			int(daily.GetHour()),
-			int(daily.GetMinute())).
+			int(weekly.GetHour()),
+			int(weekly.GetMinute())).
 			Spec()
 	} else if monthly := req.GetMonthly(); monthly != nil {
 		// monthly


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the issue where the weekly parser was using `daily.()` functions instead of the correct `weekly.()` object ones.

**Which issue(s) this PR fixes** (optional)
Closes #655 

**Special notes for your reviewer**:

