### PR TITLE
Add storage policy inspect/enumerate role to system.user (release-6.0)

### DIFF
--- a/pkg/role/sdkserviceapi.go
+++ b/pkg/role/sdkserviceapi.go
@@ -83,6 +83,14 @@ var (
 				Services: []string{"identity"},
 				Apis:     []string{"*"},
 			},
+			&api.SdkRule{
+				Services: []string{"policy"},
+				Apis: []string{
+					"*enumerate*",
+					// This will allow system.user to view default policy also
+					"*inspect*",
+				},
+			},
 		},
 	}
 )

--- a/pkg/storagepolicy/sdkstoragepolicy_test.go
+++ b/pkg/storagepolicy/sdkstoragepolicy_test.go
@@ -237,7 +237,7 @@ func TestSdkStoragePolicyUpdate(t *testing.T) {
 	assert.Equal(t, updatedResp.StoragePolicy.GetName(), inspReq.GetName())
 
 	// check indivisual params
-	//assert.Equal(t, updatedResp.StoragePolicy.GetPolicy().GetSize(), oldResp.StoragePolicy.GetPolicy().GetSize())
+	assert.Equal(t, updatedResp.StoragePolicy.GetPolicy().GetSize(), oldResp.StoragePolicy.GetPolicy().GetSize())
 	// check old param updated to new params
 	assert.Equal(t, updatedResp.StoragePolicy.GetPolicy().GetShared(), false)
 	// check new params


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds Inspect/Enumerate role to system.user for storage policies, also fix update storage policy issue 

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

