### PR TITLE
Fix group admin in ownership

### DIFF
--- a/api/ownership.go
+++ b/api/ownership.go
@@ -108,6 +108,12 @@ func (o *Ownership) GetCollaborators() []string {
 // IsUserAllowedByGroup returns true if the user is allowed access
 // by belonging to the appropriate group
 func (o *Ownership) IsUserAllowedByGroup(user *auth.UserInfo) bool {
+
+	// If it is the admin user for any group
+	if o.IsAdminByUser(user) {
+		return true
+	}
+
 	ownergroups := o.GetGroups()
 	if len(ownergroups) == 0 {
 		return false

--- a/api/ownership_test.go
+++ b/api/ownership_test.go
@@ -239,6 +239,18 @@ func TestOwnershipIsPermitted(t *testing.T) {
 			},
 			permitted: true,
 		},
+		{
+			owner: &Ownership{
+				Owner: "me",
+			},
+			user: &auth.UserInfo{
+				Username: "notme",
+				Claims: auth.Claims{
+					Groups: []string{"*"},
+				},
+			},
+			permitted: true,
+		},
 	}
 
 	for _, test := range tests {

--- a/api/spec/spec_handler.go
+++ b/api/spec/spec_handler.go
@@ -345,6 +345,8 @@ func (d *specHandler) UpdateSpecFromOpts(opts map[string]string, spec *api.Volum
 			} else {
 				spec.ForceUnsupportedFsType = forceFs
 			}
+		case api.Token:
+			// skip, if not it would be added to the labels
 		default:
 			locator.VolumeLabels[k] = v
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
* Fix group admin in ownership. A user with an admin group should be able to access any ACLS.
* Also make sure not to save token in labels

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

