### PR TITLE
Only update volume if we truly receive a spec and locator

### DIFF
--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -314,11 +314,6 @@ func (vd *volAPI) volumeSet(w http.ResponseWriter, r *http.Request) {
 		updateReq.Labels = req.Locator.VolumeLabels
 	}
 
-	if _, err := volumes.Update(ctx, updateReq); err != nil {
-		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
-		return
-	}
-
 	detachOptions := &api.SdkVolumeDetachOptions{}
 	attachOptions := &api.SdkVolumeAttachOptions{}
 
@@ -329,6 +324,13 @@ func (vd *volAPI) volumeSet(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
+
+		// Only set spec if spec and locator are not nil.
+		if _, err := volumes.Update(ctx, updateReq); err != nil {
+			vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
 	}
 
 	if req.Options["SECRET_NAME"] != "" {


### PR DESCRIPTION
Signed-off-by: Paul <paul@portworx.com>

**What this PR does / why we need it**:
Moved volume update code into spec and locator nil check.
We were updating the volume without actually having a spec or locator 
This was breaking attach/mount calls

**Special notes for your reviewer**:
```
{
 "cmd": "HostDetach",
 "status": "Ok",
 "desc": "Volume successfully detached",
 "uuid": [
  "test2"
 ]
}
```
