### PR TITLE
Add option for token creation to subtact a duration from IAT

### DIFF
--- a/pkg/auth/token.go
+++ b/pkg/auth/token.go
@@ -28,6 +28,12 @@ import (
 type Options struct {
 	// Expiration time in Unix format as per JWT standard
 	Expiration int64
+
+	// IATSubtract is the time duration you would like to remove from
+	// the token IAT (Issue At Time). This is useful as a guard against
+	// NTP drift within a cluster. Without this option, your token may
+	// be denied due to the IAT being greater than the current time.
+	IATSubtract time.Duration
 }
 
 // TokenClaims returns the claims for the raw JWT token.
@@ -89,7 +95,7 @@ func Token(
 		"email": claims.Email,
 		"name":  claims.Name,
 		"roles": claims.Roles,
-		"iat":   time.Now().Unix(),
+		"iat":   time.Now().Add(-options.IATSubtract).Unix(),
 		"exp":   options.Expiration,
 	}
 	if claims.Groups != nil {


### PR DESCRIPTION
cherry-pick of b2fc0cc21435c0d56de2f276ab3c1dd05ccd5f18