### PR TITLE
Add API to determie if user is system admin

### DIFF
--- a/api/ownership.go
+++ b/api/ownership.go
@@ -193,14 +193,7 @@ func (o *Ownership) IsOwner(user *auth.UserInfo) bool {
 // IsAdminByUser returns true if the user is an ownership admin, meaning,
 // that they belong to any group
 func (o *Ownership) IsAdminByUser(user *auth.UserInfo) bool {
-
-	// If there is a user, then auth is enabled
-	if user != nil {
-		return listContains(user.Claims.Groups, AdminGroup)
-	}
-
-	// No auth enabled, so everyone is an admin
-	return true
+	return IsAdminByUser(user)
 }
 
 // Update can be used to update an ownership with new ownership information. It
@@ -278,4 +271,26 @@ func listContains(list []string, s string) bool {
 		}
 	}
 	return false
+}
+
+// IsAdminByUser returns true if the user is an ownership admin, meaning,
+// that they belong to any group
+func IsAdminByUser(user *auth.UserInfo) bool {
+	// If there is a user, then auth is enabled
+	if user != nil {
+		return listContains(user.Claims.Groups, AdminGroup)
+	}
+
+	// No auth enabled, so everyone is an admin
+	return true
+}
+
+// Functions
+func IsAdminByContext(ctx context.Context) bool {
+	// Check if the context has information about the user. If not,
+	// then security is not enabled.
+	if userinfo, ok := auth.NewUserInfoFromContext(ctx); ok {
+		return IsAdminByUser(userinfo)
+	}
+	return true
 }

--- a/api/ownership_test.go
+++ b/api/ownership_test.go
@@ -954,3 +954,18 @@ func TestOwnershipIsPermittedByContext(t *testing.T) {
 	assert.True(t, oNil.IsPermittedByContext(ctxUser1, Ownership_Read))
 	assert.True(t, oNil.IsPermittedByContext(ctxUser2, Ownership_Read))
 }
+
+func TestOwnershipIsAdminByContext(t *testing.T) {
+	adminctx := auth.ContextSaveUserInfo(context.Background(), &auth.UserInfo{
+		Username: "admin",
+		Claims: auth.Claims{
+			Groups: []string{AdminGroup, "another group"},
+		},
+	})
+	userctx := auth.ContextSaveUserInfo(context.Background(), &auth.UserInfo{
+		Username: "user",
+	})
+	assert.True(t, IsAdminByContext(context.Background()))
+	assert.True(t, IsAdminByContext(adminctx))
+	assert.False(t, IsAdminByContext(userctx))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Other services need to determine if the user context is from a storage admin, meaning, one that can access any resource.


