### PR TITLE
Add csiRequestsSharedVolume back into CreateVolume

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -290,6 +290,9 @@ func (s *OsdCsiServer) CreateVolume(
 	// Create volume
 	var newVolumeId string
 	if source.Parent == "" {
+		// Get Capabilities and Size
+		spec.Shared = csiRequestsSharedVolume(req)
+
 		createResp, err := volumes.Create(ctx, &api.SdkVolumeCreateRequest{
 			Name:   req.GetName(),
 			Spec:   spec,


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
* Adds csiRequestsSharedVolume back into CreateVolume, which correctly sets whether a volume is shared or not.

