### PR TITLE
update affinity and anti-affinity keys to be lower camelCase

### DIFF
--- a/api/api.pb.go
+++ b/api/api.pb.go
@@ -85,7 +85,7 @@ func (x Status) String() string {
 	return proto.EnumName(Status_name, int32(x))
 }
 func (Status) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{0}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{0}
 }
 
 type DriverType int32
@@ -120,7 +120,7 @@ func (x DriverType) String() string {
 	return proto.EnumName(DriverType_name, int32(x))
 }
 func (DriverType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{1}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{1}
 }
 
 type FSType int32
@@ -164,7 +164,7 @@ func (x FSType) String() string {
 	return proto.EnumName(FSType_name, int32(x))
 }
 func (FSType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{2}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{2}
 }
 
 type GraphDriverChangeType int32
@@ -193,7 +193,7 @@ func (x GraphDriverChangeType) String() string {
 	return proto.EnumName(GraphDriverChangeType_name, int32(x))
 }
 func (GraphDriverChangeType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{3}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{3}
 }
 
 type SeverityType int32
@@ -222,7 +222,7 @@ func (x SeverityType) String() string {
 	return proto.EnumName(SeverityType_name, int32(x))
 }
 func (SeverityType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{4}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{4}
 }
 
 type ResourceType int32
@@ -254,7 +254,7 @@ func (x ResourceType) String() string {
 	return proto.EnumName(ResourceType_name, int32(x))
 }
 func (ResourceType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{5}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{5}
 }
 
 type AlertActionType int32
@@ -283,7 +283,7 @@ func (x AlertActionType) String() string {
 	return proto.EnumName(AlertActionType_name, int32(x))
 }
 func (AlertActionType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{6}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{6}
 }
 
 type VolumeActionParam int32
@@ -311,7 +311,7 @@ func (x VolumeActionParam) String() string {
 	return proto.EnumName(VolumeActionParam_name, int32(x))
 }
 func (VolumeActionParam) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{7}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{7}
 }
 
 type CosType int32
@@ -340,7 +340,7 @@ func (x CosType) String() string {
 	return proto.EnumName(CosType_name, int32(x))
 }
 func (CosType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{8}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{8}
 }
 
 type IoProfile int32
@@ -372,7 +372,7 @@ func (x IoProfile) String() string {
 	return proto.EnumName(IoProfile_name, int32(x))
 }
 func (IoProfile) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{9}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{9}
 }
 
 // VolumeState represents the state of a volume.
@@ -430,7 +430,7 @@ func (x VolumeState) String() string {
 	return proto.EnumName(VolumeState_name, int32(x))
 }
 func (VolumeState) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{10}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{10}
 }
 
 // VolumeStatus represents a health status for a volume.
@@ -468,7 +468,7 @@ func (x VolumeStatus) String() string {
 	return proto.EnumName(VolumeStatus_name, int32(x))
 }
 func (VolumeStatus) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{11}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{11}
 }
 
 type StorageMedium int32
@@ -497,7 +497,7 @@ func (x StorageMedium) String() string {
 	return proto.EnumName(StorageMedium_name, int32(x))
 }
 func (StorageMedium) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{12}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{12}
 }
 
 type ClusterNotify int32
@@ -518,7 +518,7 @@ func (x ClusterNotify) String() string {
 	return proto.EnumName(ClusterNotify_name, int32(x))
 }
 func (ClusterNotify) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{13}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{13}
 }
 
 type AttachState int32
@@ -547,7 +547,7 @@ func (x AttachState) String() string {
 	return proto.EnumName(AttachState_name, int32(x))
 }
 func (AttachState) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{14}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{14}
 }
 
 type OperationFlags int32
@@ -574,7 +574,7 @@ func (x OperationFlags) String() string {
 	return proto.EnumName(OperationFlags_name, int32(x))
 }
 func (OperationFlags) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{15}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{15}
 }
 
 // Defines times of day
@@ -620,7 +620,7 @@ func (x SdkTimeWeekday) String() string {
 	return proto.EnumName(SdkTimeWeekday_name, int32(x))
 }
 func (SdkTimeWeekday) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{16}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{16}
 }
 
 // CloudBackup operations types
@@ -650,7 +650,7 @@ func (x SdkCloudBackupOpType) String() string {
 	return proto.EnumName(SdkCloudBackupOpType_name, int32(x))
 }
 func (SdkCloudBackupOpType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{17}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{17}
 }
 
 // CloudBackup status types
@@ -700,7 +700,7 @@ func (x SdkCloudBackupStatusType) String() string {
 	return proto.EnumName(SdkCloudBackupStatusType_name, int32(x))
 }
 func (SdkCloudBackupStatusType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{18}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{18}
 }
 
 // SdkCloudBackupRequestedState defines states to set a specified backup or restore
@@ -735,7 +735,7 @@ func (x SdkCloudBackupRequestedState) String() string {
 	return proto.EnumName(SdkCloudBackupRequestedState_name, int32(x))
 }
 func (SdkCloudBackupRequestedState) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{19}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{19}
 }
 
 type SdkServiceCapability_OpenStorageService_Type int32
@@ -792,7 +792,7 @@ func (x SdkServiceCapability_OpenStorageService_Type) String() string {
 	return proto.EnumName(SdkServiceCapability_OpenStorageService_Type_name, int32(x))
 }
 func (SdkServiceCapability_OpenStorageService_Type) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{161, 0, 0}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{161, 0, 0}
 }
 
 // These values are constants that can be used by the
@@ -827,7 +827,7 @@ func (x SdkVersion_Version) String() string {
 	return proto.EnumName(SdkVersion_Version_name, int32(x))
 }
 func (SdkVersion_Version) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{162, 0}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{162, 0}
 }
 
 type CloudMigrate_OperationType int32
@@ -859,7 +859,7 @@ func (x CloudMigrate_OperationType) String() string {
 	return proto.EnumName(CloudMigrate_OperationType_name, int32(x))
 }
 func (CloudMigrate_OperationType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{164, 0}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{164, 0}
 }
 
 type CloudMigrate_Stage int32
@@ -891,7 +891,7 @@ func (x CloudMigrate_Stage) String() string {
 	return proto.EnumName(CloudMigrate_Stage_name, int32(x))
 }
 func (CloudMigrate_Stage) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{164, 1}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{164, 1}
 }
 
 type CloudMigrate_Status int32
@@ -929,7 +929,7 @@ func (x CloudMigrate_Status) String() string {
 	return proto.EnumName(CloudMigrate_Status_name, int32(x))
 }
 func (CloudMigrate_Status) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{164, 2}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{164, 2}
 }
 
 // Defines the types of enforcement on the given rules
@@ -937,25 +937,25 @@ type VolumePlacementRule_EnforcementType int32
 
 const (
 	// This specifies that the rule is required and must be strictly enforced
-	VolumePlacementRule_Required VolumePlacementRule_EnforcementType = 0
+	VolumePlacementRule_required VolumePlacementRule_EnforcementType = 0
 	// This specifies that the rule is preferred and can be best effort
-	VolumePlacementRule_Preferred VolumePlacementRule_EnforcementType = 1
+	VolumePlacementRule_preferred VolumePlacementRule_EnforcementType = 1
 )
 
 var VolumePlacementRule_EnforcementType_name = map[int32]string{
-	0: "Required",
-	1: "Preferred",
+	0: "required",
+	1: "preferred",
 }
 var VolumePlacementRule_EnforcementType_value = map[string]int32{
-	"Required":  0,
-	"Preferred": 1,
+	"required":  0,
+	"preferred": 1,
 }
 
 func (x VolumePlacementRule_EnforcementType) String() string {
 	return proto.EnumName(VolumePlacementRule_EnforcementType_name, int32(x))
 }
 func (VolumePlacementRule_EnforcementType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{202, 0}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{202, 0}
 }
 
 // This specifies the type an affinity rule can take
@@ -963,25 +963,25 @@ type VolumePlacementRule_AffinityRuleType int32
 
 const (
 	// Affinity means the rule specifies an affinity to objects that match the below label selector requirements
-	VolumePlacementRule_Affinity VolumePlacementRule_AffinityRuleType = 0
+	VolumePlacementRule_affinity VolumePlacementRule_AffinityRuleType = 0
 	// AntiAffinity means the rule specifies an anti-affinity to objects that match the below label selector requirements
-	VolumePlacementRule_AntiAffinity VolumePlacementRule_AffinityRuleType = 1
+	VolumePlacementRule_antiAffinity VolumePlacementRule_AffinityRuleType = 1
 )
 
 var VolumePlacementRule_AffinityRuleType_name = map[int32]string{
-	0: "Affinity",
-	1: "AntiAffinity",
+	0: "affinity",
+	1: "antiAffinity",
 }
 var VolumePlacementRule_AffinityRuleType_value = map[string]int32{
-	"Affinity":     0,
-	"AntiAffinity": 1,
+	"affinity":     0,
+	"antiAffinity": 1,
 }
 
 func (x VolumePlacementRule_AffinityRuleType) String() string {
 	return proto.EnumName(VolumePlacementRule_AffinityRuleType_name, int32(x))
 }
 func (VolumePlacementRule_AffinityRuleType) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{202, 1}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{202, 1}
 }
 
 // This defines operator types used in a label matching rule
@@ -1023,7 +1023,7 @@ func (x LabelSelectorRequirement_Operator) String() string {
 	return proto.EnumName(LabelSelectorRequirement_Operator_name, int32(x))
 }
 func (LabelSelectorRequirement_Operator) EnumDescriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{203, 0}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{203, 0}
 }
 
 // StorageResource groups properties of a storage device.
@@ -1066,7 +1066,7 @@ func (m *StorageResource) Reset()         { *m = StorageResource{} }
 func (m *StorageResource) String() string { return proto.CompactTextString(m) }
 func (*StorageResource) ProtoMessage()    {}
 func (*StorageResource) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{0}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{0}
 }
 func (m *StorageResource) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StorageResource.Unmarshal(m, b)
@@ -1209,7 +1209,7 @@ func (m *StoragePool) Reset()         { *m = StoragePool{} }
 func (m *StoragePool) String() string { return proto.CompactTextString(m) }
 func (*StoragePool) ProtoMessage()    {}
 func (*StoragePool) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{1}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{1}
 }
 func (m *StoragePool) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StoragePool.Unmarshal(m, b)
@@ -1295,7 +1295,7 @@ func (m *VolumeLocator) Reset()         { *m = VolumeLocator{} }
 func (m *VolumeLocator) String() string { return proto.CompactTextString(m) }
 func (*VolumeLocator) ProtoMessage()    {}
 func (*VolumeLocator) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{2}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{2}
 }
 func (m *VolumeLocator) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeLocator.Unmarshal(m, b)
@@ -1347,7 +1347,7 @@ func (m *Source) Reset()         { *m = Source{} }
 func (m *Source) String() string { return proto.CompactTextString(m) }
 func (*Source) ProtoMessage()    {}
 func (*Source) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{3}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{3}
 }
 func (m *Source) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Source.Unmarshal(m, b)
@@ -1396,7 +1396,7 @@ func (m *Group) Reset()         { *m = Group{} }
 func (m *Group) String() string { return proto.CompactTextString(m) }
 func (*Group) ProtoMessage()    {}
 func (*Group) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{4}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{4}
 }
 func (m *Group) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Group.Unmarshal(m, b)
@@ -1438,7 +1438,7 @@ func (m *IoStrategy) Reset()         { *m = IoStrategy{} }
 func (m *IoStrategy) String() string { return proto.CompactTextString(m) }
 func (*IoStrategy) ProtoMessage()    {}
 func (*IoStrategy) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{5}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{5}
 }
 func (m *IoStrategy) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_IoStrategy.Unmarshal(m, b)
@@ -1544,7 +1544,7 @@ func (m *VolumeSpec) Reset()         { *m = VolumeSpec{} }
 func (m *VolumeSpec) String() string { return proto.CompactTextString(m) }
 func (*VolumeSpec) ProtoMessage()    {}
 func (*VolumeSpec) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{6}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{6}
 }
 func (m *VolumeSpec) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeSpec.Unmarshal(m, b)
@@ -1857,7 +1857,7 @@ func (m *VolumeSpecUpdate) Reset()         { *m = VolumeSpecUpdate{} }
 func (m *VolumeSpecUpdate) String() string { return proto.CompactTextString(m) }
 func (*VolumeSpecUpdate) ProtoMessage()    {}
 func (*VolumeSpecUpdate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{7}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{7}
 }
 func (m *VolumeSpecUpdate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeSpecUpdate.Unmarshal(m, b)
@@ -2650,7 +2650,7 @@ func (m *ReplicaSet) Reset()         { *m = ReplicaSet{} }
 func (m *ReplicaSet) String() string { return proto.CompactTextString(m) }
 func (*ReplicaSet) ProtoMessage()    {}
 func (*ReplicaSet) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{8}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{8}
 }
 func (m *ReplicaSet) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ReplicaSet.Unmarshal(m, b)
@@ -2691,7 +2691,7 @@ func (m *RuntimeStateMap) Reset()         { *m = RuntimeStateMap{} }
 func (m *RuntimeStateMap) String() string { return proto.CompactTextString(m) }
 func (*RuntimeStateMap) ProtoMessage()    {}
 func (*RuntimeStateMap) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{9}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{9}
 }
 func (m *RuntimeStateMap) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_RuntimeStateMap.Unmarshal(m, b)
@@ -2777,7 +2777,7 @@ func (m *Volume) Reset()         { *m = Volume{} }
 func (m *Volume) String() string { return proto.CompactTextString(m) }
 func (*Volume) ProtoMessage()    {}
 func (*Volume) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{10}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{10}
 }
 func (m *Volume) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Volume.Unmarshal(m, b)
