### PR TITLE
Update ListnerAPIs for ClusterPair

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -124,10 +124,10 @@ type ClusterListener interface {
 // listen for incoming pairing requests.
 type ClusterListenerPairOps interface {
 	// CreatePair is called when we are pairing with another cluster
-	CreatePair(self *api.Node, response *api.ClusterPairProcessResponse) error
+	CreatePair(response *api.ClusterPairProcessResponse) error
 
 	// ProcessPairRequest is called when we get a pair request from another cluster
-	ProcessPairRequest(self *api.Node, response *api.ClusterPairProcessResponse) error
+	ProcessPairRequest(request *api.ClusterPairProcessRequest, response *api.ClusterPairProcessResponse) error
 }
 
 // ClusterListenerAlertOps is a wrapper over ClusterAlerts interface
@@ -427,14 +427,13 @@ func (nc *NullClusterListener) EraseAlert(
 }
 
 func (nc *NullClusterListener) CreatePair(
-	self *api.Node,
 	response *api.ClusterPairProcessResponse,
 ) error {
 	return nil
 }
 
 func (nc *NullClusterListener) ProcessPairRequest(
-	self *api.Node,
+	request *api.ClusterPairProcessRequest,
 	response *api.ClusterPairProcessResponse,
 ) error {
 	return nil

--- a/cluster/manager/pair.go
+++ b/cluster/manager/pair.go
@@ -50,7 +50,6 @@ func (c *ClusterManager) CreatePair(
 	// Alert all listeners that we are pairing with a cluster.
 	for e := c.listeners.Front(); e != nil; e = e.Next() {
 		err = e.Value.(cluster.ClusterListener).CreatePair(
-			&c.selfNode,
 			resp,
 		)
 		if err != nil {
@@ -107,7 +106,7 @@ func (c *ClusterManager) ProcessPairRequest(
 	// Alert all listeners that we have received a pair request
 	for e := c.listeners.Front(); e != nil; e = e.Next() {
 		err := e.Value.(cluster.ClusterListener).ProcessPairRequest(
-			&c.selfNode,
+			request,
 			response,
 		)
 		if err != nil {
@@ -133,7 +132,7 @@ func (c *ClusterManager) RefreshPair(
 		return err
 	}
 	processRequest := &api.ClusterPairProcessRequest{
-		SourceClusterId:    c.config.ClusterId,
+		SourceClusterId:    c.Uuid(),
 		RemoteClusterToken: pair.Token,
 	}
 


### PR DESCRIPTION
Don't need node information. Request for ProcessPair is helpful to pass in.
Also fix source cluster UUID in RefreshRequest

Signed-off-by: Dinesh Israni <disrani@portworx.com>



