### PR TITLE
Sending different errors when "cluster max capacity" (closes #918)

### DIFF
--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -77,6 +77,7 @@ type ClusterManager struct {
 }
 
 // ErrNewNodeOverMaxCapacity used when a new node (not yet part of the cluster) triggers max #nodes capacity.
+// NOTE: For validations, please use err.(type) rather than the value.
 type ErrNewNodeOverMaxCapacity int
 
 // Error returns a string descriptor for ErrNewNodeOverMaxCapacity
@@ -87,6 +88,7 @@ func (e ErrNewNodeOverMaxCapacity) Error() string {
 }
 
 // ErrOldNodeOverMaxCapacity used when a OLD node (already part of the cluster) triggers max #nodes capacity.
+// NOTE: For validations, please use err.(type) rather than the value.
 type ErrOldNodeOverMaxCapacity int
 
 // Error returns a string descriptor for ErrOldNodeOverMaxCapacity

--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -76,6 +76,26 @@ type ClusterManager struct {
 	snapshotPrefixes   []string
 }
 
+// ErrNewNodeOverMaxCapacity used when a new node (not yet part of the cluster) triggers max #nodes capacity.
+type ErrNewNodeOverMaxCapacity int
+
+// Error returns a string descriptor for ErrNewNodeOverMaxCapacity
+func (e ErrNewNodeOverMaxCapacity) Error() string {
+	return fmt.Sprintf("Unable to add a NEW node as cluster is operating at maximum capacity "+
+		"(%d nodes). Please remove a node before attempting to "+
+		"add a new node.", e)
+}
+
+// ErrOldNodeOverMaxCapacity used when a OLD node (already part of the cluster) triggers max #nodes capacity.
+type ErrOldNodeOverMaxCapacity int
+
+// Error returns a string descriptor for ErrOldNodeOverMaxCapacity
+func (e ErrOldNodeOverMaxCapacity) Error() string {
+	return fmt.Sprintf("Unable to add an preexisting node as cluster is operating at maximum capacity "+
+		"(%d nodes). Please remove a node before attempting to "+
+		"add a new node.", e)
+}
+
 // Init instantiates a new cluster manager.
 func Init(cfg config.ClusterConfig) error {
 	if inst != nil {
@@ -1100,9 +1120,12 @@ func (c *ClusterManager) initListeners(
 			}
 		}
 		if clusterMaxSize > 0 && numNodes > clusterMaxSize {
-			return fmt.Errorf("Cluster is operating at maximum capacity "+
-				"(%v nodes). Please remove a node before attempting to "+
-				"add a new node.", clusterMaxSize)
+			// throw a slightly different error depending if node was already
+			// in the cluster.
+			if exist {
+				return ErrOldNodeOverMaxCapacity(clusterMaxSize)
+			}
+			return ErrNewNodeOverMaxCapacity(clusterMaxSize)
 		}
 
 		// Finalize inits from subsystems under cluster db lock.


### PR DESCRIPTION
Modifying the "cluster at maximum capacity" error messages:
* sending ErrNewNodeOverMaxCapacity when NEW node is over cluster capacity
* sending ErrOldNodeOverMaxCapacity when old/pre-existing node is now over cluster capacity

Signed-off-by: Zoran Rajic <zox@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #918

**Special notes for your reviewer**:
Re-fixing the solution for https://portworx.atlassian.net/browse/PWX-7989 / https://github.com/libopenstorage/openstorage/pull/916  (e.g. the "proper fix")