### PR TITLE
Support disk provisioning on VM scale sets in Azure

### DIFF
--- a/pkg/storageops/azure/README.md
+++ b/pkg/storageops/azure/README.md
@@ -2,8 +2,11 @@
 
 You will first need to create a Azure instance and then provide details of this instance as below.
 
+If you are running the tests on an instance under scale set, only then you need to provide `AZURE_SCALE_SET_NAME`. Also you will have to provide the instance id (index in scale set) for `AZURE_INSTANCE_ID` instead of the instance name.
+
 ```bash
-export AZURE_INSTANCE_NAME=<instance-name>
+export AZURE_INSTANCE_ID=<instance-id>
+export AZURE_SCALE_SET_NAME=<scale-set-name>
 export AZURE_SUBSCRIPTION_ID=<subscription-id>
 export AZURE_RESOURCE_GROUP_NAME=<resource-group-name-of-instance>
 export AZURE_ENVIRONMENT=<azure-cloud-environment>

--- a/pkg/storageops/azure/azure.go
+++ b/pkg/storageops/azure/azure.go
@@ -19,7 +19,8 @@ import (
 )
 
 const (
-	envInstanceName      = "AZURE_INSTANCE_NAME"
+	envInstanceID        = "AZURE_INSTANCE_ID"
+	envScaleSetName      = "AZURE_SCALE_SET_NAME"
 	envSubscriptionID    = "AZURE_SUBSCRIPTION_ID"
 	envResourceGroupName = "AZURE_RESOURCE_GROUP_NAME"
 )
@@ -39,7 +40,7 @@ type azureOps struct {
 	instance          string
 	resourceGroupName string
 	disksClient       *compute.DisksClient
-	vmsClient         *compute.VirtualMachinesClient
+	vmsClient         vmsClient
 	snapshotsClient   *compute.SnapshotsClient
 }
 
@@ -52,7 +53,7 @@ func (a *azureOps) InstanceID() string {
 }
 
 func NewEnvClient() (storageops.Ops, error) {
-	instance, err := storageops.GetEnvValueStrict(envInstanceName)
+	instance, err := storageops.GetEnvValueStrict(envInstanceID)
 	if err != nil {
 		return nil, err
 	}
@@ -64,11 +65,12 @@ func NewEnvClient() (storageops.Ops, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewClient(instance, subscriptionID, resourceGroupName)
+	scaleSetName := os.Getenv(envScaleSetName)
+	return NewClient(instance, scaleSetName, subscriptionID, resourceGroupName)
 }
 
 func NewClient(
-	instance, subscriptionID, resourceGroupName string,
+	instance, scaleSetName, subscriptionID, resourceGroupName string,
 ) (storageops.Ops, error) {
 	authorizer, err := auth.NewAuthorizerFromEnvironment()
 	if err != nil {
@@ -81,11 +83,7 @@ func NewClient(
 	disksClient.RetryAttempts = clientRetryAttempts
 	disksClient.AddToUserAgent(userAgentExtension)
 
-	vmsClient := compute.NewVirtualMachinesClient(subscriptionID)
-	vmsClient.Authorizer = authorizer
-	vmsClient.PollingDelay = clientPollingDelay
-	vmsClient.RetryAttempts = clientRetryAttempts
-	vmsClient.AddToUserAgent(userAgentExtension)
+	vmsClient := NewVMsClient(scaleSetName, subscriptionID, resourceGroupName, authorizer)
 
 	snapshotsClient := compute.NewSnapshotsClient(subscriptionID)
 	snapshotsClient.Authorizer = authorizer
@@ -97,7 +95,7 @@ func NewClient(
 		instance:          instance,
 		resourceGroupName: resourceGroupName,
 		disksClient:       &disksClient,
-		vmsClient:         &vmsClient,
+		vmsClient:         vmsClient,
 		snapshotsClient:   &snapshotsClient,
 	}, nil
 }
@@ -182,9 +180,9 @@ func (a *azureOps) GetDeviceID(disk interface{}) (string, error) {
 }
 
 func (a *azureOps) Attach(diskName string) (string, error) {
-	vm, err := a.describeInstance()
+	dataDisks, err := a.vmsClient.getDataDisks(a.instance)
 	if err != nil {
-		return "", fmt.Errorf("cannot get vm %v: %v", a.instance, err)
+		return "", err
 	}
 
 	disk, err := a.disksClient.Get(
@@ -196,14 +194,14 @@ func (a *azureOps) Attach(diskName string) (string, error) {
 		return "", fmt.Errorf("cannot get disk %v: %v", diskName, err)
 	}
 
-	nextLun := nextAvailableLun(*vm.StorageProfile.DataDisks)
+	nextLun := nextAvailableLun(dataDisks)
 	if nextLun < 0 {
 		return "", fmt.Errorf("No LUN available to attach the disk. "+
-			"%v disks attached to the VM instance", len(*vm.StorageProfile.DataDisks))
+			"%v disks attached to the VM instance", len(dataDisks))
 	}
 
-	*vm.StorageProfile.DataDisks = append(
-		*vm.StorageProfile.DataDisks,
+	newDataDisks := append(
+		dataDisks,
 		compute.DataDisk{
 			Lun:          &nextLun,
 			Name:         to.StringPtr(diskName),
@@ -214,22 +212,8 @@ func (a *azureOps) Attach(diskName string) (string, error) {
 			},
 		},
 	)
-	vm.Resources = nil
-
-	ctx := context.Background()
-	future, err := a.vmsClient.CreateOrUpdate(
-		ctx,
-		a.resourceGroupName,
-		a.instance,
-		vm,
-	)
-	if err != nil {
-		return "", fmt.Errorf("cannot update vm %v: %v", a.instance, err)
-	}
-
-	err = future.WaitForCompletionRef(ctx, a.vmsClient.Client)
-	if err != nil {
-		return "", fmt.Errorf("cannot get the vm create or update future response: %v", err)
+	if err := a.vmsClient.updateDataDisks(a.instance, newDataDisks); err != nil {
+		return "", err
 	}
 
 	return a.waitForAttach(diskName)
@@ -239,19 +223,14 @@ func (a *azureOps) Detach(diskName string) error {
 	return a.detachInternal(diskName, a.instance)
 }
 
-func (a *azureOps) DetachFrom(diskName, instanceName string) error {
-	return a.detachInternal(diskName, instanceName)
+func (a *azureOps) DetachFrom(diskName, instance string) error {
+	return a.detachInternal(diskName, instance)
 }
 
-func (a *azureOps) detachInternal(diskName, instanceName string) error {
-	vm, err := a.vmsClient.Get(
-		context.Background(),
-		a.resourceGroupName,
-		instanceName,
-		compute.InstanceView,
-	)
+func (a *azureOps) detachInternal(diskName, instance string) error {
+	dataDisks, err := a.vmsClient.getDataDisks(instance)
 	if err != nil {
-		return fmt.Errorf("cannot get vm %v: %v", instanceName, err)
+		return err
 	}
 
 	disk, err := a.disksClient.Get(
@@ -265,38 +244,19 @@ func (a *azureOps) detachInternal(diskName, instanceName string) error {
 
 	diskToDetach := strings.ToLower(*disk.ID)
 
-	disks := make([]compute.DataDisk, 0)
-	for _, d := range *vm.StorageProfile.DataDisks {
+	newDataDisks := make([]compute.DataDisk, 0)
+	for _, d := range dataDisks {
 		if strings.ToLower(*d.ManagedDisk.ID) == diskToDetach {
 			continue
 		}
-		disks = append(disks, d)
+		newDataDisks = append(newDataDisks, d)
 	}
 
-	if len(disks) == 0 {
-		vm.StorageProfile.DataDisks = &[]compute.DataDisk{}
-	} else {
-		vm.StorageProfile.DataDisks = &disks
-	}
-	vm.Resources = nil
-
-	ctx := context.Background()
-	future, err := a.vmsClient.CreateOrUpdate(
-		ctx,
-		a.resourceGroupName,
-		instanceName,
-		vm,
-	)
-	if err != nil {
-		return fmt.Errorf("cannot update vm %v: %v", instanceName, err)
+	if err := a.vmsClient.updateDataDisks(instance, newDataDisks); err != nil {
+		return err
 	}
 
-	err = future.WaitForCompletionRef(ctx, a.vmsClient.Client)
-	if err != nil {
-		return fmt.Errorf("cannot get the vm create or update future response: %v", err)
-	}
-
-	return a.waitForDetach(diskName)
+	return a.waitForDetach(diskName, instance)
 }
 
 func (a *azureOps) Delete(diskName string) error {
@@ -320,16 +280,7 @@ func (a *azureOps) DeleteFrom(diskName, _ string) error {
 }
 
 func (a *azureOps) Describe() (interface{}, error) {
-	return a.describeInstance()
-}
-
-func (a *azureOps) describeInstance() (compute.VirtualMachine, error) {
-	return a.vmsClient.Get(
-		context.Background(),
-		a.resourceGroupName,
-		a.instance,
-		compute.InstanceView,
-	)
+	return a.vmsClient.describe(a.instance)
 }
 
 func (a *azureOps) FreeDevices(
@@ -362,13 +313,13 @@ func (a *azureOps) Inspect(diskNames []*string) ([]interface{}, error) {
 }
 
 func (a *azureOps) DeviceMappings() (map[string]string, error) {
-	vm, err := a.describeInstance()
+	dataDisks, err := a.vmsClient.getDataDisks(a.instance)
 	if err != nil {
 		return nil, err
 	}
 
 	devMap := make(map[string]string)
-	for _, d := range *vm.StorageProfile.DataDisks {
+	for _, d := range dataDisks {
 		devPath, err := lunToBlockDevPath(*d.Lun)
 		if err != nil {
 			return nil, storageops.NewStorageError(
@@ -444,16 +395,12 @@ func (a *azureOps) DevicePath(diskName string) (string, error) {
 		)
 	}
 
-	vm, err := a.describeInstance()
+	dataDisks, err := a.vmsClient.getDataDisks(a.instance)
 	if err != nil {
 		return "", err
 	}
 
-	if vm.StorageProfile == nil || vm.StorageProfile.DataDisks == nil {
-		return "", fmt.Errorf("instance does not have any disks attached")
-	}
-
-	for _, d := range *vm.StorageProfile.DataDisks {
+	for _, d := range dataDisks {
 		if *d.Name == diskName {
 			// Retry to get the block dev path as it may take few seconds for the path
 			// to be created even after the disk shows attached.
@@ -676,23 +623,19 @@ func (a *azureOps) waitForAttach(diskName string) (string, error) {
 	return devicePath.(string), nil
 }
 
-func (a *azureOps) waitForDetach(diskName string) error {
+func (a *azureOps) waitForDetach(diskName, instance string) error {
 	_, err := task.DoRetryWithTimeout(
 		func() (interface{}, bool, error) {
-			vm, err := a.describeInstance()
+			dataDisks, err := a.vmsClient.getDataDisks(instance)
 			if err != nil {
 				return nil, true, err
 			}
 
-			if vm.StorageProfile == nil || vm.StorageProfile.DataDisks == nil {
-				return nil, true, fmt.Errorf("vm in invalid state")
-			}
-
-			for _, d := range *vm.StorageProfile.DataDisks {
+			for _, d := range dataDisks {
 				if *d.Name == diskName {
 					return nil, true,
 						fmt.Errorf("disk %s is still attached to instance %s",
-							diskName, a.instance)
+							diskName, instance)
 				}
 			}
 

--- a/pkg/storageops/azure/base_vmsclient.go
+++ b/pkg/storageops/azure/base_vmsclient.go
@@ -1,0 +1,91 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	"github.com/Azure/go-autorest/autorest"
+)
+
+type baseVMsClient struct {
+	resourceGroupName string
+	client            *compute.VirtualMachinesClient
+}
+
+func newBaseVMsClient(
+	subscriptionID, resourceGroupName string,
+	authorizer autorest.Authorizer,
+) vmsClient {
+	vmsClient := compute.NewVirtualMachinesClient(subscriptionID)
+	vmsClient.Authorizer = authorizer
+	vmsClient.PollingDelay = clientPollingDelay
+	vmsClient.RetryAttempts = clientRetryAttempts
+	vmsClient.AddToUserAgent(userAgentExtension)
+	return &baseVMsClient{
+		resourceGroupName: resourceGroupName,
+		client:            &vmsClient,
+	}
+}
+
+func (b *baseVMsClient) describe(
+	instanceName string,
+) (interface{}, error) {
+	return b.describeInstance(instanceName)
+}
+
+func (b *baseVMsClient) getDataDisks(
+	instanceName string,
+) ([]compute.DataDisk, error) {
+	vm, err := b.describeInstance(instanceName)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get vm %v: %v", instanceName, err)
+	}
+
+	if vm.StorageProfile == nil || vm.StorageProfile.DataDisks == nil {
+		return nil, fmt.Errorf("vm storage profile is invalid")
+	}
+
+	return *vm.StorageProfile.DataDisks, nil
+}
+
+func (b *baseVMsClient) updateDataDisks(
+	instanceName string,
+	dataDisks []compute.DataDisk,
+) error {
+	updatedVM := compute.VirtualMachineUpdate{
+		VirtualMachineProperties: &compute.VirtualMachineProperties{
+			StorageProfile: &compute.StorageProfile{
+				DataDisks: &dataDisks,
+			},
+		},
+	}
+
+	ctx := context.Background()
+	future, err := b.client.Update(
+		ctx,
+		b.resourceGroupName,
+		instanceName,
+		updatedVM,
+	)
+	if err != nil {
+		return fmt.Errorf("cannot update vm %v: %v", instanceName, err)
+	}
+
+	err = future.WaitForCompletionRef(ctx, b.client.Client)
+	if err != nil {
+		return fmt.Errorf("cannot get the vm update future response: %v", err)
+	}
+	return nil
+}
+
+func (b *baseVMsClient) describeInstance(
+	instanceName string,
+) (compute.VirtualMachine, error) {
+	return b.client.Get(
+		context.Background(),
+		b.resourceGroupName,
+		instanceName,
+		compute.InstanceView,
+	)
+}

--- a/pkg/storageops/azure/scaleset_vmsclient.go
+++ b/pkg/storageops/azure/scaleset_vmsclient.go
@@ -1,0 +1,93 @@
+package azure
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	"github.com/Azure/go-autorest/autorest"
+)
+
+type scaleSetVMsClient struct {
+	scaleSetName      string
+	resourceGroupName string
+	client            *compute.VirtualMachineScaleSetVMsClient
+}
+
+func newScaleSetVMsClient(
+	scaleSetName, subscriptionID, resourceGroupName string,
+	authorizer autorest.Authorizer,
+) vmsClient {
+	vmsClient := compute.NewVirtualMachineScaleSetVMsClient(subscriptionID)
+	vmsClient.Authorizer = authorizer
+	vmsClient.PollingDelay = clientPollingDelay
+	vmsClient.RetryAttempts = clientRetryAttempts
+	vmsClient.AddToUserAgent(userAgentExtension)
+	return &scaleSetVMsClient{
+		scaleSetName:      scaleSetName,
+		resourceGroupName: resourceGroupName,
+		client:            &vmsClient,
+	}
+}
+
+func (s *scaleSetVMsClient) describe(
+	instanceID string,
+) (interface{}, error) {
+	return s.describeInstance(instanceID)
+}
+
+func (s *scaleSetVMsClient) getDataDisks(
+	instanceID string,
+) ([]compute.DataDisk, error) {
+	vm, err := s.describeInstance(instanceID)
+	if err != nil {
+		return nil, fmt.Errorf("cannot get vm %v_%v: %v", s.scaleSetName, instanceID, err)
+	}
+
+	if vm.StorageProfile == nil || vm.StorageProfile.DataDisks == nil {
+		return nil, fmt.Errorf("vm storage profile is invalid")
+	}
+
+	return *vm.StorageProfile.DataDisks, nil
+}
+
+func (s *scaleSetVMsClient) updateDataDisks(
+	instanceID string,
+	dataDisks []compute.DataDisk,
+) error {
+	vm, err := s.describeInstance(instanceID)
+	if err != nil {
+		return fmt.Errorf("cannot get vm %v_%v: %v", s.scaleSetName, instanceID, err)
+	}
+
+	vm.StorageProfile.DataDisks = &dataDisks
+
+	ctx := context.Background()
+	future, err := s.client.Update(
+		ctx,
+		s.resourceGroupName,
+		s.scaleSetName,
+		instanceID,
+		vm,
+	)
+	if err != nil {
+		return fmt.Errorf("cannot update vm %v_%v: %v", s.scaleSetName, instanceID, err)
+	}
+
+	err = future.WaitForCompletionRef(ctx, s.client.Client)
+	if err != nil {
+		return fmt.Errorf("cannot get the vm update future response: %v", err)
+	}
+	return nil
+}
+
+func (s *scaleSetVMsClient) describeInstance(
+	instanceID string,
+) (compute.VirtualMachineScaleSetVM, error) {
+	return s.client.Get(
+		context.Background(),
+		s.resourceGroupName,
+		s.scaleSetName,
+		instanceID,
+	)
+}

--- a/pkg/storageops/azure/vmsclient.go
+++ b/pkg/storageops/azure/vmsclient.go
@@ -1,0 +1,36 @@
+package azure
+
+import (
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	"github.com/Azure/go-autorest/autorest"
+)
+
+// vmsClient is an interface for azure vm client operations
+type vmsClient interface {
+	// describe returns the VM instance object
+	describe(instanceID string) (interface{}, error)
+	// getDataDisks returns a list of data disks attached to the given VM
+	getDataDisks(instanceID string) ([]compute.DataDisk, error)
+	// updateDataDisks update the data disks for the given VM
+	updateDataDisks(instanceID string, dataDisks []compute.DataDisk) error
+}
+
+func NewVMsClient(
+	scaleSetName string,
+	subscriptionID, resourceGroupName string,
+	authorizer autorest.Authorizer,
+) vmsClient {
+	if scaleSetName == "" {
+		return newBaseVMsClient(
+			subscriptionID,
+			resourceGroupName,
+			authorizer,
+		)
+	}
+	return newScaleSetVMsClient(
+		scaleSetName,
+		subscriptionID,
+		resourceGroupName,
+		authorizer,
+	)
+}


### PR DESCRIPTION
Signed-off-by: Piyush Nimbalkar <piyush@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
In azure the VM apis in scale set are different from the ones using by normal VMs. Adding support to attach/detach disk to both kinds of VMs.
- If the scale set name is non empty we assume the VM is running inside a scale set. The instance id passed in such a case is the just the index (instance id) of the VM.
- For non-scale set VMs the scale set name will be empty and instance id will have the name of the VM.


**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

