### PR TITLE
Release 6.1 - Remove the cluster max size check from openstorage

### DIFF
--- a/api/client/cluster/client.go
+++ b/api/client/cluster/client.go
@@ -280,7 +280,7 @@ func (c *clusterClient) Shutdown() error {
 	return nil
 }
 
-func (c *clusterClient) Start(int, bool, string, string) error {
+func (c *clusterClient) Start(bool, string, string) error {
 	return nil
 }
 
@@ -288,7 +288,7 @@ func (c *clusterClient) Uuid() string {
 	return ""
 }
 
-func (c *clusterClient) StartWithConfiguration(int, bool, string, []string, string, *cluster.ClusterServerConfiguration) error {
+func (c *clusterClient) StartWithConfiguration(bool, string, []string, string, *cluster.ClusterServerConfiguration) error {
 	return nil
 }
 

--- a/api/server/sdk/sdk_test.go
+++ b/api/server/sdk/sdk_test.go
@@ -247,7 +247,7 @@ func TestSdkWithNoVolumeDriverThenAddOne(t *testing.T) {
 	})
 	cm, err := clustermanager.Inst()
 	go func() {
-		cm.Start(0, false, "9002", "")
+		cm.Start(false, "9002", "")
 	}()
 	defer cm.Shutdown()
 	if err := volumedrivers.Register("fake", map[string]string{}); err != nil {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -87,7 +87,7 @@ type ClusterInitState struct {
 // FinalizeInitCb is invoked when init is complete and is in the process of
 // updating the cluster database. This callback is invoked under lock and must
 // finish quickly, else it will slow down other node joins.
-type FinalizeInitCb func() error
+type FinalizeInitCb func(*ClusterInfo) error
 
 // ClusterListener is an interface to be implemented by a storage driver
 // if it is participating in a multi host environment.  It exposes events
@@ -184,6 +184,10 @@ type ClusterListenerNodeOps interface {
 
 	// Remove is called when a node leaves the cluster
 	Remove(node *api.Node, forceRemove bool) error
+
+	// CanNodeJoin checks with the listener if this node can join
+	// the cluster. This check is done under a cluster database lock
+	CanNodeJoin(node *api.Node, clusterInfo *ClusterInfo, nodeInitialized bool) error
 
 	// CanNodeRemove test to see if we can remove this node
 	CanNodeRemove(node *api.Node) (string, error)
@@ -332,11 +336,10 @@ type Cluster interface {
 	// nodeInitialized indicates if the caller of this method expects the node
 	// to have been in an already-initialized state.
 	// All managers will default returning NotSupported.
-	Start(clusterSize int, nodeInitialized bool, gossipPort string, selfClusterDomain string) error
+	Start(nodeInitialized bool, gossipPort string, selfClusterDomain string) error
 
 	// Like Start, but have the ability to pass in managers to the cluster object
 	StartWithConfiguration(
-		clusterMaxSize int,
 		nodeInitialized bool,
 		gossipPort string,
 		snapshotPrefixes []string,
@@ -427,6 +430,10 @@ func (nc *NullClusterListener) Remove(node *api.Node, forceRemove bool) error {
 
 func (nc *NullClusterListener) CanNodeRemove(node *api.Node) (string, error) {
 	return "", nil
+}
+
+func (nc *NullClusterListener) CanNodeJoin(node *api.Node, clusterInfo *ClusterInfo, nodeInitialized bool) error {
+	return nil
 }
 
 func (nc *NullClusterListener) MarkNodeDown(node *api.Node) error {

--- a/cluster/cluster_not_supported.go
+++ b/cluster/cluster_not_supported.go
@@ -100,12 +100,12 @@ func (m *NullClusterManager) Shutdown() error {
 }
 
 // Start
-func (m *NullClusterManager) Start(arg0 int, arg1 bool, arg2 string, arg3 string) error {
+func (m *NullClusterManager) Start(arg1 bool, arg2 string, arg3 string) error {
 	return ErrNotImplemented
 }
 
 // StartWithConfiguration
-func (m *NullClusterManager) StartWithConfiguration(arg0 int, arg1 bool, arg2 string, arg3 []string, arg4 string, arg5 *ClusterServerConfiguration) error {
+func (m *NullClusterManager) StartWithConfiguration(arg1 bool, arg2 string, arg3 []string, arg4 string, arg5 *ClusterServerConfiguration) error {
 	return ErrNotImplemented
 }
 

--- a/cluster/manager/manager_test.go
+++ b/cluster/manager/manager_test.go
@@ -90,7 +90,7 @@ func TestUpdateSchedulerNodeName(t *testing.T) {
 	assert.NoError(t, err)
 	auth.InitSystemTokenManager(manager)
 
-	err = inst.StartWithConfiguration(1, false, "1001", []string{}, "", &cluster.ClusterServerConfiguration{
+	err = inst.StartWithConfiguration(false, "1001", []string{}, "", &cluster.ClusterServerConfiguration{
 		ConfigSystemTokenManager: manager,
 	})
 	assert.NoError(t, err)

--- a/cluster/mock/cluster.mock.go
+++ b/cluster/mock/cluster.mock.go
@@ -664,27 +664,27 @@ func (mr *MockClusterMockRecorder) Shutdown() *gomock.Call {
 }
 
 // Start mocks base method
-func (m *MockCluster) Start(arg0 int, arg1 bool, arg2, arg3 string) error {
-	ret := m.ctrl.Call(m, "Start", arg0, arg1, arg2, arg3)
+func (m *MockCluster) Start(arg0 bool, arg1, arg2 string) error {
+	ret := m.ctrl.Call(m, "Start", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Start indicates an expected call of Start
-func (mr *MockClusterMockRecorder) Start(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockCluster)(nil).Start), arg0, arg1, arg2, arg3)
+func (mr *MockClusterMockRecorder) Start(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockCluster)(nil).Start), arg0, arg1, arg2)
 }
 
 // StartWithConfiguration mocks base method
-func (m *MockCluster) StartWithConfiguration(arg0 int, arg1 bool, arg2 string, arg3 []string, arg4 string, arg5 *cluster.ClusterServerConfiguration) error {
-	ret := m.ctrl.Call(m, "StartWithConfiguration", arg0, arg1, arg2, arg3, arg4, arg5)
+func (m *MockCluster) StartWithConfiguration(arg0 bool, arg1 string, arg2 []string, arg3 string, arg4 *cluster.ClusterServerConfiguration) error {
+	ret := m.ctrl.Call(m, "StartWithConfiguration", arg0, arg1, arg2, arg3, arg4)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StartWithConfiguration indicates an expected call of StartWithConfiguration
-func (mr *MockClusterMockRecorder) StartWithConfiguration(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWithConfiguration", reflect.TypeOf((*MockCluster)(nil).StartWithConfiguration), arg0, arg1, arg2, arg3, arg4, arg5)
+func (mr *MockClusterMockRecorder) StartWithConfiguration(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWithConfiguration", reflect.TypeOf((*MockCluster)(nil).StartWithConfiguration), arg0, arg1, arg2, arg3, arg4)
 }
 
 // UpdateData mocks base method

--- a/cmd/osd/main.go
+++ b/cmd/osd/main.go
@@ -521,7 +521,6 @@ func start(c *cli.Context) error {
 			return fmt.Errorf("Unable to find cluster instance: %v", err)
 		}
 		if err := cm.StartWithConfiguration(
-			0,
 			false,
 			"9002",
 			[]string{},

--- a/csi/csisanity_test.go
+++ b/csi/csisanity_test.go
@@ -45,7 +45,7 @@ func TestCSISanity(t *testing.T) {
 	})
 	cm, err := clustermanager.Inst()
 	go func() {
-		cm.Start(0, false, "9002", "")
+		cm.Start(false, "9002", "")
 	}()
 	defer cm.Shutdown()
 


### PR DESCRIPTION
- Let the Storage Listeners decide the maximum no. of nodes that can be
  added to the cluster.
- Add a new StorageListener API CanNodeJoin that gets invoked before joining a node
  to a cluster.



