### PR TITLE
Fix 'go vet' on go 1.11 in api/server/sdk/volume_ops.go

### DIFF
--- a/api/server/sdk/volume_ops.go
+++ b/api/server/sdk/volume_ops.go
@@ -878,7 +878,7 @@ func mergeVolumeSpecsPolicy(vol *api.VolumeSpec, req *api.VolumeSpecPolicy, isVa
 		}
 		spec.IoStrategy = req.GetIoStrategy()
 	}
-	logrus.Debug("Updated VolumeSpecs %v", spec)
+	logrus.Debugf("Updated VolumeSpecs %v", spec)
 	return spec, nil
 }
 


### PR DESCRIPTION
Fixes: Debug call has possible formatting directive %v

Signed-off-by: Craig Rodrigues <craig@portworx.com>
