### PR TITLE
PWX-7822: Fix out-of-bounds write.  Snaps len is len(resp.GetVolumeSn…

### DIFF
--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -1005,7 +1005,7 @@ func (vd *volAPI) snapEnumerate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	snaps := make([]*api.Volume, len(ids))
+	snaps := make([]*api.Volume, len(resp.GetVolumeSnapshotIds()))
 	for i, s := range resp.GetVolumeSnapshotIds() {
 		vol, err := volumes.Inspect(ctx, &api.SdkVolumeInspectRequest{VolumeId: s})
 		if err != nil {

--- a/api/server/volume_test.go
+++ b/api/server/volume_test.go
@@ -11,9 +11,7 @@ import (
 	"github.com/libopenstorage/openstorage/pkg/auth/secrets"
 	"github.com/libopenstorage/openstorage/volume"
 	"github.com/libopenstorage/secrets/k8s"
-	"github.com/libopenstorage/secrets/mock"
-
-	//"github.com/golang/mock/gomock"
+	"github.com/libopenstorage/secrets/mock" //"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -560,6 +558,77 @@ func TestVolumeInspectFailed(t *testing.T) {
 	volumes := api.NewOpenStorageVolumeClient(testVolDriver.Conn())
 	ctx, err := contextWithToken(context.Background(), "test", "system.admin", testSharedSecret)
 	assert.NoError(t, err)
+
+	_, err = volumes.Delete(ctx, &api.SdkVolumeDeleteRequest{
+		VolumeId: id,
+	})
+	assert.NoError(t, err)
+
+}
+
+func TestVolumeSnapshotList(t *testing.T) {
+
+	var err error
+
+	snapname := "snapName"
+
+	// Setup volume rest functions server
+	ts, testVolDriver := testRestServerSdk(t)
+	defer ts.Close()
+	defer testVolDriver.Stop()
+
+	// get token
+	token, err := createToken("test", "system.admin", testSharedSecret)
+	assert.NoError(t, err)
+
+	cl, err := volumeclient.NewAuthDriverClient(ts.URL, mockDriverName, version, token, "", mockDriverName)
+	assert.NoError(t, err)
+
+	// Setup request
+	name := "myvol"
+	size := uint64(1234)
+	req := &api.VolumeCreateRequest{
+		Locator: &api.VolumeLocator{Name: name},
+		Source:  &api.Source{},
+		Spec: &api.VolumeSpec{
+			HaLevel: 3,
+			Size:    size,
+			Format:  api.FSType_FS_TYPE_EXT4,
+			Shared:  true,
+		},
+	}
+
+	// Create a volume client
+	driverclient := volumeclient.VolumeDriver(cl)
+	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	assert.Nil(t, err)
+	assert.NotEmpty(t, id)
+
+	// Assert volume information is correct
+	volumes := api.NewOpenStorageVolumeClient(testVolDriver.Conn())
+	ctx, err := contextWithToken(context.Background(), "test", "system.admin", testSharedSecret)
+	assert.NoError(t, err)
+
+	req2 := &api.SnapCreateRequest{Id: id,
+		Locator:  &api.VolumeLocator{Name: snapname},
+		Readonly: true,
+	}
+
+	_, err = driverclient.Snapshot(id, req2.GetReadonly(), req2.GetLocator(), req2.GetNoRetry())
+	assert.Nil(t, err)
+
+	res, err := driverclient.SnapEnumerate([]string{id}, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, res)
+	assert.Len(t, res, 1)
+
+	_, err = driverclient.Snapshot(id, req2.GetReadonly(), req2.GetLocator(), req2.GetNoRetry())
+	assert.Nil(t, err)
+
+	res, err = driverclient.SnapEnumerate([]string{id}, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, res)
+	assert.Len(t, res, 2)
 
 	_, err = volumes.Delete(ctx, &api.SdkVolumeDeleteRequest{
 		VolumeId: id,


### PR DESCRIPTION
…apshotIds())

Signed-off-by: Jose Rivera <jose@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Length of the return snaps list was not correct causing an out-bounds-error if the number of snaps on the volume was more than 1.   The return snaps list length should be equal to the number of snaps found for that volume.  
**Which issue(s) this PR fixes** (optional)
PWX-4411

**Special notes for your reviewer**:

