### PR TITLE
Fix travis mock-sdk-server builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,16 @@ HAS_PROTOC_GEN_GO := $(shell command -v protoc-gen-go 2> /dev/null)
 HAS_SDKTEST := $(shell command -v sdk-test 2> /dev/null)
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 
+ifeq ($(TRAVIS_BRANCH), master)
+MOCKSDKSERVERTAG := latest
+else
+
 ifeq ($(BRANCH), master)
 MOCKSDKSERVERTAG := latest
 else
 MOCKSDKSERVERTAG := $(shell go run tools/sdkver/sdkver.go)
+endif
+
 endif
 
 REGISTRY = openstorage


### PR DESCRIPTION
**What this PR does / why we need it**:
Travis in master is supposed to build with the `latest` tag.
The issue is that Travis checks out master then checks out a hash
at master. This makes the makefile detect that it is not in master
and therefore does not use the `latest` tag for the container.

