### PR TITLE
in-tree: Get k8s secret from labels if not in PVC annotations

### DIFF
--- a/api/server/middleware_auth.go
+++ b/api/server/middleware_auth.go
@@ -74,7 +74,8 @@ func (a *authMiddleware) createWithAuth(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 	if secretName == "" {
-		errorMessage := "Access denied, no secret found in the annotations of the persistent volume claim"
+		errorMessage := "Access denied, no secret found in the annotations of the persistent volume claim" +
+			" or storage class parameters"
 		a.log(locator.Name, fn).Error(errorMessage)
 		dcRes.VolumeResponse = &api.VolumeResponse{Error: errorMessage}
 		json.NewEncoder(w).Encode(&dcRes)
@@ -330,6 +331,10 @@ func (a *authMiddleware) parseSecret(
 		}
 		secretName := pvc.ObjectMeta.Annotations[secrets.SecretNameKey]
 		secretNamespace := pvc.ObjectMeta.Annotations[secrets.SecretNamespaceKey]
+		if len(secretName) == 0 {
+			return parseSecretFromLabels(specLabels, locatorLabels)
+		}
+
 		return secretName, secretNamespace, nil
 	}
 	return parseSecretFromLabels(specLabels, locatorLabels)


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
* Before, we were returning empty secret name and namespace if we did not find the secret in the PVC annotations. 
* With this PR, if we end up with an empty secret name or namespace, we'll attempt to retrieve them from the volume labels.