### PR TITLE
If the input driver name is not in the map use the default driver

### DIFF
--- a/api/server/sdk/server.go
+++ b/api/server/sdk/server.go
@@ -23,13 +23,8 @@ import (
 	"os"
 	"sync"
 
-	"github.com/sirupsen/logrus"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials"
-
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
 	grpc_auth "github.com/grpc-ecosystem/go-grpc-middleware/auth"
-
 	"github.com/libopenstorage/openstorage/alerts"
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/libopenstorage/openstorage/api/spec"
@@ -40,6 +35,9 @@ import (
 	policy "github.com/libopenstorage/openstorage/pkg/storagepolicy"
 	"github.com/libopenstorage/openstorage/volume"
 	volumedrivers "github.com/libopenstorage/openstorage/volume/drivers"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 const (
@@ -481,10 +479,11 @@ func (s *sdkGrpcServer) useAlert(a alerts.FilterDeleter) {
 // Accessors
 func (s *sdkGrpcServer) driver(ctx context.Context) volume.VolumeDriver {
 	driverName := grpcserver.GetMetadataValueFromKey(ctx, ContextDriverKey)
-	if driverName == "" {
-		driverName = DefaultDriverName
+	if handler, ok := s.driverHandlers[driverName]; ok {
+		return handler
+	} else {
+		return s.driverHandlers[DefaultDriverName]
 	}
-	return s.driverHandlers[driverName]
 }
 
 func (s *sdkGrpcServer) cluster() cluster.Cluster {


### PR DESCRIPTION
…driver.

Signed-off-by: Jose Rivera <jose@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Clients just using the API request do not specify which driver is to be used.   Need a default.   So if the driver name is not found in the map just use the default.  

**Which issue(s) this PR fixes** (optional)
Closes #
PWX-8054

**Special notes for your reviewer**:

