### PR TITLE
Fix SrcVolumeId not in SdkCloudStatus

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -868,6 +868,7 @@ func (s CloudBackupStatus) ToSdkCloudBackupStatus() *SdkCloudBackupStatus {
 		NodeId:       s.NodeID,
 		Info:         s.Info,
 		CredentialId: s.CredentialUUID,
+		SrcVolumeId:  s.SrcVolumeID,
 	}
 
 	status.StartTime, _ = ptypes.TimestampProto(s.StartTime)

--- a/volume/drivers/fake/fake.go
+++ b/volume/drivers/fake/fake.go
@@ -463,6 +463,7 @@ func (d *driver) cloudBackupCreate(input *api.CloudBackupCreateRequest) (string,
 			CompletedTime:  time.Now().Local().Add(1 * time.Second),
 			NodeID:         clusterInfo.NodeId,
 			CredentialUUID: input.CredentialUUID,
+			SrcVolumeID:    input.VolumeID,
 		},
 		Info: api.CloudBackupInfo{
 			ID:            cloudId,
@@ -556,6 +557,7 @@ func (d *driver) CloudBackupRestore(
 			CompletedTime:  time.Now().Local().Add(1 * time.Second),
 			NodeID:         clusterInfo.NodeId,
 			CredentialUUID: input.CredentialUUID,
+			SrcVolumeID:    volid,
 		},
 	}, 0)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
SdkCloudStatusResponse did not have SrcVolumeId populated.

