### PR TITLE
Original REST server to redirect requests to the SDK for auth support

### DIFF
--- a/api/client/volume/client.go
+++ b/api/client/volume/client.go
@@ -192,6 +192,7 @@ func (v *volumeClient) Snapshot(volumeID string,
 	if err := v.c.Post().Resource(snapPath).Body(request).Do().Unmarshal(response); err != nil {
 		return "", err
 	}
+
 	// TODO(pedge): this probably should not be embedded in this way
 	if response.VolumeCreateResponse != nil &&
 		response.VolumeCreateResponse.VolumeResponse != nil &&

--- a/api/server/sdk/volume_node_ops.go
+++ b/api/server/sdk/volume_node_ops.go
@@ -188,9 +188,11 @@ func (s *VolumeServer) Mount(
 		// If volume is scaled up, a new volume is created and
 		// vol will change.
 		attachOptions := make(map[string]string)
-		attachOptions[options.OptionsSecret] = req.Options.SecretName
-		attachOptions[options.OptionsSecretKey] = req.Options.SecretKey
-		attachOptions[options.OptionsSecretContext] = req.Options.SecretContext
+		if req.Options != nil {
+			attachOptions[options.OptionsSecret] = req.Options.SecretName
+			attachOptions[options.OptionsSecretKey] = req.Options.SecretKey
+			attachOptions[options.OptionsSecretContext] = req.Options.SecretContext
+		}
 		if vol.Scaled() {
 			vol, err = s.attachScale(ctx, vol, attachOptions)
 		} else {


### PR DESCRIPTION
Signed-off-by: Paul <paul@portworx.com>

**What this PR does / why we need it**:
This is required to allow authentication/authorization to work on the current API server.

**Which issue(s) this PR fixes** (optional)
Closes #799 

**Special notes for your reviewer**:

