### PR TITLE
added config caller

### DIFF
--- a/osdconfig/new.go
+++ b/osdconfig/new.go
@@ -14,6 +14,13 @@ func NewManager(kv kvdb.Kvdb) (ConfigManager, error) {
 	return newManager(kv)
 }
 
+// NewCaller can be used to instantiate ConfigCaller
+// It does not start kvdb watches and is therefore,
+// less expensive than NewManager
+func NewCaller(kv kvdb.Kvdb) (ConfigCaller, error) {
+	return newCaller(kv)
+}
+
 // newManager can be used to instantiate configManager
 // Users of this function are expected to manage the execution via context
 // github.com/sirupsen/logrus package is used for logging internally
@@ -37,6 +44,23 @@ func newManager(kv kvdb.Kvdb) (*configManager, error) {
 		logrus.Error(err)
 		return nil, err
 	}
+
+	return manager, nil
+}
+
+// newCaller can be used to instantiate configManager,
+// however, it is exported as ConfigCaller and avoids
+// starting kvdb watches.
+// Those not needing kvdb wtches should use this instead of
+// config manager.
+func newCaller(kv kvdb.Kvdb) (*configManager, error) {
+	manager := new(configManager)
+
+	manager.cbCluster = make(map[string]CallbackClusterConfigFunc)
+	manager.cbNode = make(map[string]CallbackNodeConfigFunc)
+
+	// kvdb pointer
+	manager.kv = kv
 
 	return manager, nil
 }


### PR DESCRIPTION
Signed-off-by: Saurabh Deoras <saurabh@portworx.com>

**What this PR does / why we need it**:
The osdconfig.NewManager API in openstorage is currently starting a kvdb watch on two sub trees.

However in porx, the NewManager API is called by multiple components which causes unnecessary watches to be started on etcd. Currently there are 12 osdconfig watches instead of 2 started when PX comes up.

A watch on etcd is an expensive op and should be started only once for osdconfig.
Ideally the NewManager API and the watch logic should be separated.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

