### PR TITLE
Remove unused variables to fix go 1.11 vet errors in unit tests

### DIFF
--- a/pkg/sanity/backup_restore.go
+++ b/pkg/sanity/backup_restore.go
@@ -85,7 +85,6 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 
 		var (
 			numVolumesBefore int
-			numVolumesAfter  int
 			volumeID         string
 			bkpStatusReq     *api.CloudBackupStatusRequest
 			bkpStatus        api.CloudBackupStatus
@@ -107,9 +106,8 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			err = volumedriver.Delete(volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
-			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
+			_, err = volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
-			numVolumesAfter = len(volumes)
 		})
 
 		It("Should create Volume successfully for backup", func() {
@@ -192,7 +190,6 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 
 		var (
 			numVolumesBefore int
-			numVolumesAfter  int
 			volumeID         string
 			bkpStatusReq     *api.CloudBackupStatusRequest
 			bkpStatus        api.CloudBackupStatus
@@ -214,9 +211,8 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			err = volumedriver.Delete(volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
-			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
+			_, err = volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
-			numVolumesAfter = len(volumes)
 		})
 
 		It("Should create enumerate backup volumes", func() {
@@ -312,7 +308,6 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 
 		var (
 			numVolumesBefore int
-			numVolumesAfter  int
 			volumeID         string
 			bkpStatusReq     *api.CloudBackupStatusRequest
 			bkpStatus        api.CloudBackupStatus
@@ -339,9 +334,8 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			err = volumedriver.Delete(restoredVolume)
 			Expect(err).ToNot(HaveOccurred())
 
-			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
+			_, err = volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
-			numVolumesAfter = len(volumes)
 		})
 
 		It("Should restore backup", func() {
@@ -457,7 +451,6 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 
 		var (
 			numVolumesBefore int
-			numVolumesAfter  int
 			volumeID         string
 		)
 
@@ -477,9 +470,8 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			err = volumedriver.Delete(volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
-			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
+			_, err = volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
-			numVolumesAfter = len(volumes)
 		})
 
 		It("Should create a backup schedule ", func() {
@@ -533,7 +525,6 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 
 		var (
 			numVolumesBefore int
-			numVolumesAfter  int
 			volumeID         string
 			schedules        []string
 		)
@@ -554,9 +545,8 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			err = volumedriver.Delete(volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
-			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
+			_, err = volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
-			numVolumesAfter = len(volumes)
 		})
 
 		It("Should delete a backup schedule ", func() {
@@ -624,7 +614,6 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 
 		var (
 			numVolumesBefore int
-			numVolumesAfter  int
 			volumeID         string
 			schedules        []string
 		)
@@ -645,9 +634,8 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			err = volumedriver.Delete(volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
-			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
+			_, err = volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
-			numVolumesAfter = len(volumes)
 		})
 
 		It("Should enumerate a backup schedule ", func() {
@@ -710,7 +698,6 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 
 		var (
 			numVolumesBefore int
-			numVolumesAfter  int
 			volumeID         string
 			bkpStatusReq     *api.CloudBackupStatusRequest
 			bkpStatusResp    *api.CloudBackupStatusResponse
@@ -733,9 +720,8 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			err = volumedriver.Delete(volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
-			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
+			_, err = volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
-			numVolumesAfter = len(volumes)
 		})
 
 		It("Should create Volume successfully for backup", func() {

--- a/pkg/sanity/snapshot.go
+++ b/pkg/sanity/snapshot.go
@@ -51,7 +51,6 @@ var _ = Describe("Volume [Snapshot Tests]", func() {
 
 		var (
 			numVolumesBefore int
-			numVolumesAfter  int
 			volumeID         string
 			snapID           string
 		)
@@ -72,9 +71,8 @@ var _ = Describe("Volume [Snapshot Tests]", func() {
 			err = volumedriver.Delete(snapID)
 			Expect(err).ToNot(HaveOccurred())
 
-			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
+			_, err = volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
-			numVolumesAfter = len(volumes)
 		})
 
 		It("Should create Volume successfully for snapshot", func() {
@@ -132,7 +130,6 @@ var _ = Describe("Volume [Snapshot Tests]", func() {
 
 		var (
 			numVolumesBefore int
-			numVolumesAfter  int
 			volumeID         string
 			snapID           string
 			snapIDs          []string
@@ -156,9 +153,8 @@ var _ = Describe("Volume [Snapshot Tests]", func() {
 				Expect(err).ToNot(HaveOccurred())
 			}
 
-			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
+			_, err = volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
-			numVolumesAfter = len(volumes)
 		})
 
 		It("Should enumerate Volume snapshots", func() {
@@ -232,7 +228,6 @@ var _ = Describe("Volume [Snapshot Tests]", func() {
 
 		var (
 			numVolumesBefore int
-			numVolumesAfter  int
 			volumeID         string
 			snapID           string
 		)
@@ -253,9 +248,8 @@ var _ = Describe("Volume [Snapshot Tests]", func() {
 			err = volumedriver.Delete(snapID)
 			Expect(err).ToNot(HaveOccurred())
 
-			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
+			_, err = volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
-			numVolumesAfter = len(volumes)
 		})
 
 		It("Should restore Volume successfully for snapshot", func() {

--- a/pkg/sanity/volume.go
+++ b/pkg/sanity/volume.go
@@ -54,7 +54,6 @@ var _ = Describe("Volume [Volume Tests]", func() {
 		var (
 			volumeID         string
 			numVolumesBefore int
-			numVolumesAfter  int
 		)
 
 		BeforeEach(func() {
@@ -70,9 +69,8 @@ var _ = Describe("Volume [Volume Tests]", func() {
 				err = volumedriver.Delete(volumeID)
 				Expect(err).ToNot(HaveOccurred())
 
-				volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
+				_, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 				Expect(err).ToNot(HaveOccurred())
-				numVolumesAfter = len(volumes)
 			}
 		})
 
@@ -178,7 +176,6 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			volumeID         string
 			volumeIDs        []string
 			numVolumesBefore int
-			numVolumesAfter  int
 			volumesToCreate  int
 		)
 		AfterEach(func() {
@@ -190,9 +187,8 @@ var _ = Describe("Volume [Volume Tests]", func() {
 					Expect(err).ToNot(HaveOccurred())
 				}
 
-				volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
+				_, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 				Expect(err).ToNot(HaveOccurred())
-				numVolumesAfter = len(volumes)
 			}
 		})
 
@@ -254,15 +250,13 @@ var _ = Describe("Volume [Volume Tests]", func() {
 	Describe("Volume Delete ", func() {
 
 		var (
-			volumeID         string
-			numVolumesBefore int
+			volumeID string
 		)
 
 		BeforeEach(func() {
 
 			var err error
-			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, make(map[string]string))
-			numVolumesBefore = len(volumes)
+			_, err = volumedriver.Enumerate(&api.VolumeLocator{}, make(map[string]string))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -381,7 +375,6 @@ var _ = Describe("Volume [Volume Tests]", func() {
 	Describe("Volume Attach Detach", func() {
 		var (
 			numVolumesBefore int
-			numVolumesAfter  int
 			volumeID         string
 		)
 
@@ -398,9 +391,8 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			err = volumedriver.Delete(volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
-			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
+			_, err = volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
-			numVolumesAfter = len(volumes)
 		})
 
 		It("Should attach and detach successfully", func() {
@@ -458,10 +450,8 @@ var _ = Describe("Volume [Volume Tests]", func() {
 
 		var (
 			numVolumesBefore int
-			numVolumesAfter  int
 			volumeID         string
 			mountPath        string
-			volumesToCreate  int
 		)
 
 		BeforeEach(func() {
@@ -481,9 +471,8 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			err = volumedriver.Delete(volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
-			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
+			_, err = volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
-			numVolumesAfter = len(volumes)
 		})
 
 		It("Should mount and unmount successfully", func() {
@@ -492,7 +481,6 @@ var _ = Describe("Volume [Volume Tests]", func() {
 
 			var err error
 
-			volumesToCreate = 1
 			var size = 5
 			vr := &api.VolumeCreateRequest{
 				Locator: &api.VolumeLocator{
@@ -538,7 +526,6 @@ var _ = Describe("Volume [Volume Tests]", func() {
 
 		var (
 			numVolumesBefore int
-			numVolumesAfter  int
 			volumeID         string
 		)
 
@@ -557,9 +544,8 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			err = volumedriver.Delete(volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
-			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
+			_, err = volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
-			numVolumesAfter = len(volumes)
 		})
 
 		It("Should update successfully with the new volume size.", func() {
@@ -691,7 +677,6 @@ var _ = Describe("Volume [Volume Tests]", func() {
 
 		var (
 			numVolumesBefore int
-			numVolumesAfter  int
 			volumeID         string
 		)
 
@@ -708,9 +693,8 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			err = volumedriver.Delete(volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
-			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
+			_, err = volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
-			numVolumesAfter = len(volumes)
 		})
 
 		It("Should retrieve volume stats successfully", func() {
@@ -758,7 +742,6 @@ var _ = Describe("Volume [Volume Tests]", func() {
 
 		var (
 			numVolumesBefore int
-			numVolumesAfter  int
 			volumeID         string
 		)
 
@@ -775,9 +758,8 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			err = volumedriver.Delete(volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
-			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
+			_, err = volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
-			numVolumesAfter = len(volumes)
 		})
 
 		It("Should get ActiveRequests successfully", func() {
@@ -823,7 +805,6 @@ var _ = Describe("Volume [Volume Tests]", func() {
 
 		var (
 			numVolumesBefore int
-			numVolumesAfter  int
 			volumeID         string
 		)
 
@@ -840,9 +821,8 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			err = volumedriver.Delete(volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
-			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
+			_, err = volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
-			numVolumesAfter = len(volumes)
 		})
 
 		It("Should get volume used size successfully", func() {
@@ -888,7 +868,6 @@ var _ = Describe("Volume [Volume Tests]", func() {
 
 		var (
 			numVolumesBefore int
-			numVolumesAfter  int
 			volumeID         string
 		)
 
@@ -911,9 +890,8 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			err = volumedriver.Delete(volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
-			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
+			_, err = volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
-			numVolumesAfter = len(volumes)
 		})
 
 		It("Should quiesce unquiesce volume successfully", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

This removes unused variables in the unit tests.  In go 1.11 and higher, *go test*
runs *go vet*.  go 1.11's *go vet* fails because of unused variables in the unit tests.
This fix causes the unit tests to succeed on go 1.11.
