### PR TITLE
Add authentication to REST Calls for Migration.

### DIFF
--- a/api/server/migrate.go
+++ b/api/server/migrate.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/libopenstorage/openstorage/api"
-	ost_errors "github.com/libopenstorage/openstorage/api/errors"
 )
 
 func (vd *volAPI) cloudMigrateStart(w http.ResponseWriter, r *http.Request) {
@@ -17,20 +16,51 @@ func (vd *volAPI) cloudMigrateStart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	d, err := vd.getVolDriver(r)
+	// Get context with auth token
+	ctx, err := vd.annotateContext(r)
 	if err != nil {
-		notFound(w, r)
+		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	response, err := d.CloudMigrateStart(startReq)
+	// Get gRPC connection
+	conn, err := vd.getConn()
 	if err != nil {
-		if _, ok := err.(*ost_errors.ErrExists); ok {
-			w.WriteHeader(http.StatusConflict)
-			return
+		vd.sendError(vd.name, method, w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	migrations := api.NewOpenStorageMigrateClient(conn)
+	migrateRequest := &api.SdkCloudMigrateStartRequest{
+		ClusterId: startReq.ClusterId,
+	}
+
+	switch startReq.Operation {
+	case api.CloudMigrate_MigrateCluster:
+		migrateRequest.Opt = &api.SdkCloudMigrateStartRequest_AllVolumes{
+			AllVolumes: &api.SdkCloudMigrateStartRequest_MigrateAllVolumes{},
 		}
+	case api.CloudMigrate_MigrateVolume:
+		migrateRequest.Opt = &api.SdkCloudMigrateStartRequest_Volume{
+			Volume: &api.SdkCloudMigrateStartRequest_MigrateVolume{
+				VolumeId: startReq.TargetId,
+			},
+		}
+	case api.CloudMigrate_MigrateVolumeGroup:
+		migrateRequest.Opt = &api.SdkCloudMigrateStartRequest_VolumeGroup{
+			VolumeGroup: &api.SdkCloudMigrateStartRequest_MigrateVolumeGroup{
+				GroupId: startReq.TargetId,
+			},
+		}
+	}
+
+	resp, err := migrations.Start(ctx, migrateRequest)
+	if err != nil {
 		vd.sendError(method, startReq.TargetId, w, err.Error(), http.StatusInternalServerError)
 		return
+	}
+	response := &api.CloudMigrateStartResponse{
+		TaskId: resp.GetResult().GetTaskId(),
 	}
 	json.NewEncoder(w).Encode(response)
 }
@@ -44,13 +74,26 @@ func (vd *volAPI) cloudMigrateCancel(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	d, err := vd.getVolDriver(r)
+	// Get context with auth token
+	ctx, err := vd.annotateContext(r)
 	if err != nil {
-		notFound(w, r)
+		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	err = d.CloudMigrateCancel(cancelReq)
+	// Get gRPC connection
+	conn, err := vd.getConn()
+	if err != nil {
+		vd.sendError(vd.name, method, w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	migrations := api.NewOpenStorageMigrateClient(conn)
+	migrateRequest := &api.SdkCloudMigrateCancelRequest{
+		Request: cancelReq,
+	}
+
+	_, err = migrations.Cancel(ctx, migrateRequest)
 	if err != nil {
 		vd.sendError(method, cancelReq.TaskId, w, err.Error(), http.StatusInternalServerError)
 		return
@@ -62,12 +105,6 @@ func (vd *volAPI) cloudMigrateStatus(w http.ResponseWriter, r *http.Request) {
 	statusReq := &api.CloudMigrateStatusRequest{}
 	method := "cloudMigrateState"
 
-	d, err := vd.getVolDriver(r)
-	if err != nil {
-		notFound(w, r)
-		return
-	}
-
 	// Use empty request if nothing was sent
 	if r.ContentLength != 0 {
 		if err := json.NewDecoder(r.Body).Decode(statusReq); err != nil {
@@ -76,10 +113,33 @@ func (vd *volAPI) cloudMigrateStatus(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	statusResp, err := d.CloudMigrateStatus(statusReq)
+	// Get context with auth token
+	ctx, err := vd.annotateContext(r)
+	if err != nil {
+		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Get gRPC connection
+	conn, err := vd.getConn()
+	if err != nil {
+		vd.sendError(vd.name, method, w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	migrations := api.NewOpenStorageMigrateClient(conn)
+	migrateRequest := &api.SdkCloudMigrateStatusRequest{
+		Request: statusReq,
+	}
+
+	resp, err := migrations.Status(ctx, migrateRequest)
 	if err != nil {
 		vd.sendError(method, "", w, err.Error(), http.StatusInternalServerError)
 		return
+	}
+
+	statusResp := &api.CloudMigrateStatusResponse{
+		Info: resp.GetResult().GetInfo(),
 	}
 
 	json.NewEncoder(w).Encode(statusResp)

--- a/api/server/migrate_test.go
+++ b/api/server/migrate_test.go
@@ -49,8 +49,9 @@ func TestMigrateStart(t *testing.T) {
 	}
 
 	// Start Migrate
-	_, err = volumeclient.VolumeDriver(cl).CloudMigrateStart(goodRequest)
+	resp, err := volumeclient.VolumeDriver(cl).CloudMigrateStart(goodRequest)
 	assert.Nil(t, err)
+	assert.NotNil(t, resp.TaskId)
 
 	// Assert volume information is correct
 	volumes := api.NewOpenStorageVolumeClient(testVolDriver.Conn())
@@ -101,6 +102,7 @@ func TestMigrateStatus(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Get Migrate status
-	_, err = volumeclient.VolumeDriver(cl).CloudMigrateStatus(&api.CloudMigrateStatusRequest{})
+	resp, err := volumeclient.VolumeDriver(cl).CloudMigrateStatus(&api.CloudMigrateStatusRequest{})
 	assert.Nil(t, err)
+	assert.Equal(t, 1, len(resp.Info))
 }

--- a/volume/drivers/fake/fake.go
+++ b/volume/drivers/fake/fake.go
@@ -275,6 +275,18 @@ func (d *driver) Detach(volumeID string, options map[string]string) error {
 	return nil
 }
 
+func (d *driver) CloudMigrateStart(request *api.CloudMigrateStartRequest) (*api.CloudMigrateStartResponse, error) {
+	return &api.CloudMigrateStartResponse{}, nil
+}
+
+func (d *driver) CloudMigrateCancel(request *api.CloudMigrateCancelRequest) error {
+	return nil
+}
+
+func (d *driver) CloudMigrateStatus(request *api.CloudMigrateStatusRequest) (*api.CloudMigrateStatusResponse, error) {
+	return &api.CloudMigrateStatusResponse{}, nil
+}
+
 func (d *driver) Set(volumeID string, locator *api.VolumeLocator, spec *api.VolumeSpec) error {
 	v, err := d.GetVol(volumeID)
 	if err != nil {

--- a/volume/drivers/fake/fake.go
+++ b/volume/drivers/fake/fake.go
@@ -276,7 +276,7 @@ func (d *driver) Detach(volumeID string, options map[string]string) error {
 }
 
 func (d *driver) CloudMigrateStart(request *api.CloudMigrateStartRequest) (*api.CloudMigrateStartResponse, error) {
-	return &api.CloudMigrateStartResponse{}, nil
+	return &api.CloudMigrateStartResponse{TaskId: request.TaskId}, nil
 }
 
 func (d *driver) CloudMigrateCancel(request *api.CloudMigrateCancelRequest) error {
@@ -284,7 +284,11 @@ func (d *driver) CloudMigrateCancel(request *api.CloudMigrateCancelRequest) erro
 }
 
 func (d *driver) CloudMigrateStatus(request *api.CloudMigrateStatusRequest) (*api.CloudMigrateStatusResponse, error) {
-	return &api.CloudMigrateStatusResponse{}, nil
+	cml := make(map[string]*api.CloudMigrateInfoList, 0)
+	cml["result"] = &api.CloudMigrateInfoList{}
+	return &api.CloudMigrateStatusResponse{
+		Info: cml,
+	}, nil
 }
 
 func (d *driver) Set(volumeID string, locator *api.VolumeLocator, spec *api.VolumeSpec) error {


### PR DESCRIPTION
Closes #930

When I added ownership checks on the SDK for migration I forgot to add the passthrough on the REST side.

Signed-off-by: Paul <paul@portworx.com>