### PR TITLE
SDK: Allow registering multiple VolumeDrivers with a single SDK server.

### DIFF
--- a/api/server/sdk/cloud_backup.go
+++ b/api/server/sdk/cloud_backup.go
@@ -30,8 +30,8 @@ type CloudBackupServer struct {
 	server serverAccessor
 }
 
-func (s *CloudBackupServer) driver() volume.VolumeDriver {
-	return s.server.driver()
+func (s *CloudBackupServer) driver(ctx context.Context) volume.VolumeDriver {
+	return s.server.driver(ctx)
 }
 
 // Create creates a backup for a volume
@@ -40,7 +40,7 @@ func (s *CloudBackupServer) Create(
 	req *api.SdkCloudBackupCreateRequest,
 ) (*api.SdkCloudBackupCreateResponse, error) {
 
-	if s.driver() == nil {
+	if s.driver(ctx) == nil {
 		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
 	}
 
@@ -51,12 +51,12 @@ func (s *CloudBackupServer) Create(
 	}
 
 	// Check ownership
-	if err := checkAccessFromDriverForVolumeId(ctx, s.driver(), req.GetVolumeId(), api.Ownership_Read); err != nil {
+	if err := checkAccessFromDriverForVolumeId(ctx, s.driver(ctx), req.GetVolumeId(), api.Ownership_Read); err != nil {
 		return nil, err
 	}
 
 	// Create the backup
-	r, err := s.driver().CloudBackupCreate(&api.CloudBackupCreateRequest{
+	r, err := s.driver(ctx).CloudBackupCreate(&api.CloudBackupCreateRequest{
 		VolumeID:       req.GetVolumeId(),
 		CredentialUUID: req.GetCredentialId(),
 		Full:           req.GetFull(),
@@ -77,7 +77,7 @@ func (s *CloudBackupServer) Restore(
 	ctx context.Context,
 	req *api.SdkCloudBackupRestoreRequest,
 ) (*api.SdkCloudBackupRestoreResponse, error) {
-	if s.driver() == nil {
+	if s.driver(ctx) == nil {
 		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
 	}
 
@@ -87,7 +87,7 @@ func (s *CloudBackupServer) Restore(
 		return nil, status.Error(codes.InvalidArgument, "Must provide credential uuid")
 	}
 
-	r, err := s.driver().CloudBackupRestore(&api.CloudBackupRestoreRequest{
+	r, err := s.driver(ctx).CloudBackupRestore(&api.CloudBackupRestoreRequest{
 		ID:                req.GetBackupId(),
 		RestoreVolumeName: req.GetRestoreVolumeName(),
 		CredentialUUID:    req.GetCredentialId(),
@@ -110,7 +110,7 @@ func (s *CloudBackupServer) Delete(
 	ctx context.Context,
 	req *api.SdkCloudBackupDeleteRequest,
 ) (*api.SdkCloudBackupDeleteResponse, error) {
-	if s.driver() == nil {
+	if s.driver(ctx) == nil {
 		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
 	}
 
@@ -120,7 +120,7 @@ func (s *CloudBackupServer) Delete(
 		return nil, status.Error(codes.InvalidArgument, "Must provide credential uuid")
 	}
 
-	if err := s.driver().CloudBackupDelete(&api.CloudBackupDeleteRequest{
+	if err := s.driver(ctx).CloudBackupDelete(&api.CloudBackupDeleteRequest{
 		ID:             req.GetBackupId(),
 		CredentialUUID: req.GetCredentialId(),
 		Force:          req.GetForce(),
@@ -136,7 +136,7 @@ func (s *CloudBackupServer) DeleteAll(
 	ctx context.Context,
 	req *api.SdkCloudBackupDeleteAllRequest,
 ) (*api.SdkCloudBackupDeleteAllResponse, error) {
-	if s.driver() == nil {
+	if s.driver(ctx) == nil {
 		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
 	}
 
@@ -146,7 +146,7 @@ func (s *CloudBackupServer) DeleteAll(
 		return nil, status.Error(codes.InvalidArgument, "Must provide credential uuid")
 	}
 
-	if err := s.driver().CloudBackupDeleteAll(&api.CloudBackupDeleteAllRequest{
+	if err := s.driver(ctx).CloudBackupDeleteAll(&api.CloudBackupDeleteAllRequest{
 		CloudBackupGenericRequest: api.CloudBackupGenericRequest{
 			SrcVolumeID:    req.GetSrcVolumeId(),
 			CredentialUUID: req.GetCredentialId(),
@@ -163,7 +163,7 @@ func (s *CloudBackupServer) EnumerateWithFilters(
 	ctx context.Context,
 	req *api.SdkCloudBackupEnumerateWithFiltersRequest,
 ) (*api.SdkCloudBackupEnumerateWithFiltersResponse, error) {
-	if s.driver() == nil {
+	if s.driver(ctx) == nil {
 		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
 	}
 
@@ -171,7 +171,7 @@ func (s *CloudBackupServer) EnumerateWithFilters(
 		return nil, status.Error(codes.InvalidArgument, "Must provide credential uuid")
 	}
 
-	r, err := s.driver().CloudBackupEnumerate(&api.CloudBackupEnumerateRequest{
+	r, err := s.driver(ctx).CloudBackupEnumerate(&api.CloudBackupEnumerateRequest{
 		CloudBackupGenericRequest: api.CloudBackupGenericRequest{
 			SrcVolumeID:    req.GetSrcVolumeId(),
 			ClusterID:      req.GetClusterId(),
@@ -191,7 +191,7 @@ func (s *CloudBackupServer) Status(
 	ctx context.Context,
 	req *api.SdkCloudBackupStatusRequest,
 ) (*api.SdkCloudBackupStatusResponse, error) {
-	if s.driver() == nil {
+	if s.driver(ctx) == nil {
 		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
 	}
 
@@ -199,7 +199,7 @@ func (s *CloudBackupServer) Status(
 	// TODO !
 	// Get volume id from task id
 
-	r, err := s.driver().CloudBackupStatus(&api.CloudBackupStatusRequest{
+	r, err := s.driver(ctx).CloudBackupStatus(&api.CloudBackupStatusRequest{
 		SrcVolumeID: req.GetVolumeId(),
 		Local:       req.GetLocal(),
 		ID:          req.GetTaskId(),
@@ -216,7 +216,7 @@ func (s *CloudBackupServer) Catalog(
 	ctx context.Context,
 	req *api.SdkCloudBackupCatalogRequest,
 ) (*api.SdkCloudBackupCatalogResponse, error) {
-	if s.driver() == nil {
+	if s.driver(ctx) == nil {
 		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
 	}
 
@@ -226,7 +226,7 @@ func (s *CloudBackupServer) Catalog(
 		return nil, status.Error(codes.InvalidArgument, "Must provide credential uuid")
 	}
 
-	r, err := s.driver().CloudBackupCatalog(&api.CloudBackupCatalogRequest{
+	r, err := s.driver(ctx).CloudBackupCatalog(&api.CloudBackupCatalogRequest{
 		ID:             req.GetBackupId(),
 		CredentialUUID: req.GetCredentialId(),
 	})
@@ -244,7 +244,7 @@ func (s *CloudBackupServer) History(
 	ctx context.Context,
 	req *api.SdkCloudBackupHistoryRequest,
 ) (*api.SdkCloudBackupHistoryResponse, error) {
-	if s.driver() == nil {
+	if s.driver(ctx) == nil {
 		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
 	}
 
@@ -253,11 +253,11 @@ func (s *CloudBackupServer) History(
 	}
 
 	// Check ownership
-	if err := checkAccessFromDriverForVolumeId(ctx, s.driver(), req.GetSrcVolumeId(), api.Ownership_Read); err != nil {
+	if err := checkAccessFromDriverForVolumeId(ctx, s.driver(ctx), req.GetSrcVolumeId(), api.Ownership_Read); err != nil {
 		return nil, err
 	}
 
-	r, err := s.driver().CloudBackupHistory(&api.CloudBackupHistoryRequest{
+	r, err := s.driver(ctx).CloudBackupHistory(&api.CloudBackupHistoryRequest{
 		SrcVolumeID: req.GetSrcVolumeId(),
 	})
 	if err != nil {
@@ -272,7 +272,7 @@ func (s *CloudBackupServer) StateChange(
 	ctx context.Context,
 	req *api.SdkCloudBackupStateChangeRequest,
 ) (*api.SdkCloudBackupStateChangeResponse, error) {
-	if s.driver() == nil {
+	if s.driver(ctx) == nil {
 		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
 	}
 
@@ -297,7 +297,7 @@ func (s *CloudBackupServer) StateChange(
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid requested state: %v", req.GetRequestedState())
 	}
 
-	err := s.driver().CloudBackupStateChange(&api.CloudBackupStateChangeRequest{
+	err := s.driver(ctx).CloudBackupStateChange(&api.CloudBackupStateChangeRequest{
 		Name:           req.GetTaskId(),
 		RequestedState: rs,
 	})
@@ -313,7 +313,7 @@ func (s *CloudBackupServer) SchedCreate(
 	ctx context.Context,
 	req *api.SdkCloudBackupSchedCreateRequest,
 ) (*api.SdkCloudBackupSchedCreateResponse, error) {
-	if s.driver() == nil {
+	if s.driver(ctx) == nil {
 		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
 	}
 
@@ -329,7 +329,7 @@ func (s *CloudBackupServer) SchedCreate(
 	}
 
 	// Check ownership
-	if err := checkAccessFromDriverForVolumeId(ctx, s.driver(), req.GetCloudSchedInfo().GetSrcVolumeId(), api.Ownership_Read); err != nil {
+	if err := checkAccessFromDriverForVolumeId(ctx, s.driver(ctx), req.GetCloudSchedInfo().GetSrcVolumeId(), api.Ownership_Read); err != nil {
 		return nil, err
 	}
 
@@ -346,7 +346,7 @@ func (s *CloudBackupServer) SchedCreate(
 	bkpRequest.Full = req.GetCloudSchedInfo().GetFull()
 
 	// Create the backup
-	schedResp, err := s.driver().CloudBackupSchedCreate(&bkpRequest)
+	schedResp, err := s.driver(ctx).CloudBackupSchedCreate(&bkpRequest)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Failed to create backup: %v", err)
 	}
@@ -362,7 +362,7 @@ func (s *CloudBackupServer) SchedDelete(
 	ctx context.Context,
 	req *api.SdkCloudBackupSchedDeleteRequest,
 ) (*api.SdkCloudBackupSchedDeleteResponse, error) {
-	if s.driver() == nil {
+	if s.driver(ctx) == nil {
 		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
 	}
 
@@ -374,7 +374,7 @@ func (s *CloudBackupServer) SchedDelete(
 	}
 
 	// Call cloud backup driver function to delete cloud schedule
-	if err := s.driver().CloudBackupSchedDelete(&api.CloudBackupSchedDeleteRequest{
+	if err := s.driver(ctx).CloudBackupSchedDelete(&api.CloudBackupSchedDeleteRequest{
 		UUID: req.GetBackupScheduleId(),
 	}); err != nil {
 		return nil, status.Errorf(codes.Internal, "Failed to delete cloud backup schedule: %v", err)
@@ -388,12 +388,12 @@ func (s *CloudBackupServer) SchedEnumerate(
 	ctx context.Context,
 	req *api.SdkCloudBackupSchedEnumerateRequest,
 ) (*api.SdkCloudBackupSchedEnumerateResponse, error) {
-	if s.driver() == nil {
+	if s.driver(ctx) == nil {
 		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
 	}
 
 	// Pass in ownership and show only valid ones
-	r, err := s.driver().CloudBackupSchedEnumerate()
+	r, err := s.driver(ctx).CloudBackupSchedEnumerate()
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Failed to enumerate backups: %v", err)
 	}

--- a/api/server/sdk/identity.go
+++ b/api/server/sdk/identity.go
@@ -31,8 +31,8 @@ type IdentityServer struct {
 	server serverAccessor
 }
 
-func (s *IdentityServer) driver() volume.VolumeDriver {
-	return s.server.driver()
+func (s *IdentityServer) driver(ctx context.Context) volume.VolumeDriver {
+	return s.server.driver(ctx)
 }
 
 // Capabilities returns the capabilities of the SDK server
@@ -161,12 +161,12 @@ func (s *IdentityServer) Version(
 		version *api.StorageVersion
 		err     error
 	)
-	if s.driver() == nil {
+	if s.driver(ctx) == nil {
 		version = &api.StorageVersion{
 			Driver: "no driver running",
 		}
 	} else {
-		version, err = s.driver().Version()
+		version, err = s.driver(ctx).Version()
 		if err != nil {
 			return nil, status.Errorf(
 				codes.Internal,

--- a/api/server/sdk/sdk_test.go
+++ b/api/server/sdk/sdk_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-csi/csi-test/utils"
 	"github.com/libopenstorage/openstorage/alerts"
-	"github.com/libopenstorage/openstorage/alerts/mock"
+	mockalerts "github.com/libopenstorage/openstorage/alerts/mock"
 	"github.com/libopenstorage/openstorage/api"
 	clustermanager "github.com/libopenstorage/openstorage/cluster/manager"
 	mockcluster "github.com/libopenstorage/openstorage/cluster/mock"
@@ -331,7 +331,8 @@ func TestSdkWithNoVolumeDriverThenAddOne(t *testing.T) {
 	// Now add the volume driver
 	d, err := volumedrivers.Get("fake")
 	assert.NoError(t, err)
-	server.UseVolumeDriver(d)
+	driverMap := map[string]volume.VolumeDriver{"fake": d, DefaultDriverName: d}
+	server.UseVolumeDrivers(driverMap)
 
 	// Identify that the driver is now running
 	id, err = identities.Version(context.Background(), &api.SdkIdentityVersionRequest{})

--- a/api/server/sdk/volume.go
+++ b/api/server/sdk/volume.go
@@ -38,8 +38,8 @@ func (s *VolumeServer) cluster() cluster.Cluster {
 	return s.server.cluster()
 }
 
-func (s *VolumeServer) driver() volume.VolumeDriver {
-	return s.server.driver()
+func (s *VolumeServer) driver(ctx context.Context) volume.VolumeDriver {
+	return s.server.driver(ctx)
 }
 
 func (s *VolumeServer) checkAccessForVolumeId(

--- a/api/server/sdk/volume_migrate.go
+++ b/api/server/sdk/volume_migrate.go
@@ -32,7 +32,7 @@ func (s *VolumeServer) Start(
 
 	if volume := req.GetVolume(); volume != nil {
 		// Check ownership
-		if err := checkAccessFromDriverForVolumeId(ctx, s.driver(), volume.GetVolumeId(), api.Ownership_Read); err != nil {
+		if err := checkAccessFromDriverForVolumeId(ctx, s.driver(ctx), volume.GetVolumeId(), api.Ownership_Read); err != nil {
 			return nil, err
 		}
 
@@ -58,7 +58,7 @@ func (s *VolumeServer) Start(
 }
 
 func (s *VolumeServer) haveOwnership(ctx context.Context, labels map[string]string) bool {
-	vols, err := s.driver().Enumerate(nil, labels)
+	vols, err := s.driver(ctx).Enumerate(nil, labels)
 	if err != nil {
 		return false
 	}
@@ -84,7 +84,7 @@ func (s *VolumeServer) volumeGroupMigrate(
 		TargetId:  volumeGroup.GetGroupId(),
 		TaskId:    req.GetTaskId(), // optional will be "" if not passed
 	}
-	resp, err := s.driver().CloudMigrateStart(request)
+	resp, err := s.driver(ctx).CloudMigrateStart(request)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Cannot start migration for %s : %v", req.GetClusterId(), err)
 	}
@@ -104,7 +104,7 @@ func (s *VolumeServer) allVolumesMigrate(
 		ClusterId: req.GetClusterId(),
 		TaskId:    req.GetTaskId(),
 	}
-	resp, err := s.driver().CloudMigrateStart(request)
+	resp, err := s.driver(ctx).CloudMigrateStart(request)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Cannot start migration for %s : %v", req.GetClusterId(), err)
 	}
@@ -125,7 +125,7 @@ func (s *VolumeServer) volumeMigrate(
 		TargetId:  volume.GetVolumeId(),
 		TaskId:    req.GetTaskId(),
 	}
-	resp, err := s.driver().CloudMigrateStart(request)
+	resp, err := s.driver(ctx).CloudMigrateStart(request)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Cannot start migration for %s : %v", req.GetClusterId(), err)
 	}
@@ -145,7 +145,7 @@ func (s *VolumeServer) Cancel(
 	} else if len(req.GetRequest().GetTaskId()) == 0 {
 		return nil, status.Errorf(codes.InvalidArgument, "Must supply valid Task ID")
 	}
-	err := s.driver().CloudMigrateCancel(req.GetRequest())
+	err := s.driver(ctx).CloudMigrateCancel(req.GetRequest())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Cannot stop migration for %s : %v",
 			req.GetRequest().GetTaskId(), err)
@@ -159,7 +159,7 @@ func (s *VolumeServer) Status(
 	req *api.SdkCloudMigrateStatusRequest,
 ) (*api.SdkCloudMigrateStatusResponse, error) {
 
-	resp, err := s.driver().CloudMigrateStatus(req.GetRequest())
+	resp, err := s.driver(ctx).CloudMigrateStatus(req.GetRequest())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Cannot get status of migration : %v", err)
 	}

--- a/api/server/sdk/volume_ops_test.go
+++ b/api/server/sdk/volume_ops_test.go
@@ -716,7 +716,10 @@ func TestSdkDeleteOnlyByOwner(t *testing.T) {
 	mcluster := mockcluster.NewMockCluster(mc)
 	s := VolumeServer{
 		server: &sdkGrpcServer{
-			driverHandler:  mv,
+			driverHandlers: map[string]volume.VolumeDriver{
+				"mock":            mv,
+				DefaultDriverName: mv,
+			},
 			clusterHandler: mcluster,
 		},
 	}
@@ -823,7 +826,10 @@ func TestSdkCloneOwnership(t *testing.T) {
 	mcluster := mockcluster.NewMockCluster(mc)
 	s := VolumeServer{
 		server: &sdkGrpcServer{
-			driverHandler:  mv,
+			driverHandlers: map[string]volume.VolumeDriver{
+				"mock":            mv,
+				DefaultDriverName: mv,
+			},
 			clusterHandler: mcluster,
 		},
 	}

--- a/api/server/sdk/volume_snapshot.go
+++ b/api/server/sdk/volume_snapshot.go
@@ -31,7 +31,7 @@ func (s *VolumeServer) SnapshotCreate(
 	ctx context.Context,
 	req *api.SdkVolumeSnapshotCreateRequest,
 ) (*api.SdkVolumeSnapshotCreateResponse, error) {
-	if s.cluster() == nil || s.driver() == nil {
+	if s.cluster() == nil || s.driver(ctx) == nil {
 		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
 	}
 
@@ -47,7 +47,7 @@ func (s *VolumeServer) SnapshotCreate(
 	}
 
 	readonly := true
-	snapshotID, err := s.driver().Snapshot(req.GetVolumeId(), readonly, &api.VolumeLocator{
+	snapshotID, err := s.driver(ctx).Snapshot(req.GetVolumeId(), readonly, &api.VolumeLocator{
 		Name:         req.GetName(),
 		VolumeLabels: req.GetLabels(),
 	}, false)
@@ -71,7 +71,7 @@ func (s *VolumeServer) SnapshotRestore(
 	ctx context.Context,
 	req *api.SdkVolumeSnapshotRestoreRequest,
 ) (*api.SdkVolumeSnapshotRestoreResponse, error) {
-	if s.cluster() == nil || s.driver() == nil {
+	if s.cluster() == nil || s.driver(ctx) == nil {
 		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
 	}
 
@@ -86,7 +86,7 @@ func (s *VolumeServer) SnapshotRestore(
 		return nil, err
 	}
 
-	err := s.driver().Restore(req.GetVolumeId(), req.GetSnapshotId())
+	err := s.driver(ctx).Restore(req.GetVolumeId(), req.GetSnapshotId())
 	if err != nil {
 		if err == kvdb.ErrNotFound {
 			return nil, status.Errorf(
@@ -110,7 +110,7 @@ func (s *VolumeServer) SnapshotEnumerate(
 	ctx context.Context,
 	req *api.SdkVolumeSnapshotEnumerateRequest,
 ) (*api.SdkVolumeSnapshotEnumerateResponse, error) {
-	if s.cluster() == nil || s.driver() == nil {
+	if s.cluster() == nil || s.driver(ctx) == nil {
 		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
 	}
 
@@ -136,7 +136,7 @@ func (s *VolumeServer) SnapshotEnumerateWithFilters(
 	ctx context.Context,
 	req *api.SdkVolumeSnapshotEnumerateWithFiltersRequest,
 ) (*api.SdkVolumeSnapshotEnumerateWithFiltersResponse, error) {
-	if s.cluster() == nil || s.driver() == nil {
+	if s.cluster() == nil || s.driver(ctx) == nil {
 		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
 	}
 
@@ -151,7 +151,7 @@ func (s *VolumeServer) SnapshotEnumerateWithFilters(
 		volReq = nil
 	}
 
-	snapshots, err := s.driver().SnapEnumerate(volReq, req.GetLabels())
+	snapshots, err := s.driver(ctx).SnapEnumerate(volReq, req.GetLabels())
 	if err != nil {
 		return nil, status.Errorf(
 			codes.Internal,
@@ -179,7 +179,7 @@ func (s *VolumeServer) SnapshotScheduleUpdate(
 	ctx context.Context,
 	req *api.SdkVolumeSnapshotScheduleUpdateRequest,
 ) (*api.SdkVolumeSnapshotScheduleUpdateResponse, error) {
-	if s.cluster() == nil || s.driver() == nil {
+	if s.cluster() == nil || s.driver(ctx) == nil {
 		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
 	}
 

--- a/api/server/testutils_test.go
+++ b/api/server/testutils_test.go
@@ -156,6 +156,19 @@ func newTestServerSdkNoAuth(t *testing.T) *testServer {
 	err = tester.sdk.Start()
 	assert.Nil(t, err)
 
+	// Register the drivers with SDK
+	// The tests use "fake" and "mock" both interchangeably
+	// Some of the test set the UserAgent in the REST client to mock
+	fakeDriver, err := volumedrivers.Get(fake.Name)
+	assert.NoError(t, err)
+
+	driverMap := map[string]volume.VolumeDriver{
+		fake.Name:             fakeDriver,
+		sdk.DefaultDriverName: fakeDriver,
+		mockDriverName:        fakeDriver,
+	}
+	tester.sdk.UseVolumeDrivers(driverMap)
+
 	// Setup a connection to the driver
 	tester.conn, err = grpcserver.Connect("localhost:8123", []grpc.DialOption{grpc.WithInsecure()})
 	assert.Nil(t, err)
@@ -242,6 +255,18 @@ func newTestServerSdk(t *testing.T) *testServer {
 		},
 	)
 	volumedrivers.Register(fakeWithSched, nil)
+
+	// Register the drivers with SDK
+	// The tests use "fake" and "mock" both interchangeably
+	// Some of the test set the UserAgent in the REST client to mock
+
+	driverMap := map[string]volume.VolumeDriver{
+		fake.Name:             fakeDriver,
+		fakeWithSched:         fakeDriver,
+		sdk.DefaultDriverName: fakeDriver,
+		mockDriverName:        fakeDriver,
+	}
+	tester.sdk.UseVolumeDrivers(driverMap)
 
 	return tester
 }

--- a/pkg/grpcserver/grpcutil.go
+++ b/pkg/grpcserver/grpcutil.go
@@ -16,14 +16,17 @@ limitations under the License.
 package grpcserver
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/url"
 	"time"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/libopenstorage/openstorage/pkg/util"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/metadata"
 )
 
 // Connect address by grpc
@@ -55,4 +58,16 @@ func Connect(address string, dialOptions []grpc.DialOption) (*grpc.ClientConn, e
 	}
 
 	return conn, nil
+}
+
+func AddMetadataToContext(ctx context.Context, k, v string) context.Context {
+	md, _ := metadata.FromOutgoingContext(ctx)
+	md = metadata.Join(md, metadata.New(map[string]string{
+		k: v,
+	}))
+	return metadata.NewOutgoingContext(ctx, md)
+}
+
+func GetMetadataValueFromKey(ctx context.Context, k string) string {
+	return metautils.ExtractIncoming(ctx).Get(k)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- Changed the UseVolumeDrivers API to take in a map of name to VolumeDrivers mapping
- Modified the SDK server, to inspect the context's metadata and select the correct
  VolumeDriver to use for the API.
- Modified the REST server, to parse the UserAgent in the incoming request and
  set it as a metadata key-value pair in the SDK grpc call's context.



