### PR TITLE
Fix DCOS token secret regex to be more flexible for full dcos secret path

### DIFF
--- a/api/server/docker.go
+++ b/api/server/docker.go
@@ -261,9 +261,9 @@ func (d *driver) parseTokenInput(name string, opts map[string]string) (string, e
 	}
 
 	// get token secret
-	secret, context, ok := d.GetTokenSecretFromString(name)
+	secretPath, ok := d.GetTokenSecretFromString(name)
 	if ok {
-		token, err := d.secretTokenFromStore(secret, context)
+		token, err := d.secretTokenFromStore(secretPath)
 		if err != nil {
 			return "", err
 		}
@@ -290,12 +290,12 @@ func addTokenMetadata(ctx context.Context, token string) context.Context {
 
 // secretTokenFromStore pulls the token from the configured secret store for
 // a given secret name and context.
-func (d *driver) secretTokenFromStore(secret, context string) (string, error) {
+func (d *driver) secretTokenFromStore(secret string) (string, error) {
 	if d.secretsStore == nil {
 		return "", fmt.Errorf("A secret was passed in, but no secrets provider has been initialized")
 	}
 
-	token, err := d.secretsStore.GetToken(secret, context)
+	token, err := d.secretsStore.GetToken(secret, "")
 	if err != nil {
 		return "", err
 	}

--- a/api/spec/spec_handler.go
+++ b/api/spec/spec_handler.go
@@ -53,12 +53,12 @@ type SpecHandler interface {
 	// 	("", false)
 	GetTokenFromString(str string) (string, bool)
 
-	// GetTokenSecretFromString parses the token secret and context from the name.
+	// GetTokenSecretFromString parses the full token secret path from the name.
 	// If the token was parsed, it returns:
-	// 	(tokenSecret, tokenSecretContext, true)
+	// 	(tokenSecret, true)
 	// If the token wasn't parsed, it returns:
-	// 	("", "", false)
-	GetTokenSecretFromString(str string) (string, string, bool)
+	// 	("", false)
+	GetTokenSecretFromString(str string) (string, bool)
 
 	// SpecFromOpts parses in docker options passed in the the docker run
 	// command of the form --opt name=value
@@ -94,7 +94,7 @@ type SpecHandler interface {
 var (
 	nameRegex                   = regexp.MustCompile(api.Name + "=([0-9A-Za-z_-]+),?")
 	tokenRegex                  = regexp.MustCompile(api.Token + "=([A-Za-z0-9-_=]+\\.[A-Za-z0-9-_=]+\\.?[A-Za-z0-9-_.+/=]+),?")
-	tokenSecretRegex            = regexp.MustCompile(api.TokenSecret + `=/*([0-9A-Za-z_-]+/+)*([0-9A-Za-z_-]+)/([0-9A-Za-z_-]+),?`)
+	tokenSecretRegex            = regexp.MustCompile(api.TokenSecret + `=/*([0-9A-Za-z_/]+),?`)
 	nodesRegex                  = regexp.MustCompile(api.SpecNodes + "=([A-Za-z0-9-_;]+),?")
 	parentRegex                 = regexp.MustCompile(api.SpecParent + "=([A-Za-z]+),?")
 	sizeRegex                   = regexp.MustCompile(api.SpecSize + "=([0-9A-Za-z]+),?")
@@ -393,15 +393,15 @@ func (d *specHandler) GetTokenFromString(str string) (string, bool) {
 	return token, ok
 }
 
-func (d *specHandler) GetTokenSecretFromString(str string) (string, string, bool) {
+func (d *specHandler) GetTokenSecretFromString(str string) (string, bool) {
 	submatches := tokenSecretRegex.FindStringSubmatch(str)
-	if len(submatches) < 4 {
-		return "", "", false
+	if len(submatches) < 2 {
+		return "", false
 	}
-	context := submatches[2]
-	secret := submatches[3]
+	secret := submatches[1]
+	secret = strings.TrimRight(secret, "/")
 
-	return secret, context, true
+	return secret, true
 }
 
 func (d *specHandler) SpecOptsFromString(

--- a/api/spec/spec_handler_test.go
+++ b/api/spec/spec_handler_test.go
@@ -242,25 +242,35 @@ func TestGetTokenFromString(t *testing.T) {
 func TestGetTokenSecretFromString(t *testing.T) {
 	s := NewSpecHandler()
 
-	secret := "token1"
-	context := "team1"
+	tt := []struct {
+		InputSecret    string
+		ExpectedSecret string
+		Successful     bool
+	}{
+		{
+			"/px/secrets/alpha/token1",
+			"px/secrets/alpha/token1",
+			true,
+		}, {
+			"abcd/secrets/alpha//token1/",
+			"abcd/secrets/alpha//token1",
+			true,
+		}, {
+			"simplekey",
+			"simplekey",
+			true,
+		},
+	}
 
-	sample := "name=abcd,token_secret=/px/secrets/alpha/" + context + "/" + secret + ",token="
-	sample2 := "name=abcd,token_secret=padsasdax/secr//e/sdasda//ds/asda///sts/al//pha/" + context + "/" + secret + ",token="
+	for _, tc := range tt {
+		str := "name=abcd,token_secret=" + tc.InputSecret + ",token="
+		secretParsed, ok := s.GetTokenSecretFromString(str)
+		require.Equal(t, tc.ExpectedSecret, secretParsed)
+		require.Equal(t, ok, tc.Successful)
+	}
 
-	secretParsed, contextParsed, ok := s.GetTokenSecretFromString(sample)
-	require.Equal(t, secret, secretParsed)
-	require.Equal(t, context, contextParsed)
-	require.Equal(t, ok, true)
-
-	secretParsed, contextParsed, ok = s.GetTokenSecretFromString(sample2)
-	require.Equal(t, secret, secretParsed)
-	require.Equal(t, context, contextParsed)
-	require.Equal(t, ok, true)
-
-	secretParsed, contextParsed, ok = s.GetTokenSecretFromString(fmt.Sprintf("toabcbn_secret=abcd"))
+	secretParsed, ok := s.GetTokenSecretFromString(fmt.Sprintf("toabcbn_secret=abcd"))
 	require.Equal(t, "", secretParsed)
-	require.Equal(t, "", contextParsed)
 	require.Equal(t, ok, false)
 
 }


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
* Regex was not general enough - missed case of no context and multiple levels of slashes. 
* Changed to use only secretName for entire secretPath, instead of secretName + secretContext.



