### PR TITLE
Don't print HTTP status in error message

### DIFF
--- a/api/client/request.go
+++ b/api/client/request.go
@@ -332,7 +332,7 @@ func (r Response) FormatError() error {
 	if len(r.body) == 0 {
 		return fmt.Errorf("Error: %v", r.err)
 	}
-	return fmt.Errorf("HTTP-%d: %s", r.statusCode, string(r.body))
+	return fmt.Errorf("%v", strings.TrimSpace(string(r.body)))
 }
 
 func digest(method string, path string) string {

--- a/cluster/manager/pair.go
+++ b/cluster/manager/pair.go
@@ -30,7 +30,7 @@ func (c *ClusterManager) CreatePair(
 	logrus.Infof("Attempting to pair with cluster at IP %v", remoteIp)
 
 	processRequest := &api.ClusterPairProcessRequest{
-		SourceClusterId:    c.config.ClusterId,
+		SourceClusterId:    c.Uuid(),
 		RemoteClusterToken: request.RemoteClusterToken,
 	}
 
@@ -86,6 +86,10 @@ func (c *ClusterManager) CreatePair(
 func (c *ClusterManager) ProcessPairRequest(
 	request *api.ClusterPairProcessRequest,
 ) (*api.ClusterPairProcessResponse, error) {
+	if request.SourceClusterId == c.Uuid() {
+		return nil, fmt.Errorf("Cannot create cluster pair with self")
+	}
+
 	response := &api.ClusterPairProcessResponse{
 		RemoteClusterId:   c.Uuid(),
 		RemoteClusterName: c.config.ClusterId,

--- a/cluster/manager/pair.go
+++ b/cluster/manager/pair.go
@@ -208,7 +208,6 @@ func (c *ClusterManager) EnumeratePairs() (*api.ClusterPairsEnumerateResponse, e
 	response.DefaultId, err = getDefaultPairId()
 	if err != nil {
 		logrus.Warnf("Error getting default cluster pair: %v", err)
-		return nil, err
 	}
 	return response, nil
 }
@@ -281,6 +280,9 @@ func pairCreate(info *api.ClusterPairInfo, setDefault bool) error {
 	key := ClusterPairKey + "/" + info.Id
 	_, err = kv.Create(key, info, 0)
 	if err != nil {
+		if err == kvdb.ErrExist {
+			return fmt.Errorf("Already paired with cluster %v", info.Id)
+		}
 		return err
 	}
 


### PR DESCRIPTION
There is StatusCode() if callers want that. This causes HTTP errors to be
propagated up to the APIs and printed for users which isn't relavent. Also for
an API making other API calls which failed this would print multiple HTTP error
codes.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

