### PR TITLE
Fix ownership in enumerate

### DIFF
--- a/api/server/sdk/volume_ops.go
+++ b/api/server/sdk/volume_ops.go
@@ -317,11 +317,6 @@ func (s *VolumeServer) EnumerateWithFilters(
 			VolumeLabels: req.GetLabels(),
 			Ownership:    req.GetOwnership(),
 		}
-
-		// If no ownership provided use the user's information
-		if locator.GetOwnership() == nil {
-			locator.Ownership = api.NewLocatorOwnershipFromContext(ctx)
-		}
 	}
 
 	vols, err := s.driver().Enumerate(locator, nil)


### PR DESCRIPTION
**What this PR does / why we need it**:
There is no need to also match the owner's ownership. This would mean
that an admin would only see their own volumes. Instead, let the
permission code determine if they can see the volume
