### PR TITLE
Reenable test-sdk in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
   - make install
   - make vet
   - make docker-test
+  - make test-sdk
   - if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then
       echo "${DOCKER_PASS}" | docker login -u "${DOCKER_USER}" --password-stdin;
       make push-mock-sdk-server;


### PR DESCRIPTION
Re-enable the sdk-test now that the sdk-test has been updated to support the latest CloudBackup APIs: https://github.com/libopenstorage/sdk-test/commit/ad4f596ab0a85793f4dad91291a368464fcd6458

