### PR TITLE
Add TaskId back to MigrationStart

### DIFF
--- a/api/server/migrate.go
+++ b/api/server/migrate.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/libopenstorage/openstorage/api"
+	ost_errors "github.com/libopenstorage/openstorage/api/errors"
 )
 
 func (vd *volAPI) cloudMigrateStart(w http.ResponseWriter, r *http.Request) {
@@ -32,6 +33,7 @@ func (vd *volAPI) cloudMigrateStart(w http.ResponseWriter, r *http.Request) {
 
 	migrations := api.NewOpenStorageMigrateClient(conn)
 	migrateRequest := &api.SdkCloudMigrateStartRequest{
+		TaskId:    startReq.TaskId,
 		ClusterId: startReq.ClusterId,
 	}
 
@@ -56,6 +58,10 @@ func (vd *volAPI) cloudMigrateStart(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := migrations.Start(ctx, migrateRequest)
 	if err != nil {
+		if _, ok := err.(*ost_errors.ErrExists); ok {
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
 		vd.sendError(method, startReq.TargetId, w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/api/server/migrate_test.go
+++ b/api/server/migrate_test.go
@@ -43,6 +43,7 @@ func TestMigrateStart(t *testing.T) {
 	assert.NotEmpty(t, id)
 
 	goodRequest := &api.CloudMigrateStartRequest{
+		TaskId:    "123456",
 		Operation: api.CloudMigrate_MigrateVolume,
 		ClusterId: "clusterID",
 		TargetId:  id,
@@ -52,6 +53,7 @@ func TestMigrateStart(t *testing.T) {
 	resp, err := volumeclient.VolumeDriver(cl).CloudMigrateStart(goodRequest)
 	assert.Nil(t, err)
 	assert.NotNil(t, resp.TaskId)
+	assert.Equal(t, goodRequest.TaskId, resp.TaskId)
 
 	// Assert volume information is correct
 	volumes := api.NewOpenStorageVolumeClient(testVolDriver.Conn())


### PR DESCRIPTION
Signed-off-by: Paul <paul@portworx.com>

**What this PR does / why we need it**:
I broke the tracking of migrations by removing it.
Also added back the osterrors check for idempotency.

**Which issue(s) this PR fixes** (optional)
Closes #930 

**Special notes for your reviewer**:

