### PR TITLE
Fix panic on volume update

### DIFF
--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -308,10 +308,8 @@ func (vd *volAPI) volumeSet(w http.ResponseWriter, r *http.Request) {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
 	}
-
 	updateReq := &api.SdkVolumeUpdateRequest{VolumeId: volumeID}
 	updateReq.Spec = getVolumeUpdateSpec(req.Spec, vol.GetVolume())
-
 	if req.Locator != nil && len(req.Locator.VolumeLabels) > 0 {
 		updateReq.Labels = req.Locator.VolumeLabels
 	}
@@ -416,6 +414,9 @@ func (vd *volAPI) volumeSet(w http.ResponseWriter, r *http.Request) {
 
 func getVolumeUpdateSpec(spec *api.VolumeSpec, vol *api.Volume) *api.VolumeSpecUpdate {
 	newSpec := &api.VolumeSpecUpdate{}
+	if spec == nil {
+		return newSpec
+	}
 	if spec.Shared != vol.Spec.Shared {
 		newSpec.SharedOpt = &api.VolumeSpecUpdate_Shared{
 			Shared: spec.Shared,


### PR DESCRIPTION
Signed-off-by: Paul <paul@portworx.com>

**What this PR does / why we need it**:
Fixes the nil panic we get when doing a volume update.
We were not checking if Locator was nil and we were not creating a new Spec object.


**Which issue(s) this PR fixes** (optional)
Closes #852

**Special notes for your reviewer**:

