### PR TITLE
pkg/auth noauth.GetToken should not return an error

### DIFF
--- a/pkg/auth/tokengenerator.go
+++ b/pkg/auth/tokengenerator.go
@@ -55,5 +55,5 @@ func (na *noauth) GetAuthenticator() (Authenticator, error) {
 }
 
 func (na *noauth) GetToken(opts *Options) (string, error) {
-	return "", errAuthDisabled
+	return "", nil
 }

--- a/pkg/auth/tokengenerator_test.go
+++ b/pkg/auth/tokengenerator_test.go
@@ -19,6 +19,6 @@ func TestNoAuth(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, authctr)
 	token, err := na.GetToken(&Options{})
-	assert.Error(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, token, "")
 }


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
* The original implementation for `noauth.GetToken()` used to be to `return "", nil`. I changed it to return `errAuthDisabled` to make it match `noauth.GetAuthenticator()`.
* The existing implementation depended on noauth.GetToken returning no error for when auth is not enabled.

**Which issue(s) this PR fixes** (optional)
Closes #904

**Special notes for your reviewer**:

