### PR TITLE
Call the ClusterListener APIs asynchronously

### DIFF
--- a/pkg/pcqueue/pcqueue.go
+++ b/pkg/pcqueue/pcqueue.go
@@ -1,0 +1,68 @@
+package pcqueue
+
+import (
+	"container/list"
+	"sync"
+
+	"github.com/libopenstorage/openstorage/pkg/dbg"
+	"github.com/sirupsen/logrus"
+)
+
+type Task func()
+
+type taskQueue struct {
+	// taskQ is the list of tasks
+	taskQ *list.List
+	// m is the mutex to protect taskQ
+	m *sync.Mutex
+	// cv is used to coordinate the producer-consumer threads
+	cv *sync.Cond
+}
+
+// PCQueue is a producer consumer queue.
+type PCQueue interface {
+	// Enqueue will enqueue an update. It is non-blocking.
+	Enqueue(t Task)
+	// Dump will dump information about the producer consumer queue.
+	Dump()
+}
+
+// NewPCQueue returns PCQueue
+func New(numWorkers uint8) PCQueue {
+	dbg.Assert(numWorkers > 0, "Number of workers must be greater than zero")
+	mtx := &sync.Mutex{}
+	q := &taskQueue{
+		m:     mtx,
+		cv:    sync.NewCond(mtx),
+		taskQ: list.New()}
+	workerFn := func() { q.dequeue() }
+	for i := uint8(0); i < numWorkers; i++ {
+		go workerFn()
+	}
+	return q
+}
+
+func (w *taskQueue) dequeue() {
+	for {
+		w.m.Lock()
+		for w.taskQ.Len() == 0 {
+			w.cv.Wait()
+		}
+		el := w.taskQ.Front()
+		w.taskQ.Remove(el)
+		w.m.Unlock()
+		el.Value.(Task)()
+	}
+}
+
+func (w *taskQueue) Dump() {
+	logrus.Infof("Queue size: %d", w.taskQ.Len())
+}
+
+// Enqueue enqueues and never blocks
+func (w *taskQueue) Enqueue(t Task) {
+	w.m.Lock()
+	w.taskQ.PushBack(t)
+	w.cv.Signal()
+	w.m.Unlock()
+}

--- a/pkg/pcqueue/pcqueue_test.go
+++ b/pkg/pcqueue/pcqueue_test.go
@@ -1,0 +1,61 @@
+package pcqueue
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueue(t *testing.T) {
+	for size := uint8(1); size < 10; size++ {
+		q := New(size)
+		m := &sync.Mutex{}
+		count := 0
+		doneCh := make(chan struct{}, 1)
+		numTasks := 40
+		tasks := make([]int, numTasks)
+		for i := 0; i < numTasks; i++ {
+			j := i
+			c := &count
+			// Enqueue numTasks unique task and make sure all of them
+			// are dequeued and run
+			f := func() {
+				m.Lock()
+				tasks[j] = j
+				*c++
+				if *c == numTasks {
+					close(doneCh)
+				}
+				m.Unlock()
+			}
+			q.Enqueue(f)
+		}
+		select {
+		case <-time.After(time.Second * 30):
+			break
+		case <-doneCh:
+			break
+		}
+		for i := 0; i < numTasks; i++ {
+			require.Equal(t, tasks[i], i, "task id")
+		}
+		require.Equal(t, numTasks, count, "number of tasks")
+	}
+}
+
+func TestSafeQueue(t *testing.T) {
+	q := NewSafeQueue()
+	for i := 1; i < 10; i++ {
+		for j := 0; j < 10; j++ {
+			q.Push(fmt.Sprintf("%d ", j))
+		}
+		vals := q.PopAll()
+		require.Equal(t, 10, len(vals))
+		for j := 0; j < 10; j++ {
+			require.Equal(t, vals[j].(string), fmt.Sprintf("%d ", j))
+		}
+	}
+}

--- a/pkg/pcqueue/safe_queue.go
+++ b/pkg/pcqueue/safe_queue.go
@@ -1,0 +1,46 @@
+package pcqueue
+
+import (
+	"container/list"
+	"sync"
+)
+
+// SafeQueue is a queue which can be accessed by multiple threads safely
+type SafeQueue interface {
+	// Push item at the end of the queue
+	Push(item interface{})
+	// PopAll pops all items from the the queue
+	PopAll() []interface{}
+}
+
+type safeQueue struct {
+	// q is the list of items
+	q *list.List
+	// qLock protects access to q
+	qLock sync.Mutex
+}
+
+func (s *safeQueue) Push(item interface{}) {
+	s.qLock.Lock()
+	s.q.PushBack(item)
+	s.qLock.Unlock()
+}
+
+func (s *safeQueue) PopAll() []interface{} {
+	s.qLock.Lock()
+	defer s.qLock.Unlock()
+	num := s.q.Len()
+	ret := make([]interface{}, num)
+	for i := 0; i < num; i++ {
+		el := s.q.Front()
+		s.q.Remove(el)
+		ret[i] = el.Value
+	}
+	return ret
+}
+
+func NewSafeQueue() SafeQueue {
+	return &safeQueue{
+		q: list.New(),
+	}
+}

