### PR TITLE
Add driver check to Migration calls

### DIFF
--- a/api/server/sdk/volume_migrate.go
+++ b/api/server/sdk/volume_migrate.go
@@ -30,6 +30,9 @@ func (s *VolumeServer) Start(
 	ctx context.Context,
 	req *api.SdkCloudMigrateStartRequest,
 ) (*api.SdkCloudMigrateStartResponse, error) {
+	if s.cluster() == nil || s.driver(ctx) == nil {
+		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
+	}
 
 	if volume := req.GetVolume(); volume != nil {
 		// Check ownership
@@ -59,6 +62,7 @@ func (s *VolumeServer) Start(
 }
 
 func (s *VolumeServer) haveOwnership(ctx context.Context, labels map[string]string) bool {
+	// checking if driver is initialized happens in Start
 	vols, err := s.driver(ctx).Enumerate(nil, labels)
 	if err != nil {
 		return false
@@ -78,6 +82,10 @@ func (s *VolumeServer) volumeGroupMigrate(
 	req *api.SdkCloudMigrateStartRequest,
 	volumeGroup *api.SdkCloudMigrateStartRequest_MigrateVolumeGroup,
 ) (*api.SdkCloudMigrateStartResponse, error) {
+	if s.cluster() == nil || s.driver(ctx) == nil {
+		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
+	}
+
 	//Create a request object with operation as Migrate volume
 	request := &api.CloudMigrateStartRequest{
 		Operation: api.CloudMigrate_MigrateVolumeGroup,
@@ -103,6 +111,10 @@ func (s *VolumeServer) allVolumesMigrate(
 	req *api.SdkCloudMigrateStartRequest,
 	allVolume *api.SdkCloudMigrateStartRequest_MigrateAllVolumes,
 ) (*api.SdkCloudMigrateStartResponse, error) {
+	if s.cluster() == nil || s.driver(ctx) == nil {
+		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
+	}
+
 	//Create a request object with operation as Migrate volume
 	request := &api.CloudMigrateStartRequest{
 		Operation: api.CloudMigrate_MigrateCluster,
@@ -126,6 +138,10 @@ func (s *VolumeServer) volumeMigrate(
 	req *api.SdkCloudMigrateStartRequest,
 	volume *api.SdkCloudMigrateStartRequest_MigrateVolume,
 ) (*api.SdkCloudMigrateStartResponse, error) {
+	if s.cluster() == nil || s.driver(ctx) == nil {
+		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
+	}
+
 	//Create a request object with operation as Migrate volume
 	request := &api.CloudMigrateStartRequest{
 		Operation: api.CloudMigrate_MigrateVolume,
@@ -150,6 +166,9 @@ func (s *VolumeServer) Cancel(
 	ctx context.Context,
 	req *api.SdkCloudMigrateCancelRequest,
 ) (*api.SdkCloudMigrateCancelResponse, error) {
+	if s.cluster() == nil || s.driver(ctx) == nil {
+		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
+	}
 
 	if req.GetRequest() == nil {
 		return nil, status.Errorf(codes.InvalidArgument, "Must supply valid request")
@@ -169,6 +188,9 @@ func (s *VolumeServer) Status(
 	ctx context.Context,
 	req *api.SdkCloudMigrateStatusRequest,
 ) (*api.SdkCloudMigrateStatusResponse, error) {
+	if s.cluster() == nil || s.driver(ctx) == nil {
+		return nil, status.Error(codes.Unavailable, "Resource has not been initialized")
+	}
 
 	resp, err := s.driver(ctx).CloudMigrateStatus(req.GetRequest())
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: Paul <paul@portworx.com>

The migration calls were not checking if the cluster and driver were available before making the call.
This PR addresses that.

Need Cherry-pick in 6.0 aswell.