### PR TITLE
Add Eta fields  to cloudbackup status structure.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -340,12 +340,6 @@ type CloudBackupInfo struct {
 	Metadata map[string]string
 	// Status indicates the status of the backup
 	Status string
-	// BytesTotal is the number of bytes being transferred
-	BytesTotal uint64
-	// BytesDone is the number of bytes already transferred
-	BytesDone uint64
-	// ETASeconds the time duration in seconds for cloud migration completion
-	ETASeconds int64
 }
 
 type CloudBackupEnumerateRequest struct {
@@ -414,8 +408,12 @@ type CloudBackupStatus struct {
 	OpType CloudBackupOpType
 	// State indicates if the op is currently active/done/failed
 	Status CloudBackupStatusType
-	// BytesDone indicates total Bytes uploaded/downloaded
+	// BytesDone indicates Bytes uploaded/downloaded so far
 	BytesDone uint64
+	// BytesTotal is the total number of bytes being transferred
+	BytesTotal uint64
+	// EtaSeconds estimated time in seconds for backup/restore completion
+	EtaSeconds int64
 	// StartTime indicates Op's start time
 	StartTime time.Time
 	// CompletedTime indicates Op's completed time
@@ -886,6 +884,8 @@ func (s CloudBackupStatus) ToSdkCloudBackupStatus() *SdkCloudBackupStatus {
 		Info:         s.Info,
 		CredentialId: s.CredentialUUID,
 		SrcVolumeId:  s.SrcVolumeID,
+		EtaSeconds:   s.EtaSeconds,
+		BytesTotal:   s.BytesTotal,
 	}
 
 	status.StartTime, _ = ptypes.TimestampProto(s.StartTime)

--- a/api/server/sdk/cloud_backup_test.go
+++ b/api/server/sdk/cloud_backup_test.go
@@ -392,6 +392,8 @@ func TestSdkCloudBackupStatus(t *testing.T) {
 				OpType:         api.CloudBackupOp,
 				Status:         api.CloudBackupStatusPaused,
 				BytesDone:      123456,
+				BytesTotal:     123456,
+				EtaSeconds:     0,
 				StartTime:      time.Now(),
 				CompletedTime:  time.Now(),
 				NodeID:         "mynode",
@@ -402,6 +404,8 @@ func TestSdkCloudBackupStatus(t *testing.T) {
 				OpType:         api.CloudRestoreOp,
 				Status:         api.CloudBackupStatusDone,
 				BytesDone:      97324,
+				BytesTotal:     123456,
+				EtaSeconds:     37,
 				StartTime:      time.Now(),
 				CompletedTime:  time.Now(),
 				NodeID:         "myothernode",
@@ -434,6 +438,8 @@ func TestSdkCloudBackupStatus(t *testing.T) {
 		status := statuses.Statuses[k]
 		assert.Equal(t, v.GetBackupId(), status.ID)
 		assert.Equal(t, v.GetBytesDone(), status.BytesDone)
+		assert.Equal(t, v.GetBytesTotal(), status.BytesTotal)
+		assert.Equal(t, v.GetEtaSeconds(), status.EtaSeconds)
 		assert.Equal(t, v.GetNodeId(), status.NodeID)
 		assert.Equal(t, v.GetOptype(), api.CloudBackupOpTypeToSdkCloudBackupOpType(status.OpType))
 		assert.Equal(t, v.GetStatus(), api.CloudBackupStatusTypeToSdkCloudBackupStatusType(status.Status))


### PR DESCRIPTION
Signed-off-by: veda <veda@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Cloud backup status returned by volume driver was missing these fields, which are already in sdk.
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

