### PR TITLE
Do not return errors during enumerate. (#1019)

### DIFF
--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -778,23 +778,13 @@ func (vd *volAPI) enumerate(w http.ResponseWriter, r *http.Request) {
 		ids = vls.GetVolumeIds()
 	}
 
-	vols = make([]*api.Volume, len(ids))
-	for i, s := range ids {
+	vols = make([]*api.Volume, 0)
+	for _, s := range ids {
 		vol, err := volumes.Inspect(ctx, &api.SdkVolumeInspectRequest{VolumeId: s})
-		if err != nil {
-			if s, ok := status.FromError(err); ok && s.Code() == codes.NotFound {
-				// We got an error but it's a NotFound error just return an empty array.
-				evols := make([]*api.Volume, 0)
-				json.NewEncoder(w).Encode(evols)
-				return
-			}
-			e := fmt.Errorf("enumerate Failed to inspect volumeID: %s", err.Error())
-			vd.sendError(vd.name, method, w, e.Error(), http.StatusBadRequest)
-			return
+		if err == nil {
+			vols = append(vols, vol.GetVolume())
 		}
-		vols[i] = vol.GetVolume()
 	}
-
 	json.NewEncoder(w).Encode(vols)
 }
 


### PR DESCRIPTION
* Do not return errors during enumerate.

We don't have locks on the inspect we do in our enumerate call.
So skip errors and keep enumerating.

Cherry-pick from master.