### PR TITLE
PWX-7048: Fix top-mountpoint deletion

### DIFF
--- a/csi/node_test.go
+++ b/csi/node_test.go
@@ -45,7 +45,7 @@ func TestNodePublishVolumeBadArguments(t *testing.T) {
 	}{
 		{
 			expectedErrorContains: "Volume id",
-			req:                   &csi.NodePublishVolumeRequest{},
+			req: &csi.NodePublishVolumeRequest{},
 		},
 		{
 			expectedErrorContains: "Target path",

--- a/csi/node_test.go
+++ b/csi/node_test.go
@@ -45,7 +45,7 @@ func TestNodePublishVolumeBadArguments(t *testing.T) {
 	}{
 		{
 			expectedErrorContains: "Volume id",
-			req: &csi.NodePublishVolumeRequest{},
+			req:                   &csi.NodePublishVolumeRequest{},
 		},
 		{
 			expectedErrorContains: "Target path",

--- a/pkg/util/fileutil.go
+++ b/pkg/util/fileutil.go
@@ -1,0 +1,54 @@
+/*
+Package util provides utility functions for OSD servers and drivers.
+Copyright 2017 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import (
+	"fmt"
+	"syscall"
+	"path"
+)
+
+// IsSameFilesystem takes a group of files/directories, and returns TRUE if all files/dirs belong to the same file-system.
+func IsSameFilesystem(filesOrDirs ...string) (bool, error) {
+	if len(filesOrDirs) < 2 {
+		return false, fmt.Errorf("Need at least 2 arguments")
+	}
+
+	var st0, st1 syscall.Stat_t
+
+	err := syscall.Lstat(filesOrDirs[0], &st0)
+	if err != nil {
+		return false, fmt.Errorf("Could not stat %s: %s", filesOrDirs[1], err)
+	}
+
+	for _, m := range filesOrDirs[1:] {
+		err = syscall.Lstat(m, &st1)
+		if err != nil {
+			return false, fmt.Errorf("Could not stat %s: %s", m, err)
+		} else if st0.Dev != st1.Dev {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// IsMountpoint tests if the directory is a mountpoint to a different file-system
+func IsMountpoint(dir string) (bool, error) {
+	b, err := IsSameFilesystem(dir, path.Dir(dir))
+	return !b, err
+}

--- a/pkg/util/fileutil.go
+++ b/pkg/util/fileutil.go
@@ -18,8 +18,8 @@ package util
 
 import (
 	"fmt"
-	"syscall"
 	"path"
+	"syscall"
 )
 
 // IsSameFilesystem takes a group of files/directories, and returns TRUE if all files/dirs belong to the same file-system.

--- a/pkg/util/fileutil_test.go
+++ b/pkg/util/fileutil_test.go
@@ -1,0 +1,112 @@
+/*
+Package util provides utility functions for OSD servers and drivers.
+Copyright 2017 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package util
+
+import (
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+func TestIsSameFilesystem(t *testing.T) {
+
+	if u, err := user.Current(); err != nil || u.Uid != "0" {
+		t.Skipf("Test reqires ROOT user -- skipping (uid=%v, err=%s)", u.Uid, err)
+	}
+
+	testData := []struct {
+		input     []string
+		expectRes bool
+		expectErr string
+	}{
+		{[]string{"/"}, false, "2 arguments"},
+		{[]string{"/", "/"}, true, ""},
+		{[]string{"/", "/", "/", "/", "/", "/"}, true, ""},
+		{[]string{"/", "/proc/self/mountinfo"}, false, ""},
+		{[]string{"/", "/_dont_really_exist"}, false, "Could not stat"},
+		{[]string{"/_dont_really_exist", "/"}, false, "Could not stat"},
+	}
+
+	for i, td := range testData {
+		resB, err := IsSameFilesystem(td.input...)
+		if td.expectErr != "" {
+			// Test is expecting error here -- let's check if we got a correct error
+			require.Error(t, err,
+				"was expecting error for test-entry #%d - %q", i+1, td.input)
+			assert.Contains(t, err.Error(), td.expectErr,
+				"was expecting error with %s for test-entry #%d - %q", td.expectErr, i+1, td.input)
+		} else {
+			// Test is expecting regular result here
+			assert.NoError(t, err,
+				"was NOT expecting error for test-entry #%d - %q", i+1, td.input)
+			assert.Equal(t, td.expectRes, resB,
+				"broken expectation for test-entry #%d - %q", i+1, td.input)
+		}
+	}
+
+	// Let's also prepare our bind-mount
+	tdir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+	mpath := path.Join(tdir, "anoter", "more", "3rd-subdir", "mount")
+	defer func() {
+		unix.Unmount(mpath, 0)
+		os.RemoveAll(tdir)
+	}()
+
+	err = os.MkdirAll(mpath, 0755)
+	require.NoError(t, err)
+	flags := uintptr(syscall.MS_NOATIME | syscall.MS_SILENT | syscall.MS_NODEV | syscall.MS_NOEXEC | syscall.MS_NOSUID)
+	err = unix.Mount("tmpfs", mpath, "tmpfs", flags, "size=5")
+	require.NoError(t, err)
+
+	// Validate mountpoint
+	resB, err := IsSameFilesystem(mpath, path.Dir(mpath))
+	assert.NoError(t, err)
+	assert.False(t, resB)
+
+	// .. expect same
+	resB, err = IsSameFilesystem(path.Dir(mpath), mpath)
+	assert.NoError(t, err)
+	assert.False(t, resB)
+
+	// .. expect no mountpoint
+	resB, err = IsSameFilesystem(path.Dir(mpath), path.Dir(path.Dir(mpath)))
+	assert.NoError(t, err)
+	assert.True(t, resB)
+
+	// .. expect false on mixed (applies to _all_ params on the same device)
+	resB, err = IsSameFilesystem(mpath, path.Dir(mpath), path.Dir(path.Dir(mpath)), "/")
+	assert.NoError(t, err)
+	assert.False(t, resB)
+
+	// Test IsMountpoint() while we have a mounted RAMDISK
+
+	resB, err = IsMountpoint(mpath)
+	assert.NoError(t, err)
+	assert.True(t, resB)
+
+	resB, err = IsMountpoint(path.Dir(mpath))
+	assert.NoError(t, err)
+	assert.False(t, resB)
+}

--- a/pkg/util/fileutil_test.go
+++ b/pkg/util/fileutil_test.go
@@ -52,8 +52,7 @@ func TestIsSameFilesystem(t *testing.T) {
 		resB, err := IsSameFilesystem(td.input...)
 		if td.expectErr != "" {
 			// Test is expecting error here -- let's check if we got a correct error
-			require.Error(t, err,
-				"was expecting error for test-entry #%d - %q", i+1, td.input)
+			require.Error(t, err)
 			assert.Contains(t, err.Error(), td.expectErr,
 				"was expecting error with %s for test-entry #%d - %q", td.expectErr, i+1, td.input)
 		} else {


### PR DESCRIPTION
* adding convenient util-functions IsSameFilesystem() and IsMountpoint() that
  that use low-level stat and unix device-IDs to determine if files belong to
  the same file-system
* fixing mount.removeMountPath() to make sure we are not deleting STILL MOUNTED mountpoints/binds

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
The current code can remove MOUNTED directories, breaking the container configuration:
1. start container with "-v /mnt:/mnt:shared"
2. mount storage-volume inside container _directly_ on /mnt
3. unmount volume
4. currently, the container internally remove its /mnt directory (which is a bind-mountpoint from host !!) - so the steps 1..3 are NOT REPEATABLE, and they should be

This PR fixes this behavior.

**Which issue(s) this PR fixes** (optional)
PWX-7048

**Special notes for your reviewer**:
Will also require back-port (cherry-pick) for px-2.1