### PR TITLE
Add check for empty username during authentication

### DIFF
--- a/pkg/auth/claims.go
+++ b/pkg/auth/claims.go
@@ -1,5 +1,7 @@
 package auth
 
+import "fmt"
+
 const (
 	// default type is sub
 	UsernameClaimTypeDefault UsernameClaimType = ""
@@ -52,4 +54,27 @@ func getUsername(usernameClaim UsernameClaimType, claims *Claims) string {
 		return claims.Name
 	}
 	return claims.Subject
+}
+
+func validateUsername(usernameClaim UsernameClaimType, claims *Claims) error {
+	switch usernameClaim {
+	case UsernameClaimTypeEmail:
+		if claims.Email == "" {
+			return fmt.Errorf("System set to use the value of email as the username," +
+				" therefore the value of email in the token cannot be empty")
+		}
+	case UsernameClaimTypeName:
+		if claims.Name == "" {
+			return fmt.Errorf("System set to use the value of name as the username," +
+				" therefore the value of name in the token cannot be empty")
+
+		}
+	default:
+		if claims.Subject == "" {
+			return fmt.Errorf("System set to use the value of sub as the username," +
+				" therefore the value of sub in the token cannot be empty")
+		}
+	}
+
+	return nil
 }

--- a/pkg/auth/claims_test.go
+++ b/pkg/auth/claims_test.go
@@ -37,3 +37,31 @@ func TestClaims(t *testing.T) {
 	un = getUsername(UsernameClaimTypeSubject, claims)
 	assert.Equal(t, un, subject)
 }
+
+func TestValidateUsername(t *testing.T) {
+	email, name, subject := "a@b.com", "hello", "123"
+	goodClaims := &Claims{
+		Email:   email,
+		Name:    name,
+		Subject: subject,
+	}
+	badClaims := &Claims{
+		Email:   "",
+		Name:    "",
+		Subject: "",
+	}
+
+	typesToTest := []UsernameClaimType{
+		UsernameClaimTypeEmail,
+		UsernameClaimTypeName,
+		UsernameClaimTypeSubject,
+		UsernameClaimTypeDefault,
+	}
+	for _, unType := range typesToTest {
+		err := validateUsername(unType, goodClaims)
+		assert.NoError(t, err)
+
+		err = validateUsername(unType, badClaims)
+		assert.Error(t, err)
+	}
+}

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -127,5 +127,9 @@ func (o *OIDCAuthenticator) parseClaims(claims map[string]interface{}) (*Claims,
 		return nil, fmt.Errorf("Unable to get claims from token: %v", err)
 	}
 
+	if err := validateUsername(o.usernameClaim, &sdkClaims); err != nil {
+		return nil, err
+	}
+
 	return &sdkClaims, nil
 }

--- a/pkg/auth/selfsigned.go
+++ b/pkg/auth/selfsigned.go
@@ -141,6 +141,11 @@ func (j *JwtAuthenticator) AuthenticateToken(ctx context.Context, rawtoken strin
 	if err != nil {
 		return nil, fmt.Errorf("Unable to get sdkclaims: %v", err)
 	}
+
+	if err := validateUsername(j.usernameClaim, &sdkClaims); err != nil {
+		return nil, err
+	}
+
 	return &sdkClaims, nil
 }
 

--- a/pkg/auth/token_test.go
+++ b/pkg/auth/token_test.go
@@ -28,10 +28,11 @@ func TestTokenSharedSecretSimple(t *testing.T) {
 	iss := "uid"
 	key := []byte("mysecret")
 	claims := Claims{
-		Issuer: iss,
-		Email:  "my@email.com",
-		Name:   "myname",
-		Roles:  []string{"tester"},
+		Issuer:  iss,
+		Email:   "my@email.com",
+		Name:    "myname",
+		Subject: "mysub",
+		Roles:   []string{"tester"},
 	}
 	sig := Signature{
 		Type: jwt.SigningMethodHS256,
@@ -70,7 +71,8 @@ func TestTokenSharedSecretSimple(t *testing.T) {
 
 	// Test authenticators
 	authctr, err := NewJwtAuth(&JwtAuthConfig{
-		SharedSecret: key,
+		SharedSecret:  key,
+		UsernameClaim: UsernameClaimTypeDefault,
 	})
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
* We were getting permission denied because of an empty username before. This makes it more clear that the username cannot be empty, depending on which username type they have setup.