--- a/pkg/pcqueue/semaphore.go
+++ b/pkg/pcqueue/semaphore.go
@@ -1,0 +1,67 @@
+package pcqueue
+
+import (
+	"sync"
+
+	"github.com/libopenstorage/openstorage/pkg/dbg"
+)
+
+type semaphore struct {
+	// max is the number of available resources
+	max uint32
+	// curr is the currently used resources
+	curr uint32
+	// m protects curr
+	m *sync.Mutex
+	// cv coordinates wait/signal
+	cv *sync.Cond
+}
+
+type Semaphore interface {
+	// Wait semaphore, will block until free resource is available
+	Wait()
+	// TryWait semaphore, will return boolean based on free resource availability
+	TryWait() bool
+	// Signal semaphore, asserts if resource not used.
+	Signal()
+}
+
+func NewSemaphore(size uint32) Semaphore {
+	dbg.Assert(size > 0, "Size must be greater than zero")
+	mtx := &sync.Mutex{}
+	s := &semaphore{
+		m:    mtx,
+		cv:   sync.NewCond(mtx),
+		max:  size,
+		curr: size}
+	return s
+}
+
+func (s *semaphore) Wait() {
+	s.m.Lock()
+	for s.curr == 0 {
+		s.cv.Wait()
+	}
+	dbg.Assert(s.curr > 0, "max error, curr: %d", s.curr)
+	s.curr--
+	s.m.Unlock()
+}
+
+func (s *semaphore) TryWait() bool {
+	s.m.Lock()
+	defer s.m.Unlock()
+	if s.curr == 0 {
+		return false
+	}
+	dbg.Assert(s.curr > 0, "max error, curr: %d", s.curr)
+	s.curr--
+	return true
+}
+
+func (s *semaphore) Signal() {
+	s.m.Lock()
+	s.curr++
+	dbg.Assert(s.curr <= s.max, "max mismatch, max: %d curr: %d", s.max, s.curr)
+	s.cv.Signal()
+	s.m.Unlock()
+}

--- a/pkg/pcqueue/semaphore_test.go
+++ b/pkg/pcqueue/semaphore_test.go
@@ -1,0 +1,46 @@
+package pcqueue
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSemaphore(t *testing.T) {
+	for size := uint32(1); size < 10; size++ {
+		s := NewSemaphore(size)
+		m := &sync.Mutex{}
+		count := uint32(0)
+		maxEntries := 100
+		doneCh := make(chan struct{})
+		testf := func(c *uint32, max *uint32, totalDone *int) {
+			s.Wait()
+			m.Lock()
+			(*c)++
+			require.True(t, *c <= *max, "number of simultaneous entries")
+			m.Unlock()
+
+			m.Lock()
+			require.True(t, *c > 0, "number of tasks")
+			(*c)--
+			(*totalDone)++
+			if *totalDone == maxEntries {
+				close(doneCh)
+			}
+			s.Signal()
+			m.Unlock()
+		}
+		totalEntries := 0
+		for i := 0; i < maxEntries; i++ {
+			go testf(&count, &size, &totalEntries)
+		}
+		select {
+		case <-time.After(time.Second * 60):
+			require.Fail(t, "timeout in test")
+		case <-doneCh:
+			break
+		}
+	}
+}

--- a/pkg/pcqueue/waitgroup.go
+++ b/pkg/pcqueue/waitgroup.go
@@ -1,0 +1,45 @@
+package pcqueue
+
+import (
+	"github.com/libopenstorage/openstorage/pkg/dbg"
+	"sync"
+)
+
+// WaitGroupCh is similar to sync.WaitGroup.
+// It provides additional WaitCh() so that it can be used to wait in a select.
+type WaitGroupCh interface {
+	// Done decrements counter for wait group
+	Done()
+	// WaitCh returns a receive channel which returns when count becomes zero.
+	WaitCh() <-chan struct{}
+	// Wait blocks until counter is zero
+	Wait()
+}
+
+type waitGroup struct {
+	sync.Mutex
+	count  int
+	doneCh chan struct{}
+}
+
+func NewWaitGroupCh(count int) WaitGroupCh {
+	return &waitGroup{count: count, doneCh: make(chan struct{})}
+}
+
+func (w *waitGroup) Done() {
+	w.Lock()
+	defer w.Unlock()
+	dbg.Assert(w.count > 0, "mismatched Done")
+	w.count--
+	if w.count == 0 {
+		close(w.doneCh)
+	}
+}
+
+func (w *waitGroup) WaitCh() <-chan struct{} {
+	return w.doneCh
+}
+
+func (w *waitGroup) Wait() {
+	<-w.doneCh
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- In the updateClusterStatus routine we continuously post the Node updates to all the cluster
  listeners. However they are being done synchronously .
- As in this routine the error from the Listener APIs is not processed, they can be called asynchronously.

**Special notes for your reviewer**:

Signed-off-by: Aditya Dani <aditya@portworx.com>

