### PR TITLE
grpc: Add backoff in grpc dial

### DIFF
--- a/pkg/grpcserver/grpcutil.go
+++ b/pkg/grpcserver/grpcutil.go
@@ -37,6 +37,7 @@ func Connect(address string, dialOptions []grpc.DialOption) (*grpc.ClientConn, e
 				}))
 	}
 
+	dialOptions = append(dialOptions, grpc.WithBackoffMaxDelay(time.Second))
 	conn, err := grpc.Dial(address, dialOptions...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes connections to grpc servers more reliable


