### PR TITLE
Only send e-mail notifications from Travis when the build fails, or transitions from failure to success.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ notifications:
     recipients:
       - aditya@portworx.com
       - eng@portworx.com
-    on_success: always
+    on_success: change
     on_failure: always


### PR DESCRIPTION
**What this PR does / why we need it**:

Reduce e-mails sent out by travis

