### PR TITLE
Move REST port back to 9001 from 9100

### DIFF
--- a/cmd/osd/main.go
+++ b/cmd/osd/main.go
@@ -98,7 +98,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "mgmtport,m",
 			Usage: "Management Port for REST server. Example: 9001",
-			Value: "9100",
+			Value: "9001",
 		},
 		cli.StringFlag{
 			Name:  "sdkport",


### PR DESCRIPTION

**What this PR does / why we need it**:
REST port was set to 9100 instead of 9001 and was conflicting the gRPC sdk port

**Which issue(s) this PR fixes** (optional)
Closes #868

**Special notes for your reviewer**:

