### PR TITLE
Continue on an error during Snap Enumerate

### DIFF
--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -1025,15 +1025,13 @@ func (vd *volAPI) snapEnumerate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	snaps := make([]*api.Volume, len(resp.GetVolumeSnapshotIds()))
-	for i, s := range resp.GetVolumeSnapshotIds() {
+	snaps := make([]*api.Volume, 0)
+	for _, s := range resp.GetVolumeSnapshotIds() {
 		vol, err := volumes.Inspect(ctx, &api.SdkVolumeInspectRequest{VolumeId: s})
 		if err != nil {
-			e := fmt.Errorf("Failed to inspect volumeID: %s", err.Error())
-			vd.sendError(vd.name, method, w, e.Error(), http.StatusBadRequest)
-			return
+			continue
 		}
-		snaps[i] = vol.GetVolume()
+		snaps = append(snaps, vol.GetVolume())
 	}
 	json.NewEncoder(w).Encode(snaps)
 }


### PR DESCRIPTION
Signed-off-by: Paul <paul@portworx.com>

We shouldn't return an error if inspect fails during a snapEnumerate
We can delete volumes while an enumerate is happening. and that results into a not found error.

