### PR TITLE
Docker get/path and REST stats/usesize to have no auth

### DIFF
--- a/api/server/testutils_test.go
+++ b/api/server/testutils_test.go
@@ -273,7 +273,7 @@ func testRestServerSdkNoAuth(t *testing.T) (*httptest.Server, *testServer) {
 }
 
 func testRestServerSdk(t *testing.T) (*httptest.Server, *testServer) {
-	vapi := newVolumeAPI(mockDriverName, testSdkSock)
+	vapi := newVolumeAPI("fake", testSdkSock)
 	router := mux.NewRouter()
 	// Register all routes from the App
 	for _, route := range vapi.Routes() {

--- a/volume/drivers/fake/fake.go
+++ b/volume/drivers/fake/fake.go
@@ -330,6 +330,20 @@ func (d *driver) Set(volumeID string, locator *api.VolumeLocator, spec *api.Volu
 }
 
 func (d *driver) Shutdown() {}
+
+func (d *driver) UsedSize(volumeID string) (uint64, error) {
+	vols, err := d.Inspect([]string{volumeID})
+	if err == kvdb.ErrNotFound {
+		return 0, fmt.Errorf("Volume not found")
+	} else if err != nil {
+		return 0, err
+	} else if len(vols) == 0 {
+		return 0, fmt.Errorf("Volume not found")
+	}
+
+	return uint64(12345), nil
+}
+
 func (d *driver) Stats(volumeID string, cumulative bool) (*api.Stats, error) {
 
 	vols, err := d.Inspect([]string{volumeID})


### PR DESCRIPTION
**What this PR does / why we need it**:
Docker get/path are sent without token, so to unblock docker, these functions now do not check auth. Stats and usedsize have issues with Portworx driver, and we will investigate and add them back with auth once we figure out the issue.

**Which issue(s) this PR fixes** (optional)
Closes #841
Closes #842

**Special notes for your reviewer**:

