### PR TITLE
Fix docker volume inspect to not return token

### DIFF
--- a/api/server/docker.go
+++ b/api/server/docker.go
@@ -514,7 +514,7 @@ func (d *driver) get(w http.ResponseWriter, r *http.Request) {
 	// get name from the request
 	parsed, _, _, _, name := d.SpecFromString(request.Name)
 	var returnName string
-	if parsed {
+	if !parsed {
 		returnName = request.Name
 	} else {
 		returnName = name

--- a/hack/docker-integration-test.sh
+++ b/hack/docker-integration-test.sh
@@ -19,7 +19,7 @@ get_volume_id() {
 
 assert_attached(){
 	# Get Vol ID
-	get_volume_id $volume_name
+	get_volume_id ${volume_name}_new
 	
 	attach_path=$(curl -X GET "http://localhost:9116/v1/volumes/inspect/$volume_id" -H "accept:application/json" -H "Authorization:bearer $token" | jq  ."volume" | jq ."attach_path" | jq .[0] -r)
 
@@ -64,7 +64,7 @@ sleep 3
 # Test & assert
 volume_name=$(sudo docker volume create -d fake -o size=1234 -o token=$token)
 assert_success
-sudo docker volume inspect token=$token,name=$volume_name 
+sudo docker volume inspect token=$token,name=${volume_name} 
 assert_success
 
 # Get Vol ID
@@ -75,9 +75,7 @@ assert_attached false
 
 # Run app with our  volume
 app_name="APP_TEST_$volume_name"
-
-sudo docker stop $app_name && sudo docker rm $app_name 
-sudo docker run -d --name $app_name --volume-driver fake -v token=$token,name=$volume_name:/app nginx:latest
+sudo docker run -d --name $app_name --volume-driver fake -v size=12345,token=$token,name=${volume_name}_new:/app nginx:latest
 assert_success
 assert_attached true
 


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
* Currently, for `docker volume inspect token=<token>,name=<name>` calls, we're returning the name the entire token=<token>,name=<name>. The expected behavior is to return only the name. This bug happened when we re-added logic to only return the name instead of the entire `request.Name`. request.Name is only returned when we cannot parse what the user has passed in.

**Which issue(s) this PR fixes** (optional)
Closes #809

**Special notes for your reviewer**:

