### PR TITLE
SDK to ignore the retain value for cloud-backup schedules.

### DIFF
--- a/api/server/sdk/cloud_backup_test.go
+++ b/api/server/sdk/cloud_backup_test.go
@@ -806,13 +806,13 @@ func TestSdkCloudBackupSchedEnumerate(t *testing.T) {
 			"test-uuid-1": api.CloudBackupScheduleInfo{
 				SrcVolumeID:    "myid",
 				CredentialUUID: "test-uuid-1",
-				Schedule:       "- freq: daily\n  minute: 30\n  retain: 1\n",
+				Schedule:       "- freq: daily\n  minute: 30\n",
 				MaxBackups:     4,
 			},
 			"test-uuid-2": api.CloudBackupScheduleInfo{
 				SrcVolumeID:    "myid2",
 				CredentialUUID: "test-uuid-1",
-				Schedule:       "- freq: daily\n  minute: 30\n  retain: 1\n",
+				Schedule:       "- freq: daily\n  minute: 30\n",
 				MaxBackups:     3,
 			},
 		},

--- a/api/server/sdk/schedule_policy.go
+++ b/api/server/sdk/schedule_policy.go
@@ -54,6 +54,11 @@ func (s *SchedulePolicyServer) Create(
 		return nil, status.Error(codes.InvalidArgument, "Must a supply Schedule")
 	}
 
+	for _, sdkSched := range req.GetSchedulePolicy().GetSchedules() {
+		if sdkSched.GetRetain() < 1 {
+			return nil, status.Error(codes.InvalidArgument, "Must retain more than 0")
+		}
+	}
 	out, err := sdkSchedToRetainInternalSpecYamlByte(req.GetSchedulePolicy().GetSchedules())
 	if err != nil {
 		return nil, err
@@ -88,6 +93,11 @@ func (s *SchedulePolicyServer) Update(
 		return nil, status.Error(codes.InvalidArgument, "Must supply Schedule")
 	}
 
+	for _, sdkSched := range req.GetSchedulePolicy().GetSchedules() {
+		if sdkSched.GetRetain() < 1 {
+			return nil, status.Error(codes.InvalidArgument, "Must retain more than 0")
+		}
+	}
 	out, err := sdkSchedToRetainInternalSpecYamlByte(req.GetSchedulePolicy().GetSchedules())
 	if err != nil {
 		return nil, err

--- a/api/server/sdk/utils.go
+++ b/api/server/sdk/utils.go
@@ -88,10 +88,6 @@ func sdkSchedToRetainInternalSpec(
 	req *api.SdkSchedulePolicyInterval,
 ) (*sched.RetainIntervalSpec, error) {
 
-	if req.GetRetain() < 1 {
-		return nil, status.Error(codes.InvalidArgument, "Must retain more than 0")
-	}
-
 	// Translate sdk schedule to yaml RetainIntervalSpec string.
 	var spec sched.IntervalSpec
 	if daily := req.GetDaily(); daily != nil {


### PR DESCRIPTION
Retain value for Cloud backup schedule is separate field out of schedule format.
Signed-off-by: veda <veda@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

