### PR TITLE
CloudBackup enumerate status conversion.

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -857,6 +857,29 @@ func CloudBackupStatusTypeToSdkCloudBackupStatusType(
 	}
 }
 
+func SdkCloudBackupStatusTypeToCloudBackupStatusString(
+	t SdkCloudBackupStatusType,
+) string {
+	switch t {
+	case SdkCloudBackupStatusType_SdkCloudBackupStatusTypeNotStarted:
+		return string(CloudBackupStatusNotStarted)
+	case SdkCloudBackupStatusType_SdkCloudBackupStatusTypeDone:
+		return string(CloudBackupStatusDone)
+	case SdkCloudBackupStatusType_SdkCloudBackupStatusTypeAborted:
+		return string(CloudBackupStatusAborted)
+	case SdkCloudBackupStatusType_SdkCloudBackupStatusTypePaused:
+		return string(CloudBackupStatusPaused)
+	case SdkCloudBackupStatusType_SdkCloudBackupStatusTypeStopped:
+		return string(CloudBackupStatusStopped)
+	case SdkCloudBackupStatusType_SdkCloudBackupStatusTypeActive:
+		return string(CloudBackupStatusActive)
+	case SdkCloudBackupStatusType_SdkCloudBackupStatusTypeFailed:
+		return string(CloudBackupStatusFailed)
+	default:
+		return string(CloudBackupStatusFailed)
+	}
+}
+
 func StringToSdkCloudBackupStatusType(s string) SdkCloudBackupStatusType {
 	return CloudBackupStatusTypeToSdkCloudBackupStatusType(CloudBackupStatusType(s))
 }

--- a/api/server/backup.go
+++ b/api/server/backup.go
@@ -203,7 +203,7 @@ func (vd *volAPI) cloudBackupEnumerate(w http.ResponseWriter, r *http.Request) {
 			SrcVolumeName: v.SrcVolumeName,
 			Timestamp:     prototime.TimestampToTime(v.Timestamp),
 			Metadata:      v.Metadata,
-			Status:        v.Status.String(),
+			Status:        api.SdkCloudBackupStatusTypeToCloudBackupStatusString(v.Status),
 		}
 		enumerateResp.Backups = append(enumerateResp.Backups, item)
 	}

--- a/api/server/sdk/cloud_backup.go
+++ b/api/server/sdk/cloud_backup.go
@@ -210,7 +210,6 @@ func (s *CloudBackupServer) EnumerateWithFilters(
 		if err != nil {
 			return nil, err
 		}
-		return nil, status.Error(codes.InvalidArgument, "Must provide credential uuid")
 	} else {
 		if err := s.checkAccessToCredential(ctx, req.GetCredentialId()); err != nil {
 			return nil, err


### PR DESCRIPTION
Also fix bug in the default creds path for enumerate.

Signed-off-by: veda <veda@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Status conversion to string while enumerating cloud backups.
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

