### PR TITLE
Add MarkNodeForRemoval API to the ClusterListener interface.

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -188,6 +188,11 @@ type ClusterListenerNodeOps interface {
 	// CanNodeRemove test to see if we can remove this node
 	CanNodeRemove(node *api.Node) (string, error)
 
+	// MarkNodeForRemoval instructs the listeners that the ClusterManager
+	// is going ahead with the node removal. The API does not expect any
+	// response from the listeners
+	MarkNodeForRemoval(node *api.Node)
+
 	// MarkNodeDown marks the given node's status as down
 	MarkNodeDown(node *api.Node) error
 
@@ -426,6 +431,10 @@ func (nc *NullClusterListener) CanNodeRemove(node *api.Node) (string, error) {
 
 func (nc *NullClusterListener) MarkNodeDown(node *api.Node) error {
 	return nil
+}
+
+func (nc *NullClusterListener) MarkNodeForRemoval(node *api.Node) {
+	return
 }
 
 func (nc *NullClusterListener) Update(node *api.Node) error {


### PR DESCRIPTION
- MarkNodeForRemoval is invoked to notify all the cluster listeners that
  the node is going to be marked for decommission and will be removed from
  the cluster, before actually removing from the cluster.
- It is invoked in the ClusterManager Remove() API, after the listener.CanNodeRemove()
  succeeds for all listeners. The CanNodeRemove API does not indicate the listeners if
  the node is really going to be decommissioned, as one listener does not know about
  the other listener's status.

Signed-off-by: Aditya Dani <aditya@portworx.com>


