### PR TITLE
Return proper error msg for pxctl cloudmigrate. (#1017)

### DIFF
--- a/cluster/manager/pair.go
+++ b/cluster/manager/pair.go
@@ -197,12 +197,20 @@ func (c *ClusterManager) GetPair(
 	if id == "" {
 		id, err = getDefaultPairId()
 		if err != nil {
-			return nil, err
+			if err == kvdb.ErrNotFound {
+				return nil, fmt.Errorf("No default cluster pair found.")
+			} else {
+				return nil, err
+			}
 		}
 	}
 	pair, err := pairGet(id)
 	if err != nil {
-		return nil, err
+		if err == kvdb.ErrNotFound {
+			return nil, fmt.Errorf("Cluster pair for id %v not found", id)
+		} else {
+			return nil, err
+		}
 	}
 	return &api.ClusterPairGetResponse{
 		PairInfo: pair,


### PR DESCRIPTION
* Return proper error msg for pxctl cloudmigrate.

When running 'pxctl cloudmigrate' on a cluster not configured for cloud migration.
Should return proper messages to indicate its unconfigured.

Signed-off-by: Jose Rivera <jose@portworx.com>

* Change the return err msg.

Signed-off-by: Jose Rivera <jose@portworx.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

