### PR TITLE
Let users with admin access type change ownership

### DIFF
--- a/api/ownership.go
+++ b/api/ownership.go
@@ -190,12 +190,14 @@ func (o *Ownership) Update(newownerInfo *Ownership, user *auth.UserInfo) error {
 	} else {
 		// Auth is enabled
 
-		// Only the owner or admin can change the group
-		if user.Username != o.Owner && !o.IsAdminByUser(user) {
+		// Only the owner, user with access type admin,
+		// or admin can change the group
+		if user.Username != o.Owner &&
+			!o.IsAdminByUser(user) &&
+			!o.IsPermitted(user, Ownership_Admin) {
 			return status.Error(codes.PermissionDenied,
-				"Only owner can update volume acls")
+				"Only owner or those with admin access type can update volume acls")
 		}
-		o.Acls = newownerInfo.GetAcls()
 
 		// Only the admin can change the owner
 		if newownerInfo.HasAnOwner() {
@@ -206,6 +208,7 @@ func (o *Ownership) Update(newownerInfo *Ownership, user *auth.UserInfo) error {
 					"Only the administrator can change the owner of the resource")
 			}
 		}
+		o.Acls = newownerInfo.GetAcls()
 	}
 	return nil
 }

--- a/api/ownership_test.go
+++ b/api/ownership_test.go
@@ -541,10 +541,8 @@ func TestOwnershipUpdate(t *testing.T) {
 			result: &Ownership{
 				Owner: "user1",
 				Acls: &Ownership_AccessControl{
-					Collaborators: map[string]Ownership_AccessType{
-						"user1": Ownership_Read,
-						"user2": Ownership_Read,
-						"user3": Ownership_Read,
+					Groups: map[string]Ownership_AccessType{
+						"group1": Ownership_Admin,
 					},
 				},
 			},
@@ -699,6 +697,108 @@ func TestOwnershipUpdate(t *testing.T) {
 				}},
 			user: &auth.UserInfo{
 				Username: "anotheruser",
+			},
+			expectErr: true,
+		},
+		{
+			owner: &Ownership{
+				Owner: "user1",
+				Acls: &Ownership_AccessControl{
+					Groups: map[string]Ownership_AccessType{
+						"group1": Ownership_Admin,
+					},
+					Collaborators: map[string]Ownership_AccessType{
+						"anotheruser": Ownership_Admin,
+					},
+				}},
+			update: &Ownership{
+				Acls: &Ownership_AccessControl{
+					Groups: map[string]Ownership_AccessType{
+						"group1": Ownership_Admin,
+						"group2": Ownership_Read,
+					},
+					Collaborators: map[string]Ownership_AccessType{
+						"anotheruser": Ownership_Admin,
+					},
+				},
+			},
+			result: &Ownership{
+				Owner: "user1",
+				Acls: &Ownership_AccessControl{
+					Groups: map[string]Ownership_AccessType{
+						"group1": Ownership_Admin,
+						"group2": Ownership_Read,
+					},
+					Collaborators: map[string]Ownership_AccessType{
+						"anotheruser": Ownership_Admin,
+					},
+				}},
+			user: &auth.UserInfo{
+				Username: "anotheruser",
+			},
+			expectErr: false,
+		},
+		{
+			owner: &Ownership{
+				Owner: "user1",
+				Acls: &Ownership_AccessControl{
+					Groups: map[string]Ownership_AccessType{
+						"group1": Ownership_Admin,
+					},
+				}},
+			update: &Ownership{
+				Acls: &Ownership_AccessControl{
+					Groups: map[string]Ownership_AccessType{
+						"group1": Ownership_Admin,
+						"group2": Ownership_Read,
+					},
+				},
+			},
+			result: &Ownership{
+				Owner: "user1",
+				Acls: &Ownership_AccessControl{
+					Groups: map[string]Ownership_AccessType{
+						"group1": Ownership_Admin,
+						"group2": Ownership_Read,
+					},
+				}},
+			user: &auth.UserInfo{
+				Username: "anotheruser",
+				Claims: auth.Claims{
+					Groups: []string{"group1"},
+				},
+			},
+			expectErr: false,
+		},
+		{
+			owner: &Ownership{
+				Owner: "user1",
+				Acls: &Ownership_AccessControl{
+					Groups: map[string]Ownership_AccessType{
+						"group1": Ownership_Admin,
+					},
+				}},
+			update: &Ownership{
+				Owner: "anotheruser",
+				Acls: &Ownership_AccessControl{
+					Groups: map[string]Ownership_AccessType{
+						"group1": Ownership_Admin,
+						"group2": Ownership_Read,
+					},
+				},
+			},
+			result: &Ownership{
+				Owner: "user1",
+				Acls: &Ownership_AccessControl{
+					Groups: map[string]Ownership_AccessType{
+						"group1": Ownership_Admin,
+					},
+				}},
+			user: &auth.UserInfo{
+				Username: "anotheruser",
+				Claims: auth.Claims{
+					Groups: []string{"group1"},
+				},
 			},
 			expectErr: true,
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:
Updating the ownership could only be done by the owner or cluster admin, even though a collaborator may have admin access type rights. This PR adds support for collaborators or groups with admin access type rights to also update the ownership. These users cannot change the owner, so the owner still has more rights, in that they can remove access to these collaborator/groups.

Also fixes #863 were the ownership was being changed even though it returned an error.

**Which issue(s) this PR fixes** (optional)
Closes #862
Closes #863

**Special notes for your reviewer**:

