### PR TITLE
Support auth for cloud pairing & move system token generator

### DIFF
--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -1887,17 +1887,17 @@ func (c *ClusterManager) SecretGetDefaultSecretKey() (interface{}, error) {
 
 // SecretCheckLogin validates session with secret store
 func (c *ClusterManager) SecretCheckLogin() error {
-	return c.SecretCheckLogin()
+	return c.secretsManager.SecretCheckLogin()
 }
 
 // SecretSet the given value/data against the key
 func (c *ClusterManager) SecretSet(secretKey string, secretValue interface{}) error {
-	return c.SecretSet(secretKey, secretValue)
+	return c.secretsManager.SecretSet(secretKey, secretValue)
 }
 
 // SecretGet retrieves the value/data for given key
 func (c *ClusterManager) SecretGet(secretKey string) (interface{}, error) {
-	return c.SecretGet(secretKey)
+	return c.secretsManager.SecretGet(secretKey)
 }
 
 // Uuid returns the unique id of the cluster

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -64,9 +64,8 @@ func getUsername(usernameClaim UsernameClaimType, claims *Claims) string {
 	return claims.Subject
 }
 
-// AuthorizationEnabled returns true if the storage system has authorization
-// and authentication enabled.
-func AuthorizationEnabled(ctx context.Context) bool {
-	_, ok := NewUserInfoFromContext(ctx)
-	return ok
+// Enabled returns if authentication is enabled in the system.
+// If node-node authentication is enabled, then system authentication is enabled.
+func Enabled() bool {
+	return len(inst.Issuer()) != 0
 }

--- a/pkg/auth/noauth.go
+++ b/pkg/auth/noauth.go
@@ -1,0 +1,20 @@
+package auth
+
+import (
+	"fmt"
+)
+
+// Default no auth
+type noauth struct{}
+
+func (s *noauth) Issuer() string {
+	return ""
+}
+
+func (s *noauth) GetAuthenticator() (*JwtAuthenticator, error) {
+	return nil, fmt.Errorf("No authentication set")
+}
+
+func (s *noauth) GetSystemToken() (string, error) {
+	return "", nil
+}

--- a/pkg/auth/systemtoken.go
+++ b/pkg/auth/systemtoken.go
@@ -1,0 +1,95 @@
+package auth
+
+import (
+	"fmt"
+	"time"
+)
+
+// SystemTokenGenerator provides access to tokens needed for node to
+// node communication
+type SystemTokenGenerator interface {
+
+	// Issuer returns the token issuer for this generator necessary
+	// for registering the authenticator in the SDK.
+	Issuer() string
+
+	// GetAuthenticator returns an authenticator for this issuer used by the SDK
+	GetAuthenticator() (*JwtAuthenticator, error)
+
+	// GetSystemToken returns a token which can be used for
+	// authentication and communication from node to node.
+	GetSystemToken() (string, error)
+}
+
+type Config struct {
+	ClusterUuid string
+	NodeId      string
+	Claims      *Claims
+	Secret      string
+}
+
+type systemTokenGenerator struct {
+	clusteruuid string
+	nodeId      string
+	claims      *Claims
+	secret      string
+}
+
+var _ SystemTokenGenerator = &systemTokenGenerator{}
+var _ SystemTokenGenerator = &noauth{}
+
+var (
+	inst SystemTokenGenerator = &noauth{}
+
+	// Inst returns an instance of an already instantiated object.
+	// This function can be overridden for testing purposes
+	Inst = func() (SystemTokenGenerator, error) {
+		return systemTokenGeneratorInst()
+	}
+)
+
+func systemTokenGeneratorInst() (SystemTokenGenerator, error) {
+	return inst, nil
+}
+
+// Init initializes the system token generator
+func Init(c *Config) (SystemTokenGenerator, error) {
+
+	if c == nil ||
+		len(c.ClusterUuid) == 0 ||
+		len(c.NodeId) == 0 ||
+		c.Claims == nil ||
+		len(c.Secret) == 0 {
+		return nil, fmt.Errorf("Must supply claims, clusterUuid, nodeId, and system secret")
+	}
+
+	inst = &systemTokenGenerator{
+		clusteruuid: c.ClusterUuid,
+		nodeId:      c.NodeId,
+		claims:      c.Claims,
+		secret:      c.Secret,
+	}
+	return inst, nil
+}
+
+func (s *systemTokenGenerator) Issuer() string {
+	return s.clusteruuid
+}
+
+func (s *systemTokenGenerator) GetAuthenticator() (*JwtAuthenticator, error) {
+	return NewJwtAuth(&JwtAuthConfig{
+		SharedSecret: []byte(s.secret),
+	})
+}
+
+func (s *systemTokenGenerator) GetSystemToken() (string, error) {
+	options := &Options{
+		Expiration: time.Now().Add(5 * Year).Unix(),
+	}
+	signature, err := NewSignatureSharedSecret(s.secret)
+	if err != nil {
+		return "", err
+	}
+
+	return Token(s.claims, signature, options)
+}

--- a/pkg/auth/systemtoken_test.go
+++ b/pkg/auth/systemtoken_test.go
@@ -1,0 +1,55 @@
+package auth
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoAuth(t *testing.T) {
+	assert.False(t, Enabled())
+	assert.Empty(t, inst.Issuer())
+
+	a, err := inst.GetAuthenticator()
+	assert.Nil(t, a)
+	assert.Error(t, err)
+
+	token, err := inst.GetSystemToken()
+	assert.Empty(t, token)
+	assert.NoError(t, err)
+}
+
+func TestSystemTokenGenerator(t *testing.T) {
+	oldinst := inst
+	defer func() {
+		inst = oldinst
+	}()
+	assert.False(t, Enabled())
+	claims := &Claims{
+		Issuer:  "uid",
+		Subject: "456",
+		Name:    "Internal cluster communication",
+		Email:   "abcd@abcd.com",
+		Roles:   []string{"system.admin"},
+		Groups:  []string{"*"},
+	}
+	config := &Config{
+		ClusterUuid: "uid",
+		NodeId:      "id",
+		Claims:      claims,
+		Secret:      "mysecret",
+	}
+	stg, err := Init(config)
+	assert.NoError(t, err)
+	assert.Equal(t, stg.Issuer(), config.ClusterUuid)
+	assert.True(t, Enabled())
+
+	token, err := stg.GetSystemToken()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, token)
+	assert.Equal(t, strings.Count(token, "."), 2)
+	issuer, err := TokenIssuer(token)
+	assert.NoError(t, err)
+	assert.Equal(t, issuer, stg.Issuer())
+}


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
- Moved system token generator to openstorage
- Support auth for cluster pairing by storing token 

**Which issue(s) this PR fixes** (optional)
Closes #872 
Closes #865 

**Special notes for your reviewer**:
- Fixed an issue with `c.SecretCheckLogin`, `c. SecretSet`, and `c.SecretGet` that are included in this PR.
