### PR TITLE
Fix cloud-backup APIs wrongly returning SDK format instead of opensto…

### DIFF
--- a/api/server/backup_test.go
+++ b/api/server/backup_test.go
@@ -579,7 +579,8 @@ func TestClientBackupSchedCreateSuccess(t *testing.T) {
 	goodRequest.SrcVolumeID = id
 	goodRequest.CredentialUUID = credId
 	goodRequest.Full = false
-	goodRequest.Schedule = "daily@10:00"
+	goodRequest.Schedule = "- freq: daily\n  minute: 30\n  retain: 2\n"
+	goodRequest.MaxBackups = 2
 
 	// Invoke Schedule Create
 	_, err = client.VolumeDriver(cl).CloudBackupSchedCreate(&goodRequest)

--- a/api/server/sdk/cloud_backup_test.go
+++ b/api/server/sdk/cloud_backup_test.go
@@ -754,7 +754,7 @@ func TestSdkCloudBackupSchedCreate(t *testing.T) {
 	s.MockDriver().
 		EXPECT().
 		CloudBackupSchedCreate(&mockReq).
-		Return(&api.CloudBackupSchedCreateResponse{}, nil).
+		Return(&api.CloudBackupSchedCreateResponse{UUID: "uuid"}, nil).
 		Times(1)
 
 	// Setup client


### PR DESCRIPTION
…rage format.

Server was encoding responses SDK format instead of openstorage format for
some of the cloud-backup APIS.

Signed-off-by: veda <veda@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

