### PR TITLE
Add method to update scheduler node name of current node

### DIFF
--- a/api/client/cluster/client.go
+++ b/api/client/cluster/client.go
@@ -192,6 +192,10 @@ func (c *clusterClient) UpdateLabels(nodeLabels map[string]string) error {
 	return nil
 }
 
+func (c *clusterClient) UpdateSchedulerNodeName(name string) error {
+	return nil
+}
+
 func (c *clusterClient) GetData() (map[string]*api.Node, error) {
 	return nil, nil
 }

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -200,6 +200,11 @@ type ClusterData interface {
 
 	// UpdateLabels updates node labels associated with this node
 	UpdateLabels(nodeLabels map[string]string) error
+
+	// UpdateSchedulerNodeName updates the scheduler node name
+	// associated with this node
+	UpdateSchedulerNodeName(name string) error
+
 	// GetData get sdata associated with all nodes.
 	// Key is the node id
 	GetData() (map[string]*api.Node, error)

--- a/cluster/cluster_not_supported.go
+++ b/cluster/cluster_not_supported.go
@@ -122,6 +122,11 @@ func (m *NullClusterData) UpdateLabels(arg0 map[string]string) error {
 	return ErrNotImplemented
 }
 
+// UpdateSchedulerNodeName
+func (m *NullClusterData) UpdateSchedulerNodeName(arg0 string) error {
+	return ErrNotImplemented
+}
+
 // GetData
 func (m *NullClusterData) GetData() (map[string]*api.Node, error) {
 	return nil, ErrNotImplemented

--- a/cluster/mock/cluster.mock.go
+++ b/cluster/mock/cluster.mock.go
@@ -632,6 +632,18 @@ func (mr *MockClusterMockRecorder) UpdateLabels(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateLabels", reflect.TypeOf((*MockCluster)(nil).UpdateLabels), arg0)
 }
 
+// UpdateSchedulerNodeName mocks base method
+func (m *MockCluster) UpdateSchedulerNodeName(arg0 string) error {
+	ret := m.ctrl.Call(m, "UpdateSchedulerNodeName", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateSchedulerNodeName indicates an expected call of UpdateSchedulerNodeName
+func (mr *MockClusterMockRecorder) UpdateSchedulerNodeName(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateSchedulerNodeName", reflect.TypeOf((*MockCluster)(nil).UpdateSchedulerNodeName), arg0)
+}
+
 // Uuid mocks base method
 func (m *MockCluster) Uuid() string {
 	ret := m.ctrl.Call(m, "Uuid")


### PR DESCRIPTION
Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
We need a way to update the scheduler node name in cluster database at any point in time instead of just startup. This PR has a proposed method of having separate method to update specifically the scheduler node name, similar to `UpdateLabels()` and `UpdateData()`.

Another solution was to add a new method - `UpdateNode(node api.StorageNode)`, and update all the parameters that have changed in the StorageNode object. We could probably replace the `UpdateLabels` method with this because `StorageNode` object already has the labels.

Let me know what you guys think.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

