### PR TITLE
tools: Verify SDK version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ script:
   - go fmt $(go list ./... | grep -v vendor) | wc -l | grep 0
   - make docker-proto
   - git diff $(find . -name "*.pb.*go" -o -name "api.swagger.json" | grep -v vendor) | wc -l | grep "^0"
+  - make sdk-check-version
   - make install
   - make vet
   - make docker-test

--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,8 @@ clean: $(OSDSANITY)-clean
 	$(OSDSANITY)-clean \
 	clean \
 	generate \
-	generate-mockfiles
+	generate-mockfiles \
+	sdk-check-version
 
 $(GOPATH)/bin/cover:
 	go get golang.org/x/tools/cmd/cover
@@ -366,4 +367,11 @@ docker-images: docker-build-proto docker-build-osd-dev-base
 push-docker-images: docker-images
 	docker push quay.io/openstorage/osd-dev-base
 	docker push quay.io/openstorage/osd-proto
+
+# This needs to be adjusted for each release branch according
+# to the SDK Version.
+# For master (until released), major should be 0 and patch should be 0.
+# For release branches, major and minor should be frozen.
+sdk-check-version:
+	go run tools/sdkver/sdkver.go --check-major=0 --check-patch=0
 

--- a/tools/sdkver/sdkver.go
+++ b/tools/sdkver/sdkver.go
@@ -30,6 +30,9 @@ import (
 
 type optionTypes struct {
 	swaggerFile string
+	checkMajor  string
+	checkMinor  string
+	checkPatch  string
 }
 
 var (
@@ -38,6 +41,9 @@ var (
 
 func init() {
 	flag.StringVar(&options.swaggerFile, "swagger", "", "api.swagger.json file")
+	flag.StringVar(&options.checkMajor, "check-major", "", "SDK Version.Major must match this value")
+	flag.StringVar(&options.checkMinor, "check-minor", "", "SDK Version.Minor must match this value")
+	flag.StringVar(&options.checkPatch, "check-patch", "", "SDK Version.Patch must match this value")
 	flag.Parse()
 }
 
@@ -48,6 +54,13 @@ func main() {
 		api.SdkVersion_Major,
 		api.SdkVersion_Minor,
 		api.SdkVersion_Patch)
+
+	// Check major
+	if !checkVersionValue("Major", options.checkMajor, fmt.Sprintf("%d", api.SdkVersion_Major)) ||
+		!checkVersionValue("Minor", options.checkMinor, fmt.Sprintf("%d", api.SdkVersion_Minor)) ||
+		!checkVersionValue("Patch", options.checkPatch, fmt.Sprintf("%d", api.SdkVersion_Patch)) {
+		os.Exit(1)
+	}
 
 	// Set swagger file
 	if len(options.swaggerFile) != 0 {
@@ -88,4 +101,18 @@ func setSwaggerVersion(file, version string) error {
 	}
 
 	return nil
+}
+
+func checkVersionValue(name, expected, actual string) bool {
+	if len(expected) != 0 {
+		if expected != actual {
+			fmt.Printf("Error: SDK Version %s number expected to be %s does not match %s\n",
+				name,
+				expected,
+				actual)
+			return false
+		}
+	}
+
+	return true
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
With this patch, we can ensure that only one value changes in the SDK
version. On master, we can ensure only the Minor number changes. In
release branches we can ensure only Patch number changes.

