### PR TITLE
add pkg/auth API for token claims

### DIFF
--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -82,3 +82,28 @@ func TestTokenExpired(t *testing.T) {
 	})
 	assert.False(t, token.Valid)
 }
+
+func TestTokenIssuer(t *testing.T) {
+	key := []byte("mysecret")
+	issuer := "testiss"
+
+	claims := Claims{
+		Issuer: issuer,
+	}
+	sig := Signature{
+		Type: jwt.SigningMethodHS256,
+		Key:  key,
+	}
+	opts := Options{
+		Expiration: time.Now().Add(-(time.Minute * 10)).Unix(),
+	}
+
+	// Create
+	rawtoken, err := Token(&claims, &sig, &opts)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, rawtoken)
+
+	parsedIssuer, err := TokenIssuer(rawtoken)
+	assert.NoError(t, err)
+	assert.Equal(t, issuer, parsedIssuer)
+}


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
- Introduces `TokenClaims()` API similar to `TokenIssuer()`
- `TokenIssuer()` calls `TokenClaims()` in order to get the issuer.

**Which issue(s) this PR fixes** (optional)
Closes #877 

**Special notes for your reviewer**:
- Needed to get token claims from a raw token
