### PR TITLE
Add method to check if a volume spec is equal to another

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"math"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -742,6 +743,54 @@ func (s *VolumeSpec) Copy() *VolumeSpec {
 		copy(spec.ReplicaSet.Nodes, s.ReplicaSet.Nodes)
 	}
 	return &spec
+}
+
+func (s *VolumeSpec) Equals(in *VolumeSpec) bool {
+	if in == nil {
+		return false
+	}
+
+	if in.Ephemeral == s.Ephemeral &&
+		in.Size == s.Size &&
+		in.Format == s.Format &&
+		in.BlockSize == s.BlockSize &&
+		in.HaLevel == s.HaLevel &&
+		in.Cos == s.Cos &&
+		in.IoProfile == s.IoProfile &&
+		in.Dedupe == s.Dedupe &&
+		in.SnapshotInterval == s.SnapshotInterval &&
+		reflect.DeepEqual(in.VolumeLabels, s.VolumeLabels) &&
+		in.Shared == s.Shared &&
+		isAggregrationLevelSame(in.AggregationLevel, s.AggregationLevel) &&
+		in.Encrypted == s.Encrypted &&
+		in.Passphrase == s.Passphrase &&
+		in.SnapshotSchedule == s.SnapshotSchedule &&
+		in.Scale == s.Scale &&
+		in.Sticky == s.Sticky &&
+		reflect.DeepEqual(in.Group, s.Group) &&
+		in.GroupEnforced == s.GroupEnforced &&
+		in.Compressed == s.Compressed &&
+		in.Cascaded == s.Cascaded &&
+		in.Journal == s.Journal &&
+		in.Sharedv4 == s.Sharedv4 &&
+		in.QueueDepth == s.QueueDepth &&
+		in.ForceUnsupportedFsType == s.ForceUnsupportedFsType &&
+		in.Nodiscard == s.Nodiscard {
+		return true
+	}
+
+	return false
+}
+
+func isAggregrationLevelSame(aggr1, aggr2 uint32) bool {
+	if aggr1 == aggr2 ||
+		// one of them is 0 and other is 1.
+		// Both are defaults and mean the same aggregation level
+		aggr1+aggr2 == 1 {
+		return true
+	}
+
+	return false
 }
 
 // Copy makes a deep copy of Node

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCloudBackupStatusTypeToSdkCloudBackupStatusType(t *testing.T) {
@@ -114,4 +115,36 @@ func TestStringToSdkCloudBackupStatusType(t *testing.T) {
 			test.sdkType,
 			StringToSdkCloudBackupStatusType(test.internalType))
 	}
+}
+
+func TestVolumeSpecEquals(t *testing.T) {
+
+	labels := map[string]string{
+		"foo":  "bar",
+		"foo2": "bar2",
+	}
+
+	vol1 := &VolumeSpec{
+		Ephemeral: true,
+		Size:      5,
+		HaLevel:   3,
+		IoProfile: IoProfile_IO_PROFILE_DB,
+		Group: &Group{
+			Id: "foo",
+		},
+		VolumeLabels: labels,
+	}
+
+	isEqual := vol1.Equals(nil)
+	require.False(t, isEqual, "expected both volumes not to be equal")
+
+	vol1Copy := vol1.Copy()
+
+	isEqual = vol1.Equals(vol1Copy)
+	require.True(t, isEqual, "expected both volumes to be equal")
+
+	vol1Copy.Size = 7
+	isEqual = vol1.Equals(vol1Copy)
+	require.False(t, isEqual, "expected both volumes not to be equal")
+
 }


### PR DESCRIPTION
Signed-off-by: Harsh Desai <harsh@portworx.com>

**What this PR does / why we need it**: In Portworx, we have logic to check whether a particular volume's spec is the same as other's. Currently we directly use reflect.DeepEqual to do this. But this doesn't work since for certain fields like aggregration level, the default is 0 for a new volume's spec but we internally set this to 1 for the existing volume. So we need a deep check.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

