### PR TITLE
Move docker specific code out of the SDK

### DIFF
--- a/api/server/sdk/volume_node_ops_test.go
+++ b/api/server/sdk/volume_node_ops_test.go
@@ -298,12 +298,6 @@ func TestSdkVolumeMountSuccess(t *testing.T) {
 
 	s.MockDriver().
 		EXPECT().
-		Type().
-		Return(api.DriverType_DRIVER_TYPE_NONE).
-		Times(1)
-
-	s.MockDriver().
-		EXPECT().
 		Mount(id, mountPath, nil).
 		Return(nil).
 		Times(1)
@@ -351,12 +345,6 @@ func TestSdkVolumeMountWithDriverOptionsSuccess(t *testing.T) {
 
 	s.MockDriver().
 		EXPECT().
-		Type().
-		Return(api.DriverType_DRIVER_TYPE_NONE).
-		Times(1)
-
-	s.MockDriver().
-		EXPECT().
 		Mount(id, mountPath, map[string]string{"hello": "world"}).
 		Return(nil).
 		Times(1)
@@ -398,10 +386,6 @@ func TestSdkVolumeMountFailed(t *testing.T) {
 			},
 		}, nil).
 		Times(1)
-	s.MockDriver().
-		EXPECT().
-		Type().
-		Return(api.DriverType_DRIVER_TYPE_NONE)
 	s.MockDriver().
 		EXPECT().
 		Mount(id, mountPath, nil).

--- a/csi/node_test.go
+++ b/csi/node_test.go
@@ -299,11 +299,6 @@ func TestNodePublishVolumeFailedMount(t *testing.T) {
 			Times(1),
 		s.MockDriver().
 			EXPECT().
-			Type().
-			Return(api.DriverType_DRIVER_TYPE_NONE).
-			Times(1),
-		s.MockDriver().
-			EXPECT().
 			Mount(name, targetPath, nil).
 			Return(fmt.Errorf("Unable to mount volume")).
 			Times(1),
@@ -439,11 +434,6 @@ func TestNodePublishVolumeMount(t *testing.T) {
 					},
 				},
 			}, nil).
-			Times(1),
-		s.MockDriver().
-			EXPECT().
-			Type().
-			Return(api.DriverType_DRIVER_TYPE_NONE).
 			Times(1),
 
 		s.MockDriver().


### PR DESCRIPTION
**What this PR does / why we need it**:
During development of the rerouting of the Docker server, we moved some code into the SDK. This code was being executed for other type of interfaces not just Docker, and was causing issues. Instead, we moved the code back and adjusted it to use the SDK as needed.