@@ -2989,7 +2989,7 @@ func (m *Stats) Reset()         { *m = Stats{} }
 func (m *Stats) String() string { return proto.CompactTextString(m) }
 func (*Stats) ProtoMessage()    {}
 func (*Stats) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{11}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{11}
 }
 func (m *Stats) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Stats.Unmarshal(m, b)
@@ -3100,7 +3100,7 @@ func (m *CapacityUsageInfo) Reset()         { *m = CapacityUsageInfo{} }
 func (m *CapacityUsageInfo) String() string { return proto.CompactTextString(m) }
 func (*CapacityUsageInfo) ProtoMessage()    {}
 func (*CapacityUsageInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{12}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{12}
 }
 func (m *CapacityUsageInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CapacityUsageInfo.Unmarshal(m, b)
@@ -3176,7 +3176,7 @@ func (m *Alert) Reset()         { *m = Alert{} }
 func (m *Alert) String() string { return proto.CompactTextString(m) }
 func (*Alert) ProtoMessage()    {}
 func (*Alert) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{13}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{13}
 }
 func (m *Alert) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Alert.Unmarshal(m, b)
@@ -3295,7 +3295,7 @@ func (m *SdkAlertsTimeSpan) Reset()         { *m = SdkAlertsTimeSpan{} }
 func (m *SdkAlertsTimeSpan) String() string { return proto.CompactTextString(m) }
 func (*SdkAlertsTimeSpan) ProtoMessage()    {}
 func (*SdkAlertsTimeSpan) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{14}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{14}
 }
 func (m *SdkAlertsTimeSpan) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkAlertsTimeSpan.Unmarshal(m, b)
@@ -3344,7 +3344,7 @@ func (m *SdkAlertsCountSpan) Reset()         { *m = SdkAlertsCountSpan{} }
 func (m *SdkAlertsCountSpan) String() string { return proto.CompactTextString(m) }
 func (*SdkAlertsCountSpan) ProtoMessage()    {}
 func (*SdkAlertsCountSpan) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{15}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{15}
 }
 func (m *SdkAlertsCountSpan) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkAlertsCountSpan.Unmarshal(m, b)
@@ -3395,7 +3395,7 @@ func (m *SdkAlertsOption) Reset()         { *m = SdkAlertsOption{} }
 func (m *SdkAlertsOption) String() string { return proto.CompactTextString(m) }
 func (*SdkAlertsOption) ProtoMessage()    {}
 func (*SdkAlertsOption) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{16}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{16}
 }
 func (m *SdkAlertsOption) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkAlertsOption.Unmarshal(m, b)
@@ -3591,7 +3591,7 @@ func (m *SdkAlertsResourceTypeQuery) Reset()         { *m = SdkAlertsResourceTyp
 func (m *SdkAlertsResourceTypeQuery) String() string { return proto.CompactTextString(m) }
 func (*SdkAlertsResourceTypeQuery) ProtoMessage()    {}
 func (*SdkAlertsResourceTypeQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{17}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{17}
 }
 func (m *SdkAlertsResourceTypeQuery) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkAlertsResourceTypeQuery.Unmarshal(m, b)
@@ -3634,7 +3634,7 @@ func (m *SdkAlertsAlertTypeQuery) Reset()         { *m = SdkAlertsAlertTypeQuery
 func (m *SdkAlertsAlertTypeQuery) String() string { return proto.CompactTextString(m) }
 func (*SdkAlertsAlertTypeQuery) ProtoMessage()    {}
 func (*SdkAlertsAlertTypeQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{18}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{18}
 }
 func (m *SdkAlertsAlertTypeQuery) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkAlertsAlertTypeQuery.Unmarshal(m, b)
@@ -3687,7 +3687,7 @@ func (m *SdkAlertsResourceIdQuery) Reset()         { *m = SdkAlertsResourceIdQue
 func (m *SdkAlertsResourceIdQuery) String() string { return proto.CompactTextString(m) }
 func (*SdkAlertsResourceIdQuery) ProtoMessage()    {}
 func (*SdkAlertsResourceIdQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{19}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{19}
 }
 func (m *SdkAlertsResourceIdQuery) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkAlertsResourceIdQuery.Unmarshal(m, b)
@@ -3750,7 +3750,7 @@ func (m *SdkAlertsQuery) Reset()         { *m = SdkAlertsQuery{} }
 func (m *SdkAlertsQuery) String() string { return proto.CompactTextString(m) }
 func (*SdkAlertsQuery) ProtoMessage()    {}
 func (*SdkAlertsQuery) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{20}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{20}
 }
 func (m *SdkAlertsQuery) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkAlertsQuery.Unmarshal(m, b)
@@ -3933,7 +3933,7 @@ func (m *SdkAlertsEnumerateWithFiltersRequest) Reset()         { *m = SdkAlertsE
 func (m *SdkAlertsEnumerateWithFiltersRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkAlertsEnumerateWithFiltersRequest) ProtoMessage()    {}
 func (*SdkAlertsEnumerateWithFiltersRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{21}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{21}
 }
 func (m *SdkAlertsEnumerateWithFiltersRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkAlertsEnumerateWithFiltersRequest.Unmarshal(m, b)
@@ -3973,7 +3973,7 @@ func (m *SdkAlertsEnumerateWithFiltersResponse) Reset()         { *m = SdkAlerts
 func (m *SdkAlertsEnumerateWithFiltersResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkAlertsEnumerateWithFiltersResponse) ProtoMessage()    {}
 func (*SdkAlertsEnumerateWithFiltersResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{22}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{22}
 }
 func (m *SdkAlertsEnumerateWithFiltersResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkAlertsEnumerateWithFiltersResponse.Unmarshal(m, b)
@@ -4014,7 +4014,7 @@ func (m *SdkAlertsDeleteRequest) Reset()         { *m = SdkAlertsDeleteRequest{}
 func (m *SdkAlertsDeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkAlertsDeleteRequest) ProtoMessage()    {}
 func (*SdkAlertsDeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{23}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{23}
 }
 func (m *SdkAlertsDeleteRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkAlertsDeleteRequest.Unmarshal(m, b)
@@ -4052,7 +4052,7 @@ func (m *SdkAlertsDeleteResponse) Reset()         { *m = SdkAlertsDeleteResponse
 func (m *SdkAlertsDeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkAlertsDeleteResponse) ProtoMessage()    {}
 func (*SdkAlertsDeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{24}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{24}
 }
 func (m *SdkAlertsDeleteResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkAlertsDeleteResponse.Unmarshal(m, b)
@@ -4085,7 +4085,7 @@ func (m *SdkSchedulePolicyCreateRequest) Reset()         { *m = SdkSchedulePolic
 func (m *SdkSchedulePolicyCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkSchedulePolicyCreateRequest) ProtoMessage()    {}
 func (*SdkSchedulePolicyCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{25}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{25}
 }
 func (m *SdkSchedulePolicyCreateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkSchedulePolicyCreateRequest.Unmarshal(m, b)
@@ -4125,7 +4125,7 @@ func (m *Alerts) Reset()         { *m = Alerts{} }
 func (m *Alerts) String() string { return proto.CompactTextString(m) }
 func (*Alerts) ProtoMessage()    {}
 func (*Alerts) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{26}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{26}
 }
 func (m *Alerts) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Alerts.Unmarshal(m, b)
@@ -4186,7 +4186,7 @@ func (m *ObjectstoreInfo) Reset()         { *m = ObjectstoreInfo{} }
 func (m *ObjectstoreInfo) String() string { return proto.CompactTextString(m) }
 func (*ObjectstoreInfo) ProtoMessage()    {}
 func (*ObjectstoreInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{27}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{27}
 }
 func (m *ObjectstoreInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ObjectstoreInfo.Unmarshal(m, b)
@@ -4302,7 +4302,7 @@ func (m *VolumeCreateRequest) Reset()         { *m = VolumeCreateRequest{} }
 func (m *VolumeCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*VolumeCreateRequest) ProtoMessage()    {}
 func (*VolumeCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{28}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{28}
 }
 func (m *VolumeCreateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeCreateRequest.Unmarshal(m, b)
@@ -4360,7 +4360,7 @@ func (m *VolumeResponse) Reset()         { *m = VolumeResponse{} }
 func (m *VolumeResponse) String() string { return proto.CompactTextString(m) }
 func (*VolumeResponse) ProtoMessage()    {}
 func (*VolumeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{29}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{29}
 }
 func (m *VolumeResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeResponse.Unmarshal(m, b)
@@ -4409,7 +4409,7 @@ func (m *VolumeCreateResponse) Reset()         { *m = VolumeCreateResponse{} }
 func (m *VolumeCreateResponse) String() string { return proto.CompactTextString(m) }
 func (*VolumeCreateResponse) ProtoMessage()    {}
 func (*VolumeCreateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{30}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{30}
 }
 func (m *VolumeCreateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeCreateResponse.Unmarshal(m, b)
@@ -4463,7 +4463,7 @@ func (m *VolumeStateAction) Reset()         { *m = VolumeStateAction{} }
 func (m *VolumeStateAction) String() string { return proto.CompactTextString(m) }
 func (*VolumeStateAction) ProtoMessage()    {}
 func (*VolumeStateAction) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{31}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{31}
 }
 func (m *VolumeStateAction) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeStateAction.Unmarshal(m, b)
@@ -4532,7 +4532,7 @@ func (m *VolumeSetRequest) Reset()         { *m = VolumeSetRequest{} }
 func (m *VolumeSetRequest) String() string { return proto.CompactTextString(m) }
 func (*VolumeSetRequest) ProtoMessage()    {}
 func (*VolumeSetRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{32}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{32}
 }
 func (m *VolumeSetRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeSetRequest.Unmarshal(m, b)
@@ -4602,7 +4602,7 @@ func (m *VolumeSetResponse) Reset()         { *m = VolumeSetResponse{} }
 func (m *VolumeSetResponse) String() string { return proto.CompactTextString(m) }
 func (*VolumeSetResponse) ProtoMessage()    {}
 func (*VolumeSetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{33}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{33}
 }
 func (m *VolumeSetResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeSetResponse.Unmarshal(m, b)
@@ -4654,7 +4654,7 @@ func (m *SnapCreateRequest) Reset()         { *m = SnapCreateRequest{} }
 func (m *SnapCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*SnapCreateRequest) ProtoMessage()    {}
 func (*SnapCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{34}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{34}
 }
 func (m *SnapCreateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SnapCreateRequest.Unmarshal(m, b)
@@ -4719,7 +4719,7 @@ func (m *SnapCreateResponse) Reset()         { *m = SnapCreateResponse{} }
 func (m *SnapCreateResponse) String() string { return proto.CompactTextString(m) }
 func (*SnapCreateResponse) ProtoMessage()    {}
 func (*SnapCreateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{35}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{35}
 }
 func (m *SnapCreateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SnapCreateResponse.Unmarshal(m, b)
@@ -4761,7 +4761,7 @@ func (m *VolumeInfo) Reset()         { *m = VolumeInfo{} }
 func (m *VolumeInfo) String() string { return proto.CompactTextString(m) }
 func (*VolumeInfo) ProtoMessage()    {}
 func (*VolumeInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{36}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{36}
 }
 func (m *VolumeInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeInfo.Unmarshal(m, b)
@@ -4833,7 +4833,7 @@ func (m *VolumeConsumer) Reset()         { *m = VolumeConsumer{} }
 func (m *VolumeConsumer) String() string { return proto.CompactTextString(m) }
 func (*VolumeConsumer) ProtoMessage()    {}
 func (*VolumeConsumer) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{37}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{37}
 }
 func (m *VolumeConsumer) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumeConsumer.Unmarshal(m, b)
@@ -4912,7 +4912,7 @@ func (m *GraphDriverChanges) Reset()         { *m = GraphDriverChanges{} }
 func (m *GraphDriverChanges) String() string { return proto.CompactTextString(m) }
 func (*GraphDriverChanges) ProtoMessage()    {}
 func (*GraphDriverChanges) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{38}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{38}
 }
 func (m *GraphDriverChanges) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GraphDriverChanges.Unmarshal(m, b)
@@ -4962,7 +4962,7 @@ func (m *ClusterResponse) Reset()         { *m = ClusterResponse{} }
 func (m *ClusterResponse) String() string { return proto.CompactTextString(m) }
 func (*ClusterResponse) ProtoMessage()    {}
 func (*ClusterResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{39}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{39}
 }
 func (m *ClusterResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ClusterResponse.Unmarshal(m, b)
@@ -5002,7 +5002,7 @@ func (m *ActiveRequest) Reset()         { *m = ActiveRequest{} }
 func (m *ActiveRequest) String() string { return proto.CompactTextString(m) }
 func (*ActiveRequest) ProtoMessage()    {}
 func (*ActiveRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{40}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{40}
 }
 func (m *ActiveRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ActiveRequest.Unmarshal(m, b)
@@ -5043,7 +5043,7 @@ func (m *ActiveRequests) Reset()         { *m = ActiveRequests{} }
 func (m *ActiveRequests) String() string { return proto.CompactTextString(m) }
 func (*ActiveRequests) ProtoMessage()    {}
 func (*ActiveRequests) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{41}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{41}
 }
 func (m *ActiveRequests) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ActiveRequests.Unmarshal(m, b)
@@ -5091,7 +5091,7 @@ func (m *GroupSnapCreateRequest) Reset()         { *m = GroupSnapCreateRequest{}
 func (m *GroupSnapCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*GroupSnapCreateRequest) ProtoMessage()    {}
 func (*GroupSnapCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{42}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{42}
 }
 func (m *GroupSnapCreateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GroupSnapCreateRequest.Unmarshal(m, b)
@@ -5147,7 +5147,7 @@ func (m *GroupSnapCreateResponse) Reset()         { *m = GroupSnapCreateResponse
 func (m *GroupSnapCreateResponse) String() string { return proto.CompactTextString(m) }
 func (*GroupSnapCreateResponse) ProtoMessage()    {}
 func (*GroupSnapCreateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{43}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{43}
 }
 func (m *GroupSnapCreateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_GroupSnapCreateResponse.Unmarshal(m, b)
@@ -5221,7 +5221,7 @@ func (m *StorageNode) Reset()         { *m = StorageNode{} }
 func (m *StorageNode) String() string { return proto.CompactTextString(m) }
 func (*StorageNode) ProtoMessage()    {}
 func (*StorageNode) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{44}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{44}
 }
 func (m *StorageNode) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StorageNode.Unmarshal(m, b)
@@ -5356,7 +5356,7 @@ func (m *StorageCluster) Reset()         { *m = StorageCluster{} }
 func (m *StorageCluster) String() string { return proto.CompactTextString(m) }
 func (*StorageCluster) ProtoMessage()    {}
 func (*StorageCluster) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{45}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{45}
 }
 func (m *StorageCluster) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StorageCluster.Unmarshal(m, b)
@@ -5408,7 +5408,7 @@ func (m *SdkSchedulePolicyCreateResponse) Reset()         { *m = SdkSchedulePoli
 func (m *SdkSchedulePolicyCreateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkSchedulePolicyCreateResponse) ProtoMessage()    {}
 func (*SdkSchedulePolicyCreateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{46}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{46}
 }
 func (m *SdkSchedulePolicyCreateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkSchedulePolicyCreateResponse.Unmarshal(m, b)
@@ -5441,7 +5441,7 @@ func (m *SdkSchedulePolicyUpdateRequest) Reset()         { *m = SdkSchedulePolic
 func (m *SdkSchedulePolicyUpdateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkSchedulePolicyUpdateRequest) ProtoMessage()    {}
 func (*SdkSchedulePolicyUpdateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{47}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{47}
 }
 func (m *SdkSchedulePolicyUpdateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkSchedulePolicyUpdateRequest.Unmarshal(m, b)
@@ -5479,7 +5479,7 @@ func (m *SdkSchedulePolicyUpdateResponse) Reset()         { *m = SdkSchedulePoli
 func (m *SdkSchedulePolicyUpdateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkSchedulePolicyUpdateResponse) ProtoMessage()    {}
 func (*SdkSchedulePolicyUpdateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{48}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{48}
 }
 func (m *SdkSchedulePolicyUpdateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkSchedulePolicyUpdateResponse.Unmarshal(m, b)
@@ -5510,7 +5510,7 @@ func (m *SdkSchedulePolicyEnumerateRequest) Reset()         { *m = SdkSchedulePo
 func (m *SdkSchedulePolicyEnumerateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkSchedulePolicyEnumerateRequest) ProtoMessage()    {}
 func (*SdkSchedulePolicyEnumerateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{49}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{49}
 }
 func (m *SdkSchedulePolicyEnumerateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkSchedulePolicyEnumerateRequest.Unmarshal(m, b)
@@ -5543,7 +5543,7 @@ func (m *SdkSchedulePolicyEnumerateResponse) Reset()         { *m = SdkScheduleP
 func (m *SdkSchedulePolicyEnumerateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkSchedulePolicyEnumerateResponse) ProtoMessage()    {}
 func (*SdkSchedulePolicyEnumerateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{50}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{50}
 }
 func (m *SdkSchedulePolicyEnumerateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkSchedulePolicyEnumerateResponse.Unmarshal(m, b)
@@ -5583,7 +5583,7 @@ func (m *SdkSchedulePolicyInspectRequest) Reset()         { *m = SdkSchedulePoli
 func (m *SdkSchedulePolicyInspectRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkSchedulePolicyInspectRequest) ProtoMessage()    {}
 func (*SdkSchedulePolicyInspectRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{51}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{51}
 }
 func (m *SdkSchedulePolicyInspectRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkSchedulePolicyInspectRequest.Unmarshal(m, b)
@@ -5623,7 +5623,7 @@ func (m *SdkSchedulePolicyInspectResponse) Reset()         { *m = SdkSchedulePol
 func (m *SdkSchedulePolicyInspectResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkSchedulePolicyInspectResponse) ProtoMessage()    {}
 func (*SdkSchedulePolicyInspectResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{52}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{52}
 }
 func (m *SdkSchedulePolicyInspectResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkSchedulePolicyInspectResponse.Unmarshal(m, b)
@@ -5663,7 +5663,7 @@ func (m *SdkSchedulePolicyDeleteRequest) Reset()         { *m = SdkSchedulePolic
 func (m *SdkSchedulePolicyDeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkSchedulePolicyDeleteRequest) ProtoMessage()    {}
 func (*SdkSchedulePolicyDeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{53}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{53}
 }
 func (m *SdkSchedulePolicyDeleteRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkSchedulePolicyDeleteRequest.Unmarshal(m, b)
@@ -5701,7 +5701,7 @@ func (m *SdkSchedulePolicyDeleteResponse) Reset()         { *m = SdkSchedulePoli
 func (m *SdkSchedulePolicyDeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkSchedulePolicyDeleteResponse) ProtoMessage()    {}
 func (*SdkSchedulePolicyDeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{54}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{54}
 }
 func (m *SdkSchedulePolicyDeleteResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkSchedulePolicyDeleteResponse.Unmarshal(m, b)
@@ -5736,7 +5736,7 @@ func (m *SdkSchedulePolicyIntervalDaily) Reset()         { *m = SdkSchedulePolic
 func (m *SdkSchedulePolicyIntervalDaily) String() string { return proto.CompactTextString(m) }
 func (*SdkSchedulePolicyIntervalDaily) ProtoMessage()    {}
 func (*SdkSchedulePolicyIntervalDaily) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{55}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{55}
 }
 func (m *SdkSchedulePolicyIntervalDaily) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkSchedulePolicyIntervalDaily.Unmarshal(m, b)
@@ -5786,7 +5786,7 @@ func (m *SdkSchedulePolicyIntervalWeekly) Reset()         { *m = SdkSchedulePoli
 func (m *SdkSchedulePolicyIntervalWeekly) String() string { return proto.CompactTextString(m) }
 func (*SdkSchedulePolicyIntervalWeekly) ProtoMessage()    {}
 func (*SdkSchedulePolicyIntervalWeekly) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{56}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{56}
 }
 func (m *SdkSchedulePolicyIntervalWeekly) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkSchedulePolicyIntervalWeekly.Unmarshal(m, b)
@@ -5844,7 +5844,7 @@ func (m *SdkSchedulePolicyIntervalMonthly) Reset()         { *m = SdkSchedulePol
 func (m *SdkSchedulePolicyIntervalMonthly) String() string { return proto.CompactTextString(m) }
 func (*SdkSchedulePolicyIntervalMonthly) ProtoMessage()    {}
 func (*SdkSchedulePolicyIntervalMonthly) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{57}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{57}
 }
 func (m *SdkSchedulePolicyIntervalMonthly) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkSchedulePolicyIntervalMonthly.Unmarshal(m, b)
@@ -5898,7 +5898,7 @@ func (m *SdkSchedulePolicyIntervalPeriodic) Reset()         { *m = SdkSchedulePo
 func (m *SdkSchedulePolicyIntervalPeriodic) String() string { return proto.CompactTextString(m) }
 func (*SdkSchedulePolicyIntervalPeriodic) ProtoMessage()    {}
 func (*SdkSchedulePolicyIntervalPeriodic) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{58}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{58}
 }
 func (m *SdkSchedulePolicyIntervalPeriodic) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkSchedulePolicyIntervalPeriodic.Unmarshal(m, b)
@@ -5946,7 +5946,7 @@ func (m *SdkSchedulePolicyInterval) Reset()         { *m = SdkSchedulePolicyInte
 func (m *SdkSchedulePolicyInterval) String() string { return proto.CompactTextString(m) }
 func (*SdkSchedulePolicyInterval) ProtoMessage()    {}
 func (*SdkSchedulePolicyInterval) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{59}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{59}
 }
 func (m *SdkSchedulePolicyInterval) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkSchedulePolicyInterval.Unmarshal(m, b)
@@ -6157,7 +6157,7 @@ func (m *SdkSchedulePolicy) Reset()         { *m = SdkSchedulePolicy{} }
 func (m *SdkSchedulePolicy) String() string { return proto.CompactTextString(m) }
 func (*SdkSchedulePolicy) ProtoMessage()    {}
 func (*SdkSchedulePolicy) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{60}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{60}
 }
 func (m *SdkSchedulePolicy) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkSchedulePolicy.Unmarshal(m, b)
@@ -6215,7 +6215,7 @@ func (m *SdkCredentialCreateRequest) Reset()         { *m = SdkCredentialCreateR
 func (m *SdkCredentialCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCredentialCreateRequest) ProtoMessage()    {}
 func (*SdkCredentialCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{61}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{61}
 }
 func (m *SdkCredentialCreateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCredentialCreateRequest.Unmarshal(m, b)
@@ -6408,7 +6408,7 @@ func (m *SdkCredentialCreateResponse) Reset()         { *m = SdkCredentialCreate
 func (m *SdkCredentialCreateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkCredentialCreateResponse) ProtoMessage()    {}
 func (*SdkCredentialCreateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{62}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{62}
 }
 func (m *SdkCredentialCreateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCredentialCreateResponse.Unmarshal(m, b)
@@ -6456,7 +6456,7 @@ func (m *SdkAwsCredentialRequest) Reset()         { *m = SdkAwsCredentialRequest
 func (m *SdkAwsCredentialRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkAwsCredentialRequest) ProtoMessage()    {}
 func (*SdkAwsCredentialRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{63}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{63}
 }
 func (m *SdkAwsCredentialRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkAwsCredentialRequest.Unmarshal(m, b)
@@ -6526,7 +6526,7 @@ func (m *SdkAzureCredentialRequest) Reset()         { *m = SdkAzureCredentialReq
 func (m *SdkAzureCredentialRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkAzureCredentialRequest) ProtoMessage()    {}
 func (*SdkAzureCredentialRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{64}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{64}
 }
 func (m *SdkAzureCredentialRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkAzureCredentialRequest.Unmarshal(m, b)
@@ -6575,7 +6575,7 @@ func (m *SdkGoogleCredentialRequest) Reset()         { *m = SdkGoogleCredentialR
 func (m *SdkGoogleCredentialRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkGoogleCredentialRequest) ProtoMessage()    {}
 func (*SdkGoogleCredentialRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{65}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{65}
 }
 func (m *SdkGoogleCredentialRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkGoogleCredentialRequest.Unmarshal(m, b)
@@ -6628,7 +6628,7 @@ func (m *SdkAwsCredentialResponse) Reset()         { *m = SdkAwsCredentialRespon
 func (m *SdkAwsCredentialResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkAwsCredentialResponse) ProtoMessage()    {}
 func (*SdkAwsCredentialResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{66}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{66}
 }
 func (m *SdkAwsCredentialResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkAwsCredentialResponse.Unmarshal(m, b)
@@ -6689,7 +6689,7 @@ func (m *SdkAzureCredentialResponse) Reset()         { *m = SdkAzureCredentialRe
 func (m *SdkAzureCredentialResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkAzureCredentialResponse) ProtoMessage()    {}
 func (*SdkAzureCredentialResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{67}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{67}
 }
 func (m *SdkAzureCredentialResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkAzureCredentialResponse.Unmarshal(m, b)
@@ -6729,7 +6729,7 @@ func (m *SdkGoogleCredentialResponse) Reset()         { *m = SdkGoogleCredential
 func (m *SdkGoogleCredentialResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkGoogleCredentialResponse) ProtoMessage()    {}
 func (*SdkGoogleCredentialResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{68}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{68}
 }
 func (m *SdkGoogleCredentialResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkGoogleCredentialResponse.Unmarshal(m, b)
@@ -6767,7 +6767,7 @@ func (m *SdkCredentialEnumerateRequest) Reset()         { *m = SdkCredentialEnum
 func (m *SdkCredentialEnumerateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCredentialEnumerateRequest) ProtoMessage()    {}
 func (*SdkCredentialEnumerateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{69}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{69}
 }
 func (m *SdkCredentialEnumerateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCredentialEnumerateRequest.Unmarshal(m, b)
@@ -6800,7 +6800,7 @@ func (m *SdkCredentialEnumerateResponse) Reset()         { *m = SdkCredentialEnu
 func (m *SdkCredentialEnumerateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkCredentialEnumerateResponse) ProtoMessage()    {}
 func (*SdkCredentialEnumerateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{70}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{70}
 }
 func (m *SdkCredentialEnumerateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCredentialEnumerateResponse.Unmarshal(m, b)
@@ -6840,7 +6840,7 @@ func (m *SdkCredentialInspectRequest) Reset()         { *m = SdkCredentialInspec
 func (m *SdkCredentialInspectRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCredentialInspectRequest) ProtoMessage()    {}
 func (*SdkCredentialInspectRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{71}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{71}
 }
 func (m *SdkCredentialInspectRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCredentialInspectRequest.Unmarshal(m, b)
@@ -6893,7 +6893,7 @@ func (m *SdkCredentialInspectResponse) Reset()         { *m = SdkCredentialInspe
 func (m *SdkCredentialInspectResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkCredentialInspectResponse) ProtoMessage()    {}
 func (*SdkCredentialInspectResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{72}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{72}
 }
 func (m *SdkCredentialInspectResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCredentialInspectResponse.Unmarshal(m, b)
@@ -7087,7 +7087,7 @@ func (m *SdkCredentialDeleteRequest) Reset()         { *m = SdkCredentialDeleteR
 func (m *SdkCredentialDeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCredentialDeleteRequest) ProtoMessage()    {}
 func (*SdkCredentialDeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{73}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{73}
 }
 func (m *SdkCredentialDeleteRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCredentialDeleteRequest.Unmarshal(m, b)
@@ -7125,7 +7125,7 @@ func (m *SdkCredentialDeleteResponse) Reset()         { *m = SdkCredentialDelete
 func (m *SdkCredentialDeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkCredentialDeleteResponse) ProtoMessage()    {}
 func (*SdkCredentialDeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{74}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{74}
 }
 func (m *SdkCredentialDeleteResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCredentialDeleteResponse.Unmarshal(m, b)
@@ -7158,7 +7158,7 @@ func (m *SdkCredentialValidateRequest) Reset()         { *m = SdkCredentialValid
 func (m *SdkCredentialValidateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCredentialValidateRequest) ProtoMessage()    {}
 func (*SdkCredentialValidateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{75}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{75}
 }
 func (m *SdkCredentialValidateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCredentialValidateRequest.Unmarshal(m, b)
@@ -7196,7 +7196,7 @@ func (m *SdkCredentialValidateResponse) Reset()         { *m = SdkCredentialVali
 func (m *SdkCredentialValidateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkCredentialValidateResponse) ProtoMessage()    {}
 func (*SdkCredentialValidateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{76}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{76}
 }
 func (m *SdkCredentialValidateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCredentialValidateResponse.Unmarshal(m, b)
@@ -7231,7 +7231,7 @@ func (m *SdkVolumeMountRequest) Reset()         { *m = SdkVolumeMountRequest{} }
 func (m *SdkVolumeMountRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeMountRequest) ProtoMessage()    {}
 func (*SdkVolumeMountRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{77}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{77}
 }
 func (m *SdkVolumeMountRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeMountRequest.Unmarshal(m, b)
@@ -7276,7 +7276,7 @@ func (m *SdkVolumeMountResponse) Reset()         { *m = SdkVolumeMountResponse{}
 func (m *SdkVolumeMountResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeMountResponse) ProtoMessage()    {}
 func (*SdkVolumeMountResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{78}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{78}
 }
 func (m *SdkVolumeMountResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeMountResponse.Unmarshal(m, b)
@@ -7313,7 +7313,7 @@ func (m *SdkVolumeUnmountRequest) Reset()         { *m = SdkVolumeUnmountRequest
 func (m *SdkVolumeUnmountRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeUnmountRequest) ProtoMessage()    {}
 func (*SdkVolumeUnmountRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{79}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{79}
 }
 func (m *SdkVolumeUnmountRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeUnmountRequest.Unmarshal(m, b)
@@ -7373,7 +7373,7 @@ func (m *SdkVolumeUnmountRequest_Options) Reset()         { *m = SdkVolumeUnmoun
 func (m *SdkVolumeUnmountRequest_Options) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeUnmountRequest_Options) ProtoMessage()    {}
 func (*SdkVolumeUnmountRequest_Options) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{79, 0}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{79, 0}
 }
 func (m *SdkVolumeUnmountRequest_Options) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeUnmountRequest_Options.Unmarshal(m, b)
@@ -7418,7 +7418,7 @@ func (m *SdkVolumeUnmountResponse) Reset()         { *m = SdkVolumeUnmountRespon
 func (m *SdkVolumeUnmountResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeUnmountResponse) ProtoMessage()    {}
 func (*SdkVolumeUnmountResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{80}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{80}
 }
 func (m *SdkVolumeUnmountResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeUnmountResponse.Unmarshal(m, b)
@@ -7453,7 +7453,7 @@ func (m *SdkVolumeAttachRequest) Reset()         { *m = SdkVolumeAttachRequest{}
 func (m *SdkVolumeAttachRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeAttachRequest) ProtoMessage()    {}
 func (*SdkVolumeAttachRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{81}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{81}
 }
 func (m *SdkVolumeAttachRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeAttachRequest.Unmarshal(m, b)
@@ -7507,7 +7507,7 @@ func (m *SdkVolumeAttachRequest_Options) Reset()         { *m = SdkVolumeAttachR
 func (m *SdkVolumeAttachRequest_Options) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeAttachRequest_Options) ProtoMessage()    {}
 func (*SdkVolumeAttachRequest_Options) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{81, 0}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{81, 0}
 }
 func (m *SdkVolumeAttachRequest_Options) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeAttachRequest_Options.Unmarshal(m, b)
@@ -7561,7 +7561,7 @@ func (m *SdkVolumeAttachResponse) Reset()         { *m = SdkVolumeAttachResponse
 func (m *SdkVolumeAttachResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeAttachResponse) ProtoMessage()    {}
 func (*SdkVolumeAttachResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{82}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{82}
 }
 func (m *SdkVolumeAttachResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeAttachResponse.Unmarshal(m, b)
@@ -7602,7 +7602,7 @@ func (m *SdkVolumeDetachRequest) Reset()         { *m = SdkVolumeDetachRequest{}
 func (m *SdkVolumeDetachRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeDetachRequest) ProtoMessage()    {}
 func (*SdkVolumeDetachRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{83}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{83}
 }
 func (m *SdkVolumeDetachRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeDetachRequest.Unmarshal(m, b)
@@ -7651,7 +7651,7 @@ func (m *SdkVolumeDetachRequest_Options) Reset()         { *m = SdkVolumeDetachR
 func (m *SdkVolumeDetachRequest_Options) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeDetachRequest_Options) ProtoMessage()    {}
 func (*SdkVolumeDetachRequest_Options) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{83, 0}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{83, 0}
 }
 func (m *SdkVolumeDetachRequest_Options) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeDetachRequest_Options.Unmarshal(m, b)
@@ -7696,7 +7696,7 @@ func (m *SdkVolumeDetachResponse) Reset()         { *m = SdkVolumeDetachResponse
 func (m *SdkVolumeDetachResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeDetachResponse) ProtoMessage()    {}
 func (*SdkVolumeDetachResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{84}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{84}
 }
 func (m *SdkVolumeDetachResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeDetachResponse.Unmarshal(m, b)
@@ -7732,7 +7732,7 @@ func (m *SdkVolumeCreateRequest) Reset()         { *m = SdkVolumeCreateRequest{}
 func (m *SdkVolumeCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeCreateRequest) ProtoMessage()    {}
 func (*SdkVolumeCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{85}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{85}
 }
 func (m *SdkVolumeCreateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeCreateRequest.Unmarshal(m, b)
@@ -7779,7 +7779,7 @@ func (m *SdkVolumeCreateResponse) Reset()         { *m = SdkVolumeCreateResponse
 func (m *SdkVolumeCreateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeCreateResponse) ProtoMessage()    {}
 func (*SdkVolumeCreateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{86}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{86}
 }
 func (m *SdkVolumeCreateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeCreateResponse.Unmarshal(m, b)
@@ -7821,7 +7821,7 @@ func (m *SdkVolumeCloneRequest) Reset()         { *m = SdkVolumeCloneRequest{} }
 func (m *SdkVolumeCloneRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeCloneRequest) ProtoMessage()    {}
 func (*SdkVolumeCloneRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{87}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{87}
 }
 func (m *SdkVolumeCloneRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeCloneRequest.Unmarshal(m, b)
@@ -7868,7 +7868,7 @@ func (m *SdkVolumeCloneResponse) Reset()         { *m = SdkVolumeCloneResponse{}
 func (m *SdkVolumeCloneResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeCloneResponse) ProtoMessage()    {}
 func (*SdkVolumeCloneResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{88}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{88}
 }
 func (m *SdkVolumeCloneResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeCloneResponse.Unmarshal(m, b)
@@ -7908,7 +7908,7 @@ func (m *SdkVolumeDeleteRequest) Reset()         { *m = SdkVolumeDeleteRequest{}
 func (m *SdkVolumeDeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeDeleteRequest) ProtoMessage()    {}
 func (*SdkVolumeDeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{89}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{89}
 }
 func (m *SdkVolumeDeleteRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeDeleteRequest.Unmarshal(m, b)
@@ -7946,7 +7946,7 @@ func (m *SdkVolumeDeleteResponse) Reset()         { *m = SdkVolumeDeleteResponse
 func (m *SdkVolumeDeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeDeleteResponse) ProtoMessage()    {}
 func (*SdkVolumeDeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{90}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{90}
 }
 func (m *SdkVolumeDeleteResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeDeleteResponse.Unmarshal(m, b)
@@ -7979,7 +7979,7 @@ func (m *SdkVolumeInspectRequest) Reset()         { *m = SdkVolumeInspectRequest
 func (m *SdkVolumeInspectRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeInspectRequest) ProtoMessage()    {}
 func (*SdkVolumeInspectRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{91}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{91}
 }
 func (m *SdkVolumeInspectRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeInspectRequest.Unmarshal(m, b)
@@ -8019,7 +8019,7 @@ func (m *SdkVolumeInspectResponse) Reset()         { *m = SdkVolumeInspectRespon
 func (m *SdkVolumeInspectResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeInspectResponse) ProtoMessage()    {}
 func (*SdkVolumeInspectResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{92}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{92}
 }
 func (m *SdkVolumeInspectResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeInspectResponse.Unmarshal(m, b)
@@ -8073,7 +8073,7 @@ func (m *SdkVolumeUpdateRequest) Reset()         { *m = SdkVolumeUpdateRequest{}
 func (m *SdkVolumeUpdateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeUpdateRequest) ProtoMessage()    {}
 func (*SdkVolumeUpdateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{93}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{93}
 }
 func (m *SdkVolumeUpdateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeUpdateRequest.Unmarshal(m, b)
@@ -8125,7 +8125,7 @@ func (m *SdkVolumeUpdateResponse) Reset()         { *m = SdkVolumeUpdateResponse
 func (m *SdkVolumeUpdateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeUpdateResponse) ProtoMessage()    {}
 func (*SdkVolumeUpdateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{94}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{94}
 }
 func (m *SdkVolumeUpdateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeUpdateResponse.Unmarshal(m, b)
@@ -8161,7 +8161,7 @@ func (m *SdkVolumeStatsRequest) Reset()         { *m = SdkVolumeStatsRequest{} }
 func (m *SdkVolumeStatsRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeStatsRequest) ProtoMessage()    {}
 func (*SdkVolumeStatsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{95}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{95}
 }
 func (m *SdkVolumeStatsRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeStatsRequest.Unmarshal(m, b)
@@ -8208,7 +8208,7 @@ func (m *SdkVolumeStatsResponse) Reset()         { *m = SdkVolumeStatsResponse{}
 func (m *SdkVolumeStatsResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeStatsResponse) ProtoMessage()    {}
 func (*SdkVolumeStatsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{96}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{96}
 }
 func (m *SdkVolumeStatsResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeStatsResponse.Unmarshal(m, b)
@@ -8248,7 +8248,7 @@ func (m *SdkVolumeCapacityUsageRequest) Reset()         { *m = SdkVolumeCapacity
 func (m *SdkVolumeCapacityUsageRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeCapacityUsageRequest) ProtoMessage()    {}
 func (*SdkVolumeCapacityUsageRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{97}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{97}
 }
 func (m *SdkVolumeCapacityUsageRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeCapacityUsageRequest.Unmarshal(m, b)
@@ -8288,7 +8288,7 @@ func (m *SdkVolumeCapacityUsageResponse) Reset()         { *m = SdkVolumeCapacit
 func (m *SdkVolumeCapacityUsageResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeCapacityUsageResponse) ProtoMessage()    {}
 func (*SdkVolumeCapacityUsageResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{98}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{98}
 }
 func (m *SdkVolumeCapacityUsageResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeCapacityUsageResponse.Unmarshal(m, b)
@@ -8326,7 +8326,7 @@ func (m *SdkVolumeEnumerateRequest) Reset()         { *m = SdkVolumeEnumerateReq
 func (m *SdkVolumeEnumerateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeEnumerateRequest) ProtoMessage()    {}
 func (*SdkVolumeEnumerateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{99}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{99}
 }
 func (m *SdkVolumeEnumerateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeEnumerateRequest.Unmarshal(m, b)
@@ -8359,7 +8359,7 @@ func (m *SdkVolumeEnumerateResponse) Reset()         { *m = SdkVolumeEnumerateRe
 func (m *SdkVolumeEnumerateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeEnumerateResponse) ProtoMessage()    {}
 func (*SdkVolumeEnumerateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{100}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{100}
 }
 func (m *SdkVolumeEnumerateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeEnumerateResponse.Unmarshal(m, b)
@@ -8400,7 +8400,7 @@ func (m *SdkVolumeEnumerateWithFiltersRequest) Reset()         { *m = SdkVolumeE
 func (m *SdkVolumeEnumerateWithFiltersRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeEnumerateWithFiltersRequest) ProtoMessage()    {}
 func (*SdkVolumeEnumerateWithFiltersRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{101}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{101}
 }
 func (m *SdkVolumeEnumerateWithFiltersRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeEnumerateWithFiltersRequest.Unmarshal(m, b)
@@ -8440,7 +8440,7 @@ func (m *SdkVolumeEnumerateWithFiltersResponse) Reset()         { *m = SdkVolume
 func (m *SdkVolumeEnumerateWithFiltersResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeEnumerateWithFiltersResponse) ProtoMessage()    {}
 func (*SdkVolumeEnumerateWithFiltersResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{102}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{102}
 }
 func (m *SdkVolumeEnumerateWithFiltersResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeEnumerateWithFiltersResponse.Unmarshal(m, b)
@@ -8484,7 +8484,7 @@ func (m *SdkVolumeSnapshotCreateRequest) Reset()         { *m = SdkVolumeSnapsho
 func (m *SdkVolumeSnapshotCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeSnapshotCreateRequest) ProtoMessage()    {}
 func (*SdkVolumeSnapshotCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{103}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{103}
 }
 func (m *SdkVolumeSnapshotCreateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeSnapshotCreateRequest.Unmarshal(m, b)
@@ -8538,7 +8538,7 @@ func (m *SdkVolumeSnapshotCreateResponse) Reset()         { *m = SdkVolumeSnapsh
 func (m *SdkVolumeSnapshotCreateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeSnapshotCreateResponse) ProtoMessage()    {}
 func (*SdkVolumeSnapshotCreateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{104}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{104}
 }
 func (m *SdkVolumeSnapshotCreateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeSnapshotCreateResponse.Unmarshal(m, b)
@@ -8580,7 +8580,7 @@ func (m *SdkVolumeSnapshotRestoreRequest) Reset()         { *m = SdkVolumeSnapsh
 func (m *SdkVolumeSnapshotRestoreRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeSnapshotRestoreRequest) ProtoMessage()    {}
 func (*SdkVolumeSnapshotRestoreRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{105}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{105}
 }
 func (m *SdkVolumeSnapshotRestoreRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeSnapshotRestoreRequest.Unmarshal(m, b)
@@ -8625,7 +8625,7 @@ func (m *SdkVolumeSnapshotRestoreResponse) Reset()         { *m = SdkVolumeSnaps
 func (m *SdkVolumeSnapshotRestoreResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeSnapshotRestoreResponse) ProtoMessage()    {}
 func (*SdkVolumeSnapshotRestoreResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{106}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{106}
 }
 func (m *SdkVolumeSnapshotRestoreResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeSnapshotRestoreResponse.Unmarshal(m, b)
@@ -8658,7 +8658,7 @@ func (m *SdkVolumeSnapshotEnumerateRequest) Reset()         { *m = SdkVolumeSnap
 func (m *SdkVolumeSnapshotEnumerateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeSnapshotEnumerateRequest) ProtoMessage()    {}
 func (*SdkVolumeSnapshotEnumerateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{107}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{107}
 }
 func (m *SdkVolumeSnapshotEnumerateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeSnapshotEnumerateRequest.Unmarshal(m, b)
@@ -8698,7 +8698,7 @@ func (m *SdkVolumeSnapshotEnumerateResponse) Reset()         { *m = SdkVolumeSna
 func (m *SdkVolumeSnapshotEnumerateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeSnapshotEnumerateResponse) ProtoMessage()    {}
 func (*SdkVolumeSnapshotEnumerateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{108}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{108}
 }
 func (m *SdkVolumeSnapshotEnumerateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeSnapshotEnumerateResponse.Unmarshal(m, b)
@@ -8744,7 +8744,7 @@ func (m *SdkVolumeSnapshotEnumerateWithFiltersRequest) String() string {
 }
 func (*SdkVolumeSnapshotEnumerateWithFiltersRequest) ProtoMessage() {}
 func (*SdkVolumeSnapshotEnumerateWithFiltersRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{109}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{109}
 }
 func (m *SdkVolumeSnapshotEnumerateWithFiltersRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeSnapshotEnumerateWithFiltersRequest.Unmarshal(m, b)
@@ -8795,7 +8795,7 @@ func (m *SdkVolumeSnapshotEnumerateWithFiltersResponse) String() string {
 }
 func (*SdkVolumeSnapshotEnumerateWithFiltersResponse) ProtoMessage() {}
 func (*SdkVolumeSnapshotEnumerateWithFiltersResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{110}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{110}
 }
 func (m *SdkVolumeSnapshotEnumerateWithFiltersResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeSnapshotEnumerateWithFiltersResponse.Unmarshal(m, b)
@@ -8839,7 +8839,7 @@ func (m *SdkVolumeSnapshotScheduleUpdateRequest) Reset() {
 func (m *SdkVolumeSnapshotScheduleUpdateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeSnapshotScheduleUpdateRequest) ProtoMessage()    {}
 func (*SdkVolumeSnapshotScheduleUpdateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{111}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{111}
 }
 func (m *SdkVolumeSnapshotScheduleUpdateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeSnapshotScheduleUpdateRequest.Unmarshal(m, b)
@@ -8886,7 +8886,7 @@ func (m *SdkVolumeSnapshotScheduleUpdateResponse) Reset() {
 func (m *SdkVolumeSnapshotScheduleUpdateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkVolumeSnapshotScheduleUpdateResponse) ProtoMessage()    {}
 func (*SdkVolumeSnapshotScheduleUpdateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{112}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{112}
 }
 func (m *SdkVolumeSnapshotScheduleUpdateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVolumeSnapshotScheduleUpdateResponse.Unmarshal(m, b)
@@ -8917,7 +8917,7 @@ func (m *SdkClusterInspectCurrentRequest) Reset()         { *m = SdkClusterInspe
 func (m *SdkClusterInspectCurrentRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkClusterInspectCurrentRequest) ProtoMessage()    {}
 func (*SdkClusterInspectCurrentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{113}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{113}
 }
 func (m *SdkClusterInspectCurrentRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkClusterInspectCurrentRequest.Unmarshal(m, b)
@@ -8950,7 +8950,7 @@ func (m *SdkClusterInspectCurrentResponse) Reset()         { *m = SdkClusterInsp
 func (m *SdkClusterInspectCurrentResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkClusterInspectCurrentResponse) ProtoMessage()    {}
 func (*SdkClusterInspectCurrentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{114}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{114}
 }
 func (m *SdkClusterInspectCurrentResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkClusterInspectCurrentResponse.Unmarshal(m, b)
@@ -8990,7 +8990,7 @@ func (m *SdkNodeInspectRequest) Reset()         { *m = SdkNodeInspectRequest{} }
 func (m *SdkNodeInspectRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkNodeInspectRequest) ProtoMessage()    {}
 func (*SdkNodeInspectRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{115}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{115}
 }
 func (m *SdkNodeInspectRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkNodeInspectRequest.Unmarshal(m, b)
@@ -9030,7 +9030,7 @@ func (m *SdkNodeInspectResponse) Reset()         { *m = SdkNodeInspectResponse{}
 func (m *SdkNodeInspectResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkNodeInspectResponse) ProtoMessage()    {}
 func (*SdkNodeInspectResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{116}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{116}
 }
 func (m *SdkNodeInspectResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkNodeInspectResponse.Unmarshal(m, b)
@@ -9068,7 +9068,7 @@ func (m *SdkNodeInspectCurrentRequest) Reset()         { *m = SdkNodeInspectCurr
 func (m *SdkNodeInspectCurrentRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkNodeInspectCurrentRequest) ProtoMessage()    {}
 func (*SdkNodeInspectCurrentRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{117}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{117}
 }
 func (m *SdkNodeInspectCurrentRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkNodeInspectCurrentRequest.Unmarshal(m, b)
@@ -9101,7 +9101,7 @@ func (m *SdkNodeInspectCurrentResponse) Reset()         { *m = SdkNodeInspectCur
 func (m *SdkNodeInspectCurrentResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkNodeInspectCurrentResponse) ProtoMessage()    {}
 func (*SdkNodeInspectCurrentResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{118}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{118}
 }
 func (m *SdkNodeInspectCurrentResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkNodeInspectCurrentResponse.Unmarshal(m, b)
@@ -9139,7 +9139,7 @@ func (m *SdkNodeEnumerateRequest) Reset()         { *m = SdkNodeEnumerateRequest
 func (m *SdkNodeEnumerateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkNodeEnumerateRequest) ProtoMessage()    {}
 func (*SdkNodeEnumerateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{119}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{119}
 }
 func (m *SdkNodeEnumerateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkNodeEnumerateRequest.Unmarshal(m, b)
@@ -9172,7 +9172,7 @@ func (m *SdkNodeEnumerateResponse) Reset()         { *m = SdkNodeEnumerateRespon
 func (m *SdkNodeEnumerateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkNodeEnumerateResponse) ProtoMessage()    {}
 func (*SdkNodeEnumerateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{120}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{120}
 }
 func (m *SdkNodeEnumerateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkNodeEnumerateResponse.Unmarshal(m, b)
@@ -9212,7 +9212,7 @@ func (m *SdkObjectstoreInspectRequest) Reset()         { *m = SdkObjectstoreInsp
 func (m *SdkObjectstoreInspectRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkObjectstoreInspectRequest) ProtoMessage()    {}
 func (*SdkObjectstoreInspectRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{121}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{121}
 }
 func (m *SdkObjectstoreInspectRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkObjectstoreInspectRequest.Unmarshal(m, b)
@@ -9252,7 +9252,7 @@ func (m *SdkObjectstoreInspectResponse) Reset()         { *m = SdkObjectstoreIns
 func (m *SdkObjectstoreInspectResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkObjectstoreInspectResponse) ProtoMessage()    {}
 func (*SdkObjectstoreInspectResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{122}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{122}
 }
 func (m *SdkObjectstoreInspectResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkObjectstoreInspectResponse.Unmarshal(m, b)
@@ -9292,7 +9292,7 @@ func (m *SdkObjectstoreCreateRequest) Reset()         { *m = SdkObjectstoreCreat
 func (m *SdkObjectstoreCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkObjectstoreCreateRequest) ProtoMessage()    {}
 func (*SdkObjectstoreCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{123}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{123}
 }
 func (m *SdkObjectstoreCreateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkObjectstoreCreateRequest.Unmarshal(m, b)
@@ -9333,7 +9333,7 @@ func (m *SdkObjectstoreCreateResponse) Reset()         { *m = SdkObjectstoreCrea
 func (m *SdkObjectstoreCreateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkObjectstoreCreateResponse) ProtoMessage()    {}
 func (*SdkObjectstoreCreateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{124}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{124}
 }
 func (m *SdkObjectstoreCreateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkObjectstoreCreateResponse.Unmarshal(m, b)
@@ -9373,7 +9373,7 @@ func (m *SdkObjectstoreDeleteRequest) Reset()         { *m = SdkObjectstoreDelet
 func (m *SdkObjectstoreDeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkObjectstoreDeleteRequest) ProtoMessage()    {}
 func (*SdkObjectstoreDeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{125}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{125}
 }
 func (m *SdkObjectstoreDeleteRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkObjectstoreDeleteRequest.Unmarshal(m, b)
@@ -9411,7 +9411,7 @@ func (m *SdkObjectstoreDeleteResponse) Reset()         { *m = SdkObjectstoreDele
 func (m *SdkObjectstoreDeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkObjectstoreDeleteResponse) ProtoMessage()    {}
 func (*SdkObjectstoreDeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{126}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{126}
 }
 func (m *SdkObjectstoreDeleteResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkObjectstoreDeleteResponse.Unmarshal(m, b)
@@ -9446,7 +9446,7 @@ func (m *SdkObjectstoreUpdateRequest) Reset()         { *m = SdkObjectstoreUpdat
 func (m *SdkObjectstoreUpdateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkObjectstoreUpdateRequest) ProtoMessage()    {}
 func (*SdkObjectstoreUpdateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{127}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{127}
 }
 func (m *SdkObjectstoreUpdateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkObjectstoreUpdateRequest.Unmarshal(m, b)
@@ -9491,7 +9491,7 @@ func (m *SdkObjectstoreUpdateResponse) Reset()         { *m = SdkObjectstoreUpda
 func (m *SdkObjectstoreUpdateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkObjectstoreUpdateResponse) ProtoMessage()    {}
 func (*SdkObjectstoreUpdateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{128}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{128}
 }
 func (m *SdkObjectstoreUpdateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkObjectstoreUpdateResponse.Unmarshal(m, b)
@@ -9534,7 +9534,7 @@ func (m *SdkCloudBackupCreateRequest) Reset()         { *m = SdkCloudBackupCreat
 func (m *SdkCloudBackupCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupCreateRequest) ProtoMessage()    {}
 func (*SdkCloudBackupCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{129}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{129}
 }
 func (m *SdkCloudBackupCreateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupCreateRequest.Unmarshal(m, b)
@@ -9602,7 +9602,7 @@ func (m *SdkCloudBackupCreateResponse) Reset()         { *m = SdkCloudBackupCrea
 func (m *SdkCloudBackupCreateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupCreateResponse) ProtoMessage()    {}
 func (*SdkCloudBackupCreateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{130}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{130}
 }
 func (m *SdkCloudBackupCreateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupCreateResponse.Unmarshal(m, b)
@@ -9653,7 +9653,7 @@ func (m *SdkCloudBackupRestoreRequest) Reset()         { *m = SdkCloudBackupRest
 func (m *SdkCloudBackupRestoreRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupRestoreRequest) ProtoMessage()    {}
 func (*SdkCloudBackupRestoreRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{131}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{131}
 }
 func (m *SdkCloudBackupRestoreRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupRestoreRequest.Unmarshal(m, b)
@@ -9724,7 +9724,7 @@ func (m *SdkCloudBackupRestoreResponse) Reset()         { *m = SdkCloudBackupRes
 func (m *SdkCloudBackupRestoreResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupRestoreResponse) ProtoMessage()    {}
 func (*SdkCloudBackupRestoreResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{132}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{132}
 }
 func (m *SdkCloudBackupRestoreResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupRestoreResponse.Unmarshal(m, b)
@@ -9777,7 +9777,7 @@ func (m *SdkCloudBackupDeleteRequest) Reset()         { *m = SdkCloudBackupDelet
 func (m *SdkCloudBackupDeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupDeleteRequest) ProtoMessage()    {}
 func (*SdkCloudBackupDeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{133}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{133}
 }
 func (m *SdkCloudBackupDeleteRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupDeleteRequest.Unmarshal(m, b)
@@ -9829,7 +9829,7 @@ func (m *SdkCloudBackupDeleteResponse) Reset()         { *m = SdkCloudBackupDele
 func (m *SdkCloudBackupDeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupDeleteResponse) ProtoMessage()    {}
 func (*SdkCloudBackupDeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{134}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{134}
 }
 func (m *SdkCloudBackupDeleteResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupDeleteResponse.Unmarshal(m, b)
@@ -9865,7 +9865,7 @@ func (m *SdkCloudBackupDeleteAllRequest) Reset()         { *m = SdkCloudBackupDe
 func (m *SdkCloudBackupDeleteAllRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupDeleteAllRequest) ProtoMessage()    {}
 func (*SdkCloudBackupDeleteAllRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{135}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{135}
 }
 func (m *SdkCloudBackupDeleteAllRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupDeleteAllRequest.Unmarshal(m, b)
@@ -9910,7 +9910,7 @@ func (m *SdkCloudBackupDeleteAllResponse) Reset()         { *m = SdkCloudBackupD
 func (m *SdkCloudBackupDeleteAllResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupDeleteAllResponse) ProtoMessage()    {}
 func (*SdkCloudBackupDeleteAllResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{136}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{136}
 }
 func (m *SdkCloudBackupDeleteAllResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupDeleteAllResponse.Unmarshal(m, b)
@@ -9963,7 +9963,7 @@ func (m *SdkCloudBackupEnumerateWithFiltersRequest) Reset() {
 func (m *SdkCloudBackupEnumerateWithFiltersRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupEnumerateWithFiltersRequest) ProtoMessage()    {}
 func (*SdkCloudBackupEnumerateWithFiltersRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{137}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{137}
 }
 func (m *SdkCloudBackupEnumerateWithFiltersRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupEnumerateWithFiltersRequest.Unmarshal(m, b)
@@ -10035,7 +10035,7 @@ func (m *SdkCloudBackupInfo) Reset()         { *m = SdkCloudBackupInfo{} }
 func (m *SdkCloudBackupInfo) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupInfo) ProtoMessage()    {}
 func (*SdkCloudBackupInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{138}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{138}
 }
 func (m *SdkCloudBackupInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupInfo.Unmarshal(m, b)
@@ -10113,7 +10113,7 @@ func (m *SdkCloudBackupEnumerateWithFiltersResponse) String() string {
 }
 func (*SdkCloudBackupEnumerateWithFiltersResponse) ProtoMessage() {}
 func (*SdkCloudBackupEnumerateWithFiltersResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{139}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{139}
 }
 func (m *SdkCloudBackupEnumerateWithFiltersResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupEnumerateWithFiltersResponse.Unmarshal(m, b)
@@ -10176,7 +10176,7 @@ func (m *SdkCloudBackupStatus) Reset()         { *m = SdkCloudBackupStatus{} }
 func (m *SdkCloudBackupStatus) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupStatus) ProtoMessage()    {}
 func (*SdkCloudBackupStatus) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{140}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{140}
 }
 func (m *SdkCloudBackupStatus) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupStatus.Unmarshal(m, b)
@@ -10302,7 +10302,7 @@ func (m *SdkCloudBackupStatusRequest) Reset()         { *m = SdkCloudBackupStatu
 func (m *SdkCloudBackupStatusRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupStatusRequest) ProtoMessage()    {}
 func (*SdkCloudBackupStatusRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{141}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{141}
 }
 func (m *SdkCloudBackupStatusRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupStatusRequest.Unmarshal(m, b)
@@ -10357,7 +10357,7 @@ func (m *SdkCloudBackupStatusResponse) Reset()         { *m = SdkCloudBackupStat
 func (m *SdkCloudBackupStatusResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupStatusResponse) ProtoMessage()    {}
 func (*SdkCloudBackupStatusResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{142}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{142}
 }
 func (m *SdkCloudBackupStatusResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupStatusResponse.Unmarshal(m, b)
@@ -10399,7 +10399,7 @@ func (m *SdkCloudBackupCatalogRequest) Reset()         { *m = SdkCloudBackupCata
 func (m *SdkCloudBackupCatalogRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupCatalogRequest) ProtoMessage()    {}
 func (*SdkCloudBackupCatalogRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{143}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{143}
 }
 func (m *SdkCloudBackupCatalogRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupCatalogRequest.Unmarshal(m, b)
@@ -10446,7 +10446,7 @@ func (m *SdkCloudBackupCatalogResponse) Reset()         { *m = SdkCloudBackupCat
 func (m *SdkCloudBackupCatalogResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupCatalogResponse) ProtoMessage()    {}
 func (*SdkCloudBackupCatalogResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{144}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{144}
 }
 func (m *SdkCloudBackupCatalogResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupCatalogResponse.Unmarshal(m, b)
@@ -10491,7 +10491,7 @@ func (m *SdkCloudBackupHistoryItem) Reset()         { *m = SdkCloudBackupHistory
 func (m *SdkCloudBackupHistoryItem) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupHistoryItem) ProtoMessage()    {}
 func (*SdkCloudBackupHistoryItem) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{145}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{145}
 }
 func (m *SdkCloudBackupHistoryItem) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupHistoryItem.Unmarshal(m, b)
@@ -10547,7 +10547,7 @@ func (m *SdkCloudBackupHistoryRequest) Reset()         { *m = SdkCloudBackupHist
 func (m *SdkCloudBackupHistoryRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupHistoryRequest) ProtoMessage()    {}
 func (*SdkCloudBackupHistoryRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{146}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{146}
 }
 func (m *SdkCloudBackupHistoryRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupHistoryRequest.Unmarshal(m, b)
@@ -10587,7 +10587,7 @@ func (m *SdkCloudBackupHistoryResponse) Reset()         { *m = SdkCloudBackupHis
 func (m *SdkCloudBackupHistoryResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupHistoryResponse) ProtoMessage()    {}
 func (*SdkCloudBackupHistoryResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{147}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{147}
 }
 func (m *SdkCloudBackupHistoryResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupHistoryResponse.Unmarshal(m, b)
@@ -10631,7 +10631,7 @@ func (m *SdkCloudBackupStateChangeRequest) Reset()         { *m = SdkCloudBackup
 func (m *SdkCloudBackupStateChangeRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupStateChangeRequest) ProtoMessage()    {}
 func (*SdkCloudBackupStateChangeRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{148}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{148}
 }
 func (m *SdkCloudBackupStateChangeRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupStateChangeRequest.Unmarshal(m, b)
@@ -10676,7 +10676,7 @@ func (m *SdkCloudBackupStateChangeResponse) Reset()         { *m = SdkCloudBacku
 func (m *SdkCloudBackupStateChangeResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupStateChangeResponse) ProtoMessage()    {}
 func (*SdkCloudBackupStateChangeResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{149}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{149}
 }
 func (m *SdkCloudBackupStateChangeResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupStateChangeResponse.Unmarshal(m, b)
@@ -10719,7 +10719,7 @@ func (m *SdkCloudBackupScheduleInfo) Reset()         { *m = SdkCloudBackupSchedu
 func (m *SdkCloudBackupScheduleInfo) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupScheduleInfo) ProtoMessage()    {}
 func (*SdkCloudBackupScheduleInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{150}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{150}
 }
 func (m *SdkCloudBackupScheduleInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupScheduleInfo.Unmarshal(m, b)
@@ -10788,7 +10788,7 @@ func (m *SdkCloudBackupSchedCreateRequest) Reset()         { *m = SdkCloudBackup
 func (m *SdkCloudBackupSchedCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupSchedCreateRequest) ProtoMessage()    {}
 func (*SdkCloudBackupSchedCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{151}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{151}
 }
 func (m *SdkCloudBackupSchedCreateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupSchedCreateRequest.Unmarshal(m, b)
@@ -10829,7 +10829,7 @@ func (m *SdkCloudBackupSchedCreateResponse) Reset()         { *m = SdkCloudBacku
 func (m *SdkCloudBackupSchedCreateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupSchedCreateResponse) ProtoMessage()    {}
 func (*SdkCloudBackupSchedCreateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{152}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{152}
 }
 func (m *SdkCloudBackupSchedCreateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupSchedCreateResponse.Unmarshal(m, b)
@@ -10869,7 +10869,7 @@ func (m *SdkCloudBackupSchedDeleteRequest) Reset()         { *m = SdkCloudBackup
 func (m *SdkCloudBackupSchedDeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupSchedDeleteRequest) ProtoMessage()    {}
 func (*SdkCloudBackupSchedDeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{153}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{153}
 }
 func (m *SdkCloudBackupSchedDeleteRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupSchedDeleteRequest.Unmarshal(m, b)
@@ -10907,7 +10907,7 @@ func (m *SdkCloudBackupSchedDeleteResponse) Reset()         { *m = SdkCloudBacku
 func (m *SdkCloudBackupSchedDeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupSchedDeleteResponse) ProtoMessage()    {}
 func (*SdkCloudBackupSchedDeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{154}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{154}
 }
 func (m *SdkCloudBackupSchedDeleteResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupSchedDeleteResponse.Unmarshal(m, b)
@@ -10938,7 +10938,7 @@ func (m *SdkCloudBackupSchedEnumerateRequest) Reset()         { *m = SdkCloudBac
 func (m *SdkCloudBackupSchedEnumerateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupSchedEnumerateRequest) ProtoMessage()    {}
 func (*SdkCloudBackupSchedEnumerateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{155}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{155}
 }
 func (m *SdkCloudBackupSchedEnumerateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupSchedEnumerateRequest.Unmarshal(m, b)
@@ -10972,7 +10972,7 @@ func (m *SdkCloudBackupSchedEnumerateResponse) Reset()         { *m = SdkCloudBa
 func (m *SdkCloudBackupSchedEnumerateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudBackupSchedEnumerateResponse) ProtoMessage()    {}
 func (*SdkCloudBackupSchedEnumerateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{156}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{156}
 }
 func (m *SdkCloudBackupSchedEnumerateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudBackupSchedEnumerateResponse.Unmarshal(m, b)
@@ -11010,7 +11010,7 @@ func (m *SdkIdentityCapabilitiesRequest) Reset()         { *m = SdkIdentityCapab
 func (m *SdkIdentityCapabilitiesRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkIdentityCapabilitiesRequest) ProtoMessage()    {}
 func (*SdkIdentityCapabilitiesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{157}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{157}
 }
 func (m *SdkIdentityCapabilitiesRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkIdentityCapabilitiesRequest.Unmarshal(m, b)
@@ -11043,7 +11043,7 @@ func (m *SdkIdentityCapabilitiesResponse) Reset()         { *m = SdkIdentityCapa
 func (m *SdkIdentityCapabilitiesResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkIdentityCapabilitiesResponse) ProtoMessage()    {}
 func (*SdkIdentityCapabilitiesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{158}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{158}
 }
 func (m *SdkIdentityCapabilitiesResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkIdentityCapabilitiesResponse.Unmarshal(m, b)
@@ -11081,7 +11081,7 @@ func (m *SdkIdentityVersionRequest) Reset()         { *m = SdkIdentityVersionReq
 func (m *SdkIdentityVersionRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkIdentityVersionRequest) ProtoMessage()    {}
 func (*SdkIdentityVersionRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{159}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{159}
 }
 func (m *SdkIdentityVersionRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkIdentityVersionRequest.Unmarshal(m, b)
@@ -11116,7 +11116,7 @@ func (m *SdkIdentityVersionResponse) Reset()         { *m = SdkIdentityVersionRe
 func (m *SdkIdentityVersionResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkIdentityVersionResponse) ProtoMessage()    {}
 func (*SdkIdentityVersionResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{160}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{160}
 }
 func (m *SdkIdentityVersionResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkIdentityVersionResponse.Unmarshal(m, b)
@@ -11167,7 +11167,7 @@ func (m *SdkServiceCapability) Reset()         { *m = SdkServiceCapability{} }
 func (m *SdkServiceCapability) String() string { return proto.CompactTextString(m) }
 func (*SdkServiceCapability) ProtoMessage()    {}
 func (*SdkServiceCapability) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{161}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{161}
 }
 func (m *SdkServiceCapability) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkServiceCapability.Unmarshal(m, b)
@@ -11280,7 +11280,7 @@ func (m *SdkServiceCapability_OpenStorageService) Reset() {
 func (m *SdkServiceCapability_OpenStorageService) String() string { return proto.CompactTextString(m) }
 func (*SdkServiceCapability_OpenStorageService) ProtoMessage()    {}
 func (*SdkServiceCapability_OpenStorageService) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{161, 0}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{161, 0}
 }
 func (m *SdkServiceCapability_OpenStorageService) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkServiceCapability_OpenStorageService.Unmarshal(m, b)
@@ -11329,7 +11329,7 @@ func (m *SdkVersion) Reset()         { *m = SdkVersion{} }
 func (m *SdkVersion) String() string { return proto.CompactTextString(m) }
 func (*SdkVersion) ProtoMessage()    {}
 func (*SdkVersion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{162}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{162}
 }
 func (m *SdkVersion) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkVersion.Unmarshal(m, b)
@@ -11394,7 +11394,7 @@ func (m *StorageVersion) Reset()         { *m = StorageVersion{} }
 func (m *StorageVersion) String() string { return proto.CompactTextString(m) }
 func (*StorageVersion) ProtoMessage()    {}
 func (*StorageVersion) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{163}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{163}
 }
 func (m *StorageVersion) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_StorageVersion.Unmarshal(m, b)
@@ -11445,7 +11445,7 @@ func (m *CloudMigrate) Reset()         { *m = CloudMigrate{} }
 func (m *CloudMigrate) String() string { return proto.CompactTextString(m) }
 func (*CloudMigrate) ProtoMessage()    {}
 func (*CloudMigrate) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{164}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{164}
 }
 func (m *CloudMigrate) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CloudMigrate.Unmarshal(m, b)
@@ -11485,7 +11485,7 @@ func (m *CloudMigrateStartRequest) Reset()         { *m = CloudMigrateStartReque
 func (m *CloudMigrateStartRequest) String() string { return proto.CompactTextString(m) }
 func (*CloudMigrateStartRequest) ProtoMessage()    {}
 func (*CloudMigrateStartRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{165}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{165}
 }
 func (m *CloudMigrateStartRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CloudMigrateStartRequest.Unmarshal(m, b)
@@ -11554,7 +11554,7 @@ func (m *SdkCloudMigrateStartRequest) Reset()         { *m = SdkCloudMigrateStar
 func (m *SdkCloudMigrateStartRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudMigrateStartRequest) ProtoMessage()    {}
 func (*SdkCloudMigrateStartRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{166}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{166}
 }
 func (m *SdkCloudMigrateStartRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudMigrateStartRequest.Unmarshal(m, b)
@@ -11741,7 +11741,7 @@ func (m *SdkCloudMigrateStartRequest_MigrateVolume) Reset() {
 func (m *SdkCloudMigrateStartRequest_MigrateVolume) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudMigrateStartRequest_MigrateVolume) ProtoMessage()    {}
 func (*SdkCloudMigrateStartRequest_MigrateVolume) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{166, 0}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{166, 0}
 }
 func (m *SdkCloudMigrateStartRequest_MigrateVolume) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudMigrateStartRequest_MigrateVolume.Unmarshal(m, b)
@@ -11784,7 +11784,7 @@ func (m *SdkCloudMigrateStartRequest_MigrateVolumeGroup) String() string {
 }
 func (*SdkCloudMigrateStartRequest_MigrateVolumeGroup) ProtoMessage() {}
 func (*SdkCloudMigrateStartRequest_MigrateVolumeGroup) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{166, 1}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{166, 1}
 }
 func (m *SdkCloudMigrateStartRequest_MigrateVolumeGroup) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudMigrateStartRequest_MigrateVolumeGroup.Unmarshal(m, b)
@@ -11826,7 +11826,7 @@ func (m *SdkCloudMigrateStartRequest_MigrateAllVolumes) String() string {
 }
 func (*SdkCloudMigrateStartRequest_MigrateAllVolumes) ProtoMessage() {}
 func (*SdkCloudMigrateStartRequest_MigrateAllVolumes) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{166, 2}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{166, 2}
 }
 func (m *SdkCloudMigrateStartRequest_MigrateAllVolumes) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudMigrateStartRequest_MigrateAllVolumes.Unmarshal(m, b)
@@ -11859,7 +11859,7 @@ func (m *CloudMigrateStartResponse) Reset()         { *m = CloudMigrateStartResp
 func (m *CloudMigrateStartResponse) String() string { return proto.CompactTextString(m) }
 func (*CloudMigrateStartResponse) ProtoMessage()    {}
 func (*CloudMigrateStartResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{167}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{167}
 }
 func (m *CloudMigrateStartResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CloudMigrateStartResponse.Unmarshal(m, b)
@@ -11899,7 +11899,7 @@ func (m *SdkCloudMigrateStartResponse) Reset()         { *m = SdkCloudMigrateSta
 func (m *SdkCloudMigrateStartResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudMigrateStartResponse) ProtoMessage()    {}
 func (*SdkCloudMigrateStartResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{168}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{168}
 }
 func (m *SdkCloudMigrateStartResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudMigrateStartResponse.Unmarshal(m, b)
@@ -11939,7 +11939,7 @@ func (m *CloudMigrateCancelRequest) Reset()         { *m = CloudMigrateCancelReq
 func (m *CloudMigrateCancelRequest) String() string { return proto.CompactTextString(m) }
 func (*CloudMigrateCancelRequest) ProtoMessage()    {}
 func (*CloudMigrateCancelRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{169}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{169}
 }
 func (m *CloudMigrateCancelRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CloudMigrateCancelRequest.Unmarshal(m, b)
@@ -11979,7 +11979,7 @@ func (m *SdkCloudMigrateCancelRequest) Reset()         { *m = SdkCloudMigrateCan
 func (m *SdkCloudMigrateCancelRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudMigrateCancelRequest) ProtoMessage()    {}
 func (*SdkCloudMigrateCancelRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{170}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{170}
 }
 func (m *SdkCloudMigrateCancelRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudMigrateCancelRequest.Unmarshal(m, b)
@@ -12017,7 +12017,7 @@ func (m *SdkCloudMigrateCancelResponse) Reset()         { *m = SdkCloudMigrateCa
 func (m *SdkCloudMigrateCancelResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudMigrateCancelResponse) ProtoMessage()    {}
 func (*SdkCloudMigrateCancelResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{171}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{171}
 }
 func (m *SdkCloudMigrateCancelResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudMigrateCancelResponse.Unmarshal(m, b)
@@ -12077,7 +12077,7 @@ func (m *CloudMigrateInfo) Reset()         { *m = CloudMigrateInfo{} }
 func (m *CloudMigrateInfo) String() string { return proto.CompactTextString(m) }
 func (*CloudMigrateInfo) ProtoMessage()    {}
 func (*CloudMigrateInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{172}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{172}
 }
 func (m *CloudMigrateInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CloudMigrateInfo.Unmarshal(m, b)
@@ -12213,7 +12213,7 @@ func (m *CloudMigrateInfoList) Reset()         { *m = CloudMigrateInfoList{} }
 func (m *CloudMigrateInfoList) String() string { return proto.CompactTextString(m) }
 func (*CloudMigrateInfoList) ProtoMessage()    {}
 func (*CloudMigrateInfoList) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{173}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{173}
 }
 func (m *CloudMigrateInfoList) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CloudMigrateInfoList.Unmarshal(m, b)
@@ -12251,7 +12251,7 @@ func (m *SdkCloudMigrateStatusRequest) Reset()         { *m = SdkCloudMigrateSta
 func (m *SdkCloudMigrateStatusRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudMigrateStatusRequest) ProtoMessage()    {}
 func (*SdkCloudMigrateStatusRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{174}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{174}
 }
 func (m *SdkCloudMigrateStatusRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudMigrateStatusRequest.Unmarshal(m, b)
@@ -12284,7 +12284,7 @@ func (m *CloudMigrateStatusResponse) Reset()         { *m = CloudMigrateStatusRe
 func (m *CloudMigrateStatusResponse) String() string { return proto.CompactTextString(m) }
 func (*CloudMigrateStatusResponse) ProtoMessage()    {}
 func (*CloudMigrateStatusResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{175}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{175}
 }
 func (m *CloudMigrateStatusResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CloudMigrateStatusResponse.Unmarshal(m, b)
@@ -12324,7 +12324,7 @@ func (m *SdkCloudMigrateStatusResponse) Reset()         { *m = SdkCloudMigrateSt
 func (m *SdkCloudMigrateStatusResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkCloudMigrateStatusResponse) ProtoMessage()    {}
 func (*SdkCloudMigrateStatusResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{176}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{176}
 }
 func (m *SdkCloudMigrateStatusResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkCloudMigrateStatusResponse.Unmarshal(m, b)
@@ -12370,7 +12370,7 @@ func (m *ClusterPairCreateRequest) Reset()         { *m = ClusterPairCreateReque
 func (m *ClusterPairCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*ClusterPairCreateRequest) ProtoMessage()    {}
 func (*ClusterPairCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{177}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{177}
 }
 func (m *ClusterPairCreateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ClusterPairCreateRequest.Unmarshal(m, b)
@@ -12433,7 +12433,7 @@ func (m *ClusterPairCreateResponse) Reset()         { *m = ClusterPairCreateResp
 func (m *ClusterPairCreateResponse) String() string { return proto.CompactTextString(m) }
 func (*ClusterPairCreateResponse) ProtoMessage()    {}
 func (*ClusterPairCreateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{178}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{178}
 }
 func (m *ClusterPairCreateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ClusterPairCreateResponse.Unmarshal(m, b)
@@ -12479,7 +12479,7 @@ func (m *SdkClusterPairCreateRequest) Reset()         { *m = SdkClusterPairCreat
 func (m *SdkClusterPairCreateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkClusterPairCreateRequest) ProtoMessage()    {}
 func (*SdkClusterPairCreateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{179}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{179}
 }
 func (m *SdkClusterPairCreateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkClusterPairCreateRequest.Unmarshal(m, b)
@@ -12519,7 +12519,7 @@ func (m *SdkClusterPairCreateResponse) Reset()         { *m = SdkClusterPairCrea
 func (m *SdkClusterPairCreateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkClusterPairCreateResponse) ProtoMessage()    {}
 func (*SdkClusterPairCreateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{180}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{180}
 }
 func (m *SdkClusterPairCreateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkClusterPairCreateResponse.Unmarshal(m, b)
@@ -12561,7 +12561,7 @@ func (m *ClusterPairProcessRequest) Reset()         { *m = ClusterPairProcessReq
 func (m *ClusterPairProcessRequest) String() string { return proto.CompactTextString(m) }
 func (*ClusterPairProcessRequest) ProtoMessage()    {}
 func (*ClusterPairProcessRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{181}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{181}
 }
 func (m *ClusterPairProcessRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ClusterPairProcessRequest.Unmarshal(m, b)
@@ -12615,7 +12615,7 @@ func (m *ClusterPairProcessResponse) Reset()         { *m = ClusterPairProcessRe
 func (m *ClusterPairProcessResponse) String() string { return proto.CompactTextString(m) }
 func (*ClusterPairProcessResponse) ProtoMessage()    {}
 func (*ClusterPairProcessResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{182}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{182}
 }
 func (m *ClusterPairProcessResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ClusterPairProcessResponse.Unmarshal(m, b)
@@ -12676,7 +12676,7 @@ func (m *SdkClusterPairDeleteRequest) Reset()         { *m = SdkClusterPairDelet
 func (m *SdkClusterPairDeleteRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkClusterPairDeleteRequest) ProtoMessage()    {}
 func (*SdkClusterPairDeleteRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{183}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{183}
 }
 func (m *SdkClusterPairDeleteRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkClusterPairDeleteRequest.Unmarshal(m, b)
@@ -12714,7 +12714,7 @@ func (m *SdkClusterPairDeleteResponse) Reset()         { *m = SdkClusterPairDele
 func (m *SdkClusterPairDeleteResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkClusterPairDeleteResponse) ProtoMessage()    {}
 func (*SdkClusterPairDeleteResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{184}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{184}
 }
 func (m *SdkClusterPairDeleteResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkClusterPairDeleteResponse.Unmarshal(m, b)
@@ -12747,7 +12747,7 @@ func (m *ClusterPairTokenGetResponse) Reset()         { *m = ClusterPairTokenGet
 func (m *ClusterPairTokenGetResponse) String() string { return proto.CompactTextString(m) }
 func (*ClusterPairTokenGetResponse) ProtoMessage()    {}
 func (*ClusterPairTokenGetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{185}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{185}
 }
 func (m *ClusterPairTokenGetResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ClusterPairTokenGetResponse.Unmarshal(m, b)
@@ -12785,7 +12785,7 @@ func (m *SdkClusterPairGetTokenRequest) Reset()         { *m = SdkClusterPairGet
 func (m *SdkClusterPairGetTokenRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkClusterPairGetTokenRequest) ProtoMessage()    {}
 func (*SdkClusterPairGetTokenRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{186}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{186}
 }
 func (m *SdkClusterPairGetTokenRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkClusterPairGetTokenRequest.Unmarshal(m, b)
@@ -12818,7 +12818,7 @@ func (m *SdkClusterPairGetTokenResponse) Reset()         { *m = SdkClusterPairGe
 func (m *SdkClusterPairGetTokenResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkClusterPairGetTokenResponse) ProtoMessage()    {}
 func (*SdkClusterPairGetTokenResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{187}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{187}
 }
 func (m *SdkClusterPairGetTokenResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkClusterPairGetTokenResponse.Unmarshal(m, b)
@@ -12856,7 +12856,7 @@ func (m *SdkClusterPairResetTokenRequest) Reset()         { *m = SdkClusterPairR
 func (m *SdkClusterPairResetTokenRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkClusterPairResetTokenRequest) ProtoMessage()    {}
 func (*SdkClusterPairResetTokenRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{188}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{188}
 }
 func (m *SdkClusterPairResetTokenRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkClusterPairResetTokenRequest.Unmarshal(m, b)
@@ -12889,7 +12889,7 @@ func (m *SdkClusterPairResetTokenResponse) Reset()         { *m = SdkClusterPair
 func (m *SdkClusterPairResetTokenResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkClusterPairResetTokenResponse) ProtoMessage()    {}
 func (*SdkClusterPairResetTokenResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{189}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{189}
 }
 func (m *SdkClusterPairResetTokenResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkClusterPairResetTokenResponse.Unmarshal(m, b)
@@ -12942,7 +12942,7 @@ func (m *ClusterPairInfo) Reset()         { *m = ClusterPairInfo{} }
 func (m *ClusterPairInfo) String() string { return proto.CompactTextString(m) }
 func (*ClusterPairInfo) ProtoMessage()    {}
 func (*ClusterPairInfo) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{190}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{190}
 }
 func (m *ClusterPairInfo) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ClusterPairInfo.Unmarshal(m, b)
@@ -13024,7 +13024,7 @@ func (m *SdkClusterPairInspectRequest) Reset()         { *m = SdkClusterPairInsp
 func (m *SdkClusterPairInspectRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkClusterPairInspectRequest) ProtoMessage()    {}
 func (*SdkClusterPairInspectRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{191}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{191}
 }
 func (m *SdkClusterPairInspectRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkClusterPairInspectRequest.Unmarshal(m, b)
@@ -13064,7 +13064,7 @@ func (m *ClusterPairGetResponse) Reset()         { *m = ClusterPairGetResponse{}
 func (m *ClusterPairGetResponse) String() string { return proto.CompactTextString(m) }
 func (*ClusterPairGetResponse) ProtoMessage()    {}
 func (*ClusterPairGetResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{192}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{192}
 }
 func (m *ClusterPairGetResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ClusterPairGetResponse.Unmarshal(m, b)
@@ -13104,7 +13104,7 @@ func (m *SdkClusterPairInspectResponse) Reset()         { *m = SdkClusterPairIns
 func (m *SdkClusterPairInspectResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkClusterPairInspectResponse) ProtoMessage()    {}
 func (*SdkClusterPairInspectResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{193}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{193}
 }
 func (m *SdkClusterPairInspectResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkClusterPairInspectResponse.Unmarshal(m, b)
@@ -13142,7 +13142,7 @@ func (m *SdkClusterPairEnumerateRequest) Reset()         { *m = SdkClusterPairEn
 func (m *SdkClusterPairEnumerateRequest) String() string { return proto.CompactTextString(m) }
 func (*SdkClusterPairEnumerateRequest) ProtoMessage()    {}
 func (*SdkClusterPairEnumerateRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{194}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{194}
 }
 func (m *SdkClusterPairEnumerateRequest) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkClusterPairEnumerateRequest.Unmarshal(m, b)
@@ -13177,7 +13177,7 @@ func (m *ClusterPairsEnumerateResponse) Reset()         { *m = ClusterPairsEnume
 func (m *ClusterPairsEnumerateResponse) String() string { return proto.CompactTextString(m) }
 func (*ClusterPairsEnumerateResponse) ProtoMessage()    {}
 func (*ClusterPairsEnumerateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{195}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{195}
 }
 func (m *ClusterPairsEnumerateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ClusterPairsEnumerateResponse.Unmarshal(m, b)
@@ -13224,7 +13224,7 @@ func (m *SdkClusterPairEnumerateResponse) Reset()         { *m = SdkClusterPairE
 func (m *SdkClusterPairEnumerateResponse) String() string { return proto.CompactTextString(m) }
 func (*SdkClusterPairEnumerateResponse) ProtoMessage()    {}
 func (*SdkClusterPairEnumerateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{196}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{196}
 }
 func (m *SdkClusterPairEnumerateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_SdkClusterPairEnumerateResponse.Unmarshal(m, b)
@@ -13273,7 +13273,7 @@ func (m *Catalog) Reset()         { *m = Catalog{} }
 func (m *Catalog) String() string { return proto.CompactTextString(m) }
 func (*Catalog) ProtoMessage()    {}
 func (*Catalog) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{197}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{197}
 }
 func (m *Catalog) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Catalog.Unmarshal(m, b)
@@ -13349,7 +13349,7 @@ func (m *Report) Reset()         { *m = Report{} }
 func (m *Report) String() string { return proto.CompactTextString(m) }
 func (*Report) ProtoMessage()    {}
 func (*Report) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{198}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{198}
 }
 func (m *Report) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Report.Unmarshal(m, b)
@@ -13397,7 +13397,7 @@ func (m *CatalogResponse) Reset()         { *m = CatalogResponse{} }
 func (m *CatalogResponse) String() string { return proto.CompactTextString(m) }
 func (*CatalogResponse) ProtoMessage()    {}
 func (*CatalogResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{199}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{199}
 }
 func (m *CatalogResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_CatalogResponse.Unmarshal(m, b)
@@ -13449,7 +13449,7 @@ func (m *LocateResponse) Reset()         { *m = LocateResponse{} }
 func (m *LocateResponse) String() string { return proto.CompactTextString(m) }
 func (*LocateResponse) ProtoMessage()    {}
 func (*LocateResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{200}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{200}
 }
 func (m *LocateResponse) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_LocateResponse.Unmarshal(m, b)
@@ -13499,7 +13499,7 @@ func (m *VolumePlacementStrategy) Reset()         { *m = VolumePlacementStrategy
 func (m *VolumePlacementStrategy) String() string { return proto.CompactTextString(m) }
 func (*VolumePlacementStrategy) ProtoMessage()    {}
 func (*VolumePlacementStrategy) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{201}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{201}
 }
 func (m *VolumePlacementStrategy) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumePlacementStrategy.Unmarshal(m, b)
@@ -13552,7 +13552,7 @@ func (m *VolumePlacementRule) Reset()         { *m = VolumePlacementRule{} }
 func (m *VolumePlacementRule) String() string { return proto.CompactTextString(m) }
 func (*VolumePlacementRule) ProtoMessage()    {}
 func (*VolumePlacementRule) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{202}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{202}
 }
 func (m *VolumePlacementRule) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_VolumePlacementRule.Unmarshal(m, b)
@@ -13590,14 +13590,14 @@ func (m *VolumePlacementRule) GetEnforcement() VolumePlacementRule_EnforcementTy
 	if m != nil {
 		return m.Enforcement
 	}
-	return VolumePlacementRule_Required
+	return VolumePlacementRule_required
 }
 
 func (m *VolumePlacementRule) GetType() VolumePlacementRule_AffinityRuleType {
 	if m != nil {
 		return m.Type
 	}
-	return VolumePlacementRule_Affinity
+	return VolumePlacementRule_affinity
 }
 
 func (m *VolumePlacementRule) GetMatchExpressions() []*LabelSelectorRequirement {
@@ -13629,7 +13629,7 @@ func (m *LabelSelectorRequirement) Reset()         { *m = LabelSelectorRequireme
 func (m *LabelSelectorRequirement) String() string { return proto.CompactTextString(m) }
 func (*LabelSelectorRequirement) ProtoMessage()    {}
 func (*LabelSelectorRequirement) Descriptor() ([]byte, []int) {
-	return fileDescriptor_api_a214a49c752b16b9, []int{203}
+	return fileDescriptor_api_f6f8e46d19aedb85, []int{203}
 }
 func (m *LabelSelectorRequirement) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_LabelSelectorRequirement.Unmarshal(m, b)
@@ -16712,9 +16712,9 @@ var _OpenStorageCloudBackup_serviceDesc = grpc.ServiceDesc{
 	Metadata: "api/api.proto",
 }
 
-func init() { proto.RegisterFile("api/api.proto", fileDescriptor_api_a214a49c752b16b9) }
+func init() { proto.RegisterFile("api/api.proto", fileDescriptor_api_f6f8e46d19aedb85) }
 
-var fileDescriptor_api_a214a49c752b16b9 = []byte{
+var fileDescriptor_api_f6f8e46d19aedb85 = []byte{
 	// 11235 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xbc, 0x7d, 0x6d, 0x8c, 0x1c, 0xc9,
 	0x75, 0xd8, 0xf6, 0xcc, 0xce, 0xce, 0xcc, 0xdb, 0xaf, 0xde, 0x22, 0x6f, 0x39, 0x1c, 0x92, 0x47,
@@ -17224,9 +17224,9 @@ var fileDescriptor_api_a214a49c752b16b9 = []byte{
 	0x78, 0x6f, 0x28, 0x84, 0x4b, 0xfb, 0xfb, 0x76, 0xdb, 0xf6, 0x4f, 0x58, 0x22, 0xba, 0xc9, 0x20,
 	0x8f, 0x60, 0xe6, 0xc8, 0xf2, 0x1b, 0x87, 0x75, 0xfa, 0x11, 0x7e, 0x91, 0x0b, 0x17, 0x3c, 0xee,
 	0xb0, 0x95, 0xdc, 0xb1, 0xa3, 0xab, 0x67, 0x8d, 0xb6, 0x70, 0xee, 0x88, 0x8f, 0x20, 0x60, 0x03,
-	0x3a, 0xe2, 0xa8, 0x44, 0x28, 0x8c, 0x79, 0x98, 0x8e, 0x75, 0x81, 0x4c, 0x60, 0x74, 0x3b, 0xfc,
-	0x70, 0x82, 0x3e, 0x42, 0x26, 0xa1, 0xb8, 0xe3, 0xd2, 0x7d, 0xea, 0xb2, 0xa4, 0x66, 0x2c, 0x82,
-	0x1e, 0xa7, 0x90, 0x55, 0x08, 0xf2, 0xf4, 0x11, 0xa2, 0xc3, 0xc4, 0x52, 0xdb, 0xb7, 0xc3, 0x1c,
+	0x3a, 0xe2, 0xa8, 0x44, 0x28, 0x8c, 0x79, 0x98, 0x8e, 0x75, 0x81, 0x4c, 0x40, 0x21, 0xf8, 0xa0,
+	0x82, 0x3e, 0x42, 0x26, 0xa1, 0xd8, 0x71, 0xe9, 0x3e, 0x75, 0x59, 0x52, 0x33, 0x16, 0x41, 0x8f,
+	0x53, 0xc8, 0x2a, 0x58, 0x22, 0x4f, 0x1f, 0x21, 0x3a, 0x4c, 0x58, 0x6d, 0xdf, 0x0e, 0xa0, 0x74,
 	0xcd, 0xf8, 0x0b, 0x0d, 0x4a, 0xbd, 0x48, 0x4a, 0x91, 0xad, 0x2d, 0x28, 0x70, 0xe3, 0xaf, 0xb8,
 	0xe7, 0x98, 0x4a, 0x09, 0x74, 0xd2, 0x0b, 0x9d, 0xb0, 0x22, 0x3b, 0xae, 0x19, 0xe2, 0x60, 0xa3,
 	0x8e, 0xe2, 0x19, 0xec, 0x98, 0x45, 0xca, 0x78, 0x08, 0x85, 0x00, 0x9a, 0x8c, 0x41, 0xa6, 0xda,
@@ -17417,6 +17417,6 @@ var fileDescriptor_api_a214a49c752b16b9 = []byte{
 	0x50, 0xed, 0x49, 0xc1, 0xda, 0x3e, 0x26, 0xff, 0x40, 0x83, 0x29, 0x35, 0xd4, 0x19, 0x79, 0xf5,
 	0x94, 0x91, 0xd1, 0x38, 0xd5, 0xf7, 0x9e, 0x29, 0x9e, 0x5a, 0x30, 0x7d, 0x49, 0x1f, 0xb6, 0x2e,
 	0x5f, 0x84, 0x33, 0x0d, 0xe7, 0x28, 0x8e, 0x7f, 0x47, 0xfb, 0x52, 0xd6, 0xea, 0xd8, 0x4f, 0xc6,
-	0xf0, 0x5d, 0xd6, 0x67, 0xff, 0x5f, 0x00, 0x00, 0x00, 0xff, 0xff, 0xb3, 0x16, 0x6f, 0x0d, 0x83,
+	0xf0, 0x5d, 0xd6, 0x67, 0xff, 0x5f, 0x00, 0x00, 0x00, 0xff, 0xff, 0x52, 0x03, 0xc1, 0x5b, 0x83,
 	0xa5, 0x00, 0x00,
 }

--- a/api/api.proto
+++ b/api/api.proto
@@ -2993,9 +2993,9 @@ message VolumePlacementRule {
   // Defines the types of enforcement on the given rules
   enum EnforcementType {
     // This specifies that the rule is required and must be strictly enforced
-    Required = 0;
+    required = 0;
     // This specifies that the rule is preferred and can be best effort
-    Preferred = 1;
+    preferred = 1;
   }
 
   // Enforcement specifies the rule enforcement policy. Can take values: required or preferred.
@@ -3005,9 +3005,9 @@ message VolumePlacementRule {
   // This specifies the type an affinity rule can take
   enum AffinityRuleType {
     // Affinity means the rule specifies an affinity to objects that match the below label selector requirements
-    Affinity = 0;
+    affinity = 0;
     // AntiAffinity means the rule specifies an anti-affinity to objects that match the below label selector requirements
-    AntiAffinity = 1;
+    antiAffinity = 1;
   }
 
   // Type is the type of the affinity rule

--- a/api/server/sdk/api/api.swagger.json
+++ b/api/server/sdk/api/api.swagger.json
@@ -77,21 +77,21 @@
       "type": "string"
     },
     "VolumePlacementRuleAffinityRuleType": {
-      "default": "Affinity",
-      "description": "- Affinity: Affinity means the rule specifies an affinity to objects that match the below label selector requirements\n - AntiAffinity: AntiAffinity means the rule specifies an anti-affinity to objects that match the below label selector requirements",
+      "default": "affinity",
+      "description": "- affinity: Affinity means the rule specifies an affinity to objects that match the below label selector requirements\n - antiAffinity: AntiAffinity means the rule specifies an anti-affinity to objects that match the below label selector requirements",
       "enum": [
-        "Affinity",
-        "AntiAffinity"
+        "affinity",
+        "antiAffinity"
       ],
       "title": "This specifies the type an affinity rule can take",
       "type": "string"
     },
     "VolumePlacementRuleEnforcementType": {
-      "default": "Required",
-      "description": "- Required: This specifies that the rule is required and must be strictly enforced\n - Preferred: This specifies that the rule is preferred and can be best effort",
+      "default": "required",
+      "description": "- required: This specifies that the rule is required and must be strictly enforced\n - preferred: This specifies that the rule is preferred and can be best effort",
       "enum": [
-        "Required",
-        "Preferred"
+        "required",
+        "preferred"
       ],
       "title": "Defines the types of enforcement on the given rules",
       "type": "string"


### PR DESCRIPTION
Signed-off-by: Harsh Desai <harsh@portworx.com>

**What this PR does / why we need it**: Making `EnforcementType` and `AffinityRuleType` lower  camelCase as that's how we want users to use it in the Kubernetes spec. Having lower camelCase automatically generates the lookup maps e.g `VolumePlacementRule_EnforcementType_value ` which can key off the lower camelCase from the Kubernetes spec without doing any string manipulation.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

