### PR TITLE
Fix go 1.11 vet error

### DIFF
--- a/volume/drivers/aws/aws.go
+++ b/volume/drivers/aws/aws.go
@@ -462,7 +462,7 @@ func (d *Driver) Detach(volumeID string, options map[string]string) error {
 	} else {
 		volume.DevicePath = ""
 		if err := d.UpdateVol(volume); err != nil {
-			logrus.Warnf("Failed to update volume", volumeID)
+			logrus.Warnf("Failed to update volume: %s", volumeID)
 		}
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes this go 1.11 vet error:

volume/drivers/aws/aws.go:465:16: Warnf call has arguments but no formatting directives
