### PR TITLE
Add certs to mock-sdk-server

### DIFF
--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -1,6 +1,9 @@
 FROM alpine
 MAINTAINER luis@portworx.com
 
+RUN apk update && \
+  apk add --no-cache ca-certificates
+
 EXPOSE 9100 9110
 ADD ./etc/config/config-fake.yaml /config-fake.yaml
 ADD ./_tmp/osd /

--- a/cmd/osd/main.go
+++ b/cmd/osd/main.go
@@ -168,6 +168,7 @@ func main() {
 		cli.StringFlag{
 			Name:  "jwt-system-shared-secret",
 			Usage: "JSON Web Token system shared secret used by clusters to create tokens for internal cluster communication",
+			Value: "non-secure-secret",
 		},
 	}
 	app.Action = wrapAction(start)


### PR DESCRIPTION
**What this PR does / why we need it**:
This allows the mock-sdk-server to access cloud OIDCs

