### PR TITLE
Use sdk for docker commands and add docker volume integration test

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -15,6 +15,7 @@ import (
 // Strings for VolumeSpec
 const (
 	Name                     = "name"
+	Token                    = "token"
 	SpecNodes                = "nodes"
 	SpecParent               = "parent"
 	SpecEphemeral            = "ephemeral"

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -46,6 +46,7 @@ func StartGraphAPI(name string, restBase string) error {
 // Linux container engine and volume management commands from the CLI/UX.
 func StartPluginAPI(
 	name string,
+	sdkUds string,
 	mgmtBase string,
 	pluginBase string,
 	mgmtPort uint16,
@@ -59,7 +60,7 @@ func StartPluginAPI(
 		return err
 	}
 	if err := StartVolumePluginAPI(
-		name,
+		name, sdkUds,
 		pluginBase,
 		pluginPort,
 	); err != nil {
@@ -94,12 +95,11 @@ func GetVolumeAPIRoutes(name string) []*Route {
 // StartVolumePluginAPI starts a REST server to receive volume API commands
 // from the linux container  engine
 func StartVolumePluginAPI(
-	name string,
+	name, sdkUds string,
 	pluginBase string,
 	pluginPort uint16,
 ) error {
-
-	volPluginApi := newVolumePlugin(name)
+	volPluginApi := newVolumePlugin(name, sdkUds)
 	if err := startServer(
 		name,
 		pluginBase,

--- a/api/spec/spec_handler.go
+++ b/api/spec/spec_handler.go
@@ -44,6 +44,15 @@ type SpecHandler interface {
 		string,
 	)
 
+	// GetTokenFromString parses the token from the name.
+	// If the token is not present in the name, it will
+	// check inside of the docker options passed in.
+	// If the token was parsed, it returns:
+	// 	(token, true)
+	// If the token wasn't parsed, it returns:
+	// 	("", false)
+	GetTokenFromString(str string) (string, bool)
+
 	// SpecFromOpts parses in docker options passed in the the docker run
 	// command of the form --opt name=value
 	// source is populated if --opt parent=<volume_id> is specified.
@@ -77,6 +86,7 @@ type SpecHandler interface {
 
 var (
 	nameRegex                   = regexp.MustCompile(api.Name + "=([0-9A-Za-z_-]+),?")
+	tokenRegex                  = regexp.MustCompile(api.Token + "=([A-Za-z0-9-_=]+\\.[A-Za-z0-9-_=]+\\.?[A-Za-z0-9-_.+/=]+),?")
 	nodesRegex                  = regexp.MustCompile(api.SpecNodes + "=([A-Za-z0-9-_;]+),?")
 	parentRegex                 = regexp.MustCompile(api.SpecParent + "=([A-Za-z]+),?")
 	sizeRegex                   = regexp.MustCompile(api.SpecSize + "=([0-9A-Za-z]+),?")
@@ -353,6 +363,11 @@ func (d *specHandler) SpecFromOpts(
 
 	spec := d.DefaultSpec()
 	return d.UpdateSpecFromOpts(opts, spec, locator, source)
+}
+
+func (d *specHandler) GetTokenFromString(str string) (string, bool) {
+	ok, token := d.getVal(tokenRegex, str)
+	return token, ok
 }
 
 func (d *specHandler) SpecOptsFromString(

--- a/api/testing/testing_test.go
+++ b/api/testing/testing_test.go
@@ -63,6 +63,7 @@ func TestAll(t *testing.T) {
 
 	server.StartPluginAPI(
 		nfs.Name,
+		"",
 		volume.DriverAPIBase,
 		volume.PluginAPIBase,
 		0,

--- a/cmd/osd/main.go
+++ b/cmd/osd/main.go
@@ -304,8 +304,9 @@ func start(c *cli.Context) error {
 			pluginPort = 0
 		}
 
+		sdksocket := fmt.Sprintf("/var/lib/osd/driver/%s-sdk.sock", d)
 		if err := server.StartPluginAPI(
-			d,
+			d, sdksocket,
 			volume.DriverAPIBase,
 			volume.PluginAPIBase,
 			uint16(mgmtPort),
@@ -339,7 +340,6 @@ func start(c *cli.Context) error {
 		csiServer.Start()
 
 		// Start SDK Server for this driver
-		sdksocket := fmt.Sprintf("/var/lib/osd/driver/%s-sdk.sock", d)
 		os.Remove(sdksocket)
 
 		sdkServer, err := sdk.New(&sdk.ServerConfig{

--- a/hack/docker-integration-test.sh
+++ b/hack/docker-integration-test.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -x
+
+cleanup() {
+	rm .osd_integration_test_id
+	sudo pkill -15 -f $GOPATH/bin/osd
+}
+
+assert_success() {
+	if [ $? -ne 0 ];
+	then
+		cleanup
+		exit 1
+	fi
+}
+
+# Start OSD
+make install
+sudo $GOPATH/bin/osd -d --driver=name=nfs,server=127.0.0.1,path=/nfs --sdkport 9106 --sdkrestport 9116 &
+jobs -l
+
+# Test & assert
+sudo docker volume create -d nfs -o size=1234 > .osd_integration_test_id
+assert_success
+sudo docker volume inspect `cat .osd_integration_test_id`
+assert_success
+sudo docker volume rm `cat .osd_integration_test_id`
+assert_success
+
+# Cleanup
+cleanup


### PR DESCRIPTION
**What this PR does / why we need it**:
* Switched the following commands to use the sdk server instead of the go interfaces
  * create
  * remove
  * get
  * list
  * path
* Also made the above commands parse out a token from the docker request and added to sdk request metadata.
* Added hack/docker-integration-test.sh
  * starts osd as a background process
  * tests docker volume create, inspect, rm

*Which issue(s) this PR fixes** (optional)
Closes #786 
Closes #785 

**Special notes for your reviewer**:
* includes some code copied from @lpabon's sdk-auth-4-ownership branch which hasn't been merged yet
