### PR TITLE
Fix getting ownership from cred params

### DIFF
--- a/api/server/sdk/credentials.go
+++ b/api/server/sdk/credentials.go
@@ -446,6 +446,9 @@ func (s *CredentialServer) getOwnershipFromCred(cred interface{}) (*api.Ownershi
 	var ownership *api.Ownership
 	ownershipString, ok := info[api.OptCredOwnership].(string)
 	if ok {
+		if len(ownershipString) == 0 {
+			return nil, nil
+		}
 		ownership = &api.Ownership{}
 		err := jsonpb.UnmarshalString(ownershipString, ownership)
 		if err != nil {

--- a/api/server/sdk/credentials_test.go
+++ b/api/server/sdk/credentials_test.go
@@ -996,3 +996,37 @@ func TestSdkCredentialOwnership(t *testing.T) {
 	})
 	assert.NoError(t, err)
 }
+
+func TestSdkCredentialGetOwnershipFromCred(t *testing.T) {
+	s := &CredentialServer{}
+
+	o, err := s.getOwnershipFromCred(map[string]interface{}{
+		api.OptCredOwnership: "",
+	})
+	assert.NoError(t, err)
+	assert.Nil(t, o)
+
+	o, err = s.getOwnershipFromCred(map[string]interface{}{
+		"hello": "world",
+	})
+	assert.NoError(t, err)
+	assert.Nil(t, o)
+
+	ownership := &api.Ownership{
+		Owner: "user1",
+		Acls: &api.Ownership_AccessControl{
+			Collaborators: map[string]api.Ownership_AccessType{
+				"collabread":  api.Ownership_Read,
+				"collabadmin": api.Ownership_Admin,
+			},
+		},
+	}
+	m := jsonpb.Marshaler{OrigName: true}
+	oStr, err := m.MarshalToString(ownership)
+	assert.NoError(t, err)
+	o, err = s.getOwnershipFromCred(map[string]interface{}{
+		api.OptCredOwnership: oStr,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, o)
+}


### PR DESCRIPTION

**What this PR does / why we need it**:
Fixes an issue in the SDK credentials where it incorrectly tries to get the ownership from an empty string

**Which issue(s) this PR fixes** (optional)
Closes #941

**Special notes for your reviewer**:

