### PR TITLE
Delete Alert: When using resourceIDFilter use Delete instead of DeleteTree

### DIFF
--- a/alerts/alerts.go
+++ b/alerts/alerts.go
@@ -259,6 +259,7 @@ Loop:
 			minSeverityFilter,
 			flagCheckFilter,
 			matchAlertTypeFilter,
+			resourceIDFilter,
 			matchResourceIDFilter:
 			allFiltersIndexBased = false
 			break Loop


### PR DESCRIPTION

Signed-off-by: Aditya Dani <aditya@portworx.com>


**What this PR does / why we need it**:
- When using the resourceIDFilter, a single alert is returned after filtering all the alerts.
- For a single alert, the correct kvdb API, to use is Delete() instead of DeleteTree()


**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

