### PR TITLE
PWX-7978: Set the node status after the listeners have started.

### DIFF
--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -970,8 +970,6 @@ func (c *ClusterManager) waitForQuorum(exist bool) error {
 				}
 				return err
 			}
-			c.status = api.Status_STATUS_OK
-			c.selfNode.Status = api.Status_STATUS_OK
 			break
 		} else {
 			c.status = api.Status_STATUS_NOT_IN_QUORUM
@@ -999,6 +997,10 @@ func (c *ClusterManager) waitForQuorum(exist bool) error {
 			logrus.Warnln("Failed to notify ", e.Value.(cluster.ClusterListener).String())
 		}
 	}
+
+	// Update the status after the listeners are started to ensure all REST points are available.
+	c.status = api.Status_STATUS_OK
+	c.selfNode.Status = api.Status_STATUS_OK
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Jose Rivera <jose@portworx.com>

What this PR does / why we need it:
The Node status was being set to OK ("operational") before the REST services were started via the listeners. This can cause an issue with automation because automation would immediately issue requests to the node as soon as it becomes OK ("operational") and would receive errors cause the REST services were not avail yet. So don't set the node status to OK until the listeners have started.

Which issue(s) this PR fixes (optional)
Closes #
PWX-7978
