### PR TITLE
Remove unused variable to eliminate go vet 1.11 error

### DIFF
--- a/pkg/sanity/volume.go
+++ b/pkg/sanity/volume.go
@@ -461,7 +461,6 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			numVolumesAfter  int
 			volumeID         string
 			mountPath        string
-			volumesToCreate  int
 		)
 
 		BeforeEach(func() {
@@ -492,7 +491,6 @@ var _ = Describe("Volume [Volume Tests]", func() {
 
 			var err error
 
-			volumesToCreate = 1
 			var size = 5
 			vr := &api.VolumeCreateRequest{
 				Locator: &api.VolumeLocator{


### PR DESCRIPTION
Signed-off-by: Craig Rodrigues <craig@portworx.com>

**What this PR does / why we need it**:

This patch removes an unused variable error with go vet 1.11+.
This is needed to run the unit tests on go 1.11+