### PR TITLE
Add check for authProviderType before initializing secretsStore

### DIFF
--- a/api/server/server.go
+++ b/api/server/server.go
@@ -91,7 +91,9 @@ func StartVolumePluginAPI(
 ) error {
 	var secretsStore secrets.Auth
 	var err error
-	if authProvider != nil {
+
+	// Only initialize secrets store if we have a valid auth provider.
+	if authProvider != nil && authProviderType != secrets.TypeNone {
 		secretsStore, err = secrets.NewAuth(authProviderType, authProvider)
 		if err != nil {
 			return err


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
* If authProviderType is none, we should not attempt to initialize SecretsStore.

**Which issue(s) this PR fixes** (optional)
Closes #975

**Special notes for your reviewer**:

