### PR TITLE
Fix ownership update

### DIFF
--- a/api/ownership_test.go
+++ b/api/ownership_test.go
@@ -261,10 +261,11 @@ func TestOwnershipIsPermitted(t *testing.T) {
 func TestOwnershipUpdate(t *testing.T) {
 
 	tests := []struct {
-		owner  *Ownership
-		update *Ownership
-		result *Ownership
-		user   *auth.UserInfo
+		owner     *Ownership
+		update    *Ownership
+		result    *Ownership
+		user      *auth.UserInfo
+		expectErr bool
 	}{
 		{
 			owner: &Ownership{
@@ -290,6 +291,7 @@ func TestOwnershipUpdate(t *testing.T) {
 					Groups: []string{"group"},
 				},
 			},
+			expectErr: false,
 		},
 		{
 			owner: &Ownership{
@@ -317,6 +319,7 @@ func TestOwnershipUpdate(t *testing.T) {
 					Groups: []string{"group"},
 				},
 			},
+			expectErr: false,
 		},
 		{
 			owner: &Ownership{
@@ -337,6 +340,7 @@ func TestOwnershipUpdate(t *testing.T) {
 					Groups: []string{"*"},
 				},
 			},
+			expectErr: false,
 		},
 		{
 			owner: &Ownership{
@@ -356,12 +360,37 @@ func TestOwnershipUpdate(t *testing.T) {
 					Groups: []string{"*"},
 				},
 			},
+			expectErr: false,
+		},
+		{
+			owner: &Ownership{
+				Owner: "user1",
+				Acls: &Ownership_AccessControl{
+					Groups: []string{"group1"},
+				}},
+			update: &Ownership{
+				Acls: &Ownership_AccessControl{},
+			},
+			result: &Ownership{
+				Owner: "user1",
+				Acls: &Ownership_AccessControl{
+					Groups: []string{"group1"},
+				}},
+			user: &auth.UserInfo{
+				Username: "anotheruser",
+			},
+			expectErr: true,
 		},
 	}
 
 	for _, test := range tests {
-		r := test.owner.Update(test.update, test.user)
-		assert.True(t, reflect.DeepEqual(r, test.result), fmt.Sprintf("%v | %v", r, test.result))
+		err := test.owner.Update(test.update, test.user)
+		if test.expectErr {
+			assert.Error(t, err, fmt.Sprintf("%v | %v", test.owner, test.result))
+		} else {
+			assert.NoError(t, err, fmt.Sprintf("%v | %v", test.owner, test.result))
+		}
+		assert.True(t, reflect.DeepEqual(test.owner, test.result), fmt.Sprintf("%v | %v", test.owner, test.result))
 	}
 }
 

--- a/api/server/sdk/volume_ops.go
+++ b/api/server/sdk/volume_ops.go
@@ -376,7 +376,9 @@ func (s *VolumeServer) Update(
 		}
 
 		user, _ := auth.NewUserInfoFromContext(ctx)
-		spec.Ownership.Update(req.GetSpec().GetOwnership(), user)
+		if err := spec.Ownership.Update(req.GetSpec().GetOwnership(), user); err != nil {
+			return nil, err
+		}
 	}
 
 	// Check if labels have been updated


### PR DESCRIPTION
**What this PR does / why we need it**:
The function should return that the caller has no access to update ownership

