### PR TITLE
Set SystemTokenManager have internal issuer - system_token_issuer

### DIFF
--- a/pkg/auth/systemtoken/systemtoken_test.go
+++ b/pkg/auth/systemtoken/systemtoken_test.go
@@ -18,7 +18,7 @@ func TestSystemTokenGenerator(t *testing.T) {
 	}
 	stm, err := NewManager(config)
 	assert.NoError(t, err)
-	assert.Equal(t, stm.Issuer(), config.ClusterId)
+	assert.Equal(t, stm.Issuer(), systemIssuer)
 
 	token, err := stm.GetToken(&auth.Options{
 		Expiration: time.Now().Add(5 * auth.Year).Unix(),


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
* Sets the system token issuer to be a set issuer, allowing clusters system managers to communicate with each other.

**Which issue(s) this PR fixes** (optional)
Closes #985

**Special notes for your reviewer**:

