### PR TITLE
Release-4.0 Remove the cluster max size check from openstorage

### DIFF
--- a/api/client/cluster/client.go
+++ b/api/client/cluster/client.go
@@ -269,7 +269,7 @@ func (c *clusterClient) Shutdown() error {
 	return nil
 }
 
-func (c *clusterClient) Start(int, bool, string) error {
+func (c *clusterClient) Start(bool, string) error {
 	return nil
 }
 
@@ -277,7 +277,7 @@ func (c *clusterClient) Uuid() string {
 	return ""
 }
 
-func (c *clusterClient) StartWithConfiguration(int, bool, string, *cluster.ClusterServerConfiguration) error {
+func (c *clusterClient) StartWithConfiguration(bool, string, *cluster.ClusterServerConfiguration) error {
 	return nil
 }
 

--- a/api/server/sdk/sdk_test.go
+++ b/api/server/sdk/sdk_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-csi/csi-test/utils"
 	"github.com/libopenstorage/openstorage/alerts"
-	"github.com/libopenstorage/openstorage/alerts/mock"
+	mockalerts "github.com/libopenstorage/openstorage/alerts/mock"
 	"github.com/libopenstorage/openstorage/api"
 	clustermanager "github.com/libopenstorage/openstorage/cluster/manager"
 	mockcluster "github.com/libopenstorage/openstorage/cluster/mock"
@@ -204,7 +204,7 @@ func TestSdkWithNoVolumeDriverThenAddOne(t *testing.T) {
 	})
 	cm, err := clustermanager.Inst()
 	go func() {
-		cm.Start(0, false, "9002")
+		cm.Start(false, "9002")
 	}()
 	defer cm.Shutdown()
 	if err := volumedrivers.Register("fake", map[string]string{}); err != nil {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -79,7 +79,7 @@ type ClusterInitState struct {
 // FinalizeInitCb is invoked when init is complete and is in the process of
 // updating the cluster database. This callback is invoked under lock and must
 // finish quickly, else it will slow down other node joins.
-type FinalizeInitCb func() error
+type FinalizeInitCb func(*ClusterInfo) error
 
 // ClusterListener is an interface to be implemented by a storage driver
 // if it is participating in a multi host environment.  It exposes events
@@ -176,6 +176,10 @@ type ClusterListenerNodeOps interface {
 
 	// Remove is called when a node leaves the cluster
 	Remove(node *api.Node, forceRemove bool) error
+
+	// CanNodeJoin checks with the listener if this node can join
+	// the cluster. This check is done under a cluster database lock
+	CanNodeJoin(node *api.Node, clusterInfo *ClusterInfo, nodeInitialized bool) error
 
 	// CanNodeRemove test to see if we can remove this node
 	CanNodeRemove(node *api.Node) (string, error)
@@ -305,10 +309,10 @@ type Cluster interface {
 	// nodeInitialized indicates if the caller of this method expects the node
 	// to have been in an already-initialized state.
 	// All managers will default returning NotSupported.
-	Start(clusterSize int, nodeInitialized bool, gossipPort string) error
+	Start(nodeInitialized bool, gossipPort string) error
 
 	// Like Start, but have the ability to pass in managers to the cluster object
-	StartWithConfiguration(clusterMaxSize int, nodeInitialized bool, gossipPort string, config *ClusterServerConfiguration) error
+	StartWithConfiguration(nodeInitialized bool, gossipPort string, config *ClusterServerConfiguration) error
 
 	// Get a unique identifier for this cluster. Depending on the implementation, this could
 	// be different than the _id_ from ClusterInfo. This id _must_ be unique across
@@ -387,6 +391,10 @@ func (nc *NullClusterListener) Remove(node *api.Node, forceRemove bool) error {
 
 func (nc *NullClusterListener) CanNodeRemove(node *api.Node) (string, error) {
 	return "", nil
+}
+
+func (nc *NullClusterListener) CanNodeJoin(node *api.Node, clusterInfo *ClusterInfo, nodeInitialized bool) error {
+	return nil
 }
 
 func (nc *NullClusterListener) MarkNodeDown(node *api.Node) error {

--- a/cluster/cluster_not_supported.go
+++ b/cluster/cluster_not_supported.go
@@ -97,12 +97,12 @@ func (m *NullClusterManager) Shutdown() error {
 }
 
 // Start
-func (m *NullClusterManager) Start(arg0 int, arg1 bool, arg2 string) error {
+func (m *NullClusterManager) Start(arg1 bool, arg2 string) error {
 	return ErrNotImplemented
 }
 
 // StartWithConfiguration
-func (m *NullClusterManager) StartWithConfiguration(arg0 int, arg1 bool, arg2 string, arg3 *ClusterServerConfiguration) error {
+func (m *NullClusterManager) StartWithConfiguration(arg1 bool, arg2 string, arg3 *ClusterServerConfiguration) error {
 	return ErrNotImplemented
 }
 

--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -103,7 +103,7 @@ func clusterInst() (cluster.Cluster, error) {
 	return inst, nil
 }
 
-type checkFunc func(cluster.ClusterInfo) error
+type checkFunc func(*cluster.ClusterInfo) error
 
 func ifaceToIp(iface *net.Interface) (string, error) {
 	addrs, err := iface.Addrs()
@@ -1025,7 +1025,6 @@ func (c *ClusterManager) quorumMember() bool {
 
 func (c *ClusterManager) initListeners(
 	db kvdb.Kvdb,
-	clusterMaxSize int,
 	nodeExists *bool,
 	nodeInitialized bool,
 ) (uint64, *cluster.ClusterInfo, error) {
@@ -1066,22 +1065,21 @@ func (c *ClusterManager) initListeners(
 		logrus.Infof("This node does not participates in quorum decisions")
 	}
 
-	initFunc := func(clusterInfo cluster.ClusterInfo) error {
-		numNodes := 0
-		for _, node := range clusterInfo.NodeEntries {
-			if node.Status != api.Status_STATUS_DECOMMISSION {
-				numNodes++
+	initFunc := func(clusterInfo *cluster.ClusterInfo) error {
+		// Irrespective of whether the node is doing an Init or is
+		// already in cluster, check with listeners if it is OK to join
+		// this cluster.
+		for e := c.listeners.Front(); e != nil; e = e.Next() {
+			err := e.Value.(cluster.ClusterListener).CanNodeJoin(&c.selfNode, clusterInfo, nodeInitialized)
+			if err != nil {
+				logrus.Errorf("Failed finalizing init: %s", err.Error())
+				return err
 			}
 		}
-		if clusterMaxSize > 0 && numNodes > clusterMaxSize {
-			return fmt.Errorf("Cluster is operating at maximum capacity "+
-				"(%v nodes). Please remove a node before attempting to "+
-				"add a new node.", clusterMaxSize)
-		}
-
 		// Finalize inits from subsystems under cluster db lock.
+		// finalizeCbs can be empty if this node is already initialized
 		for _, finalizeCb := range finalizeCbs {
-			if err := finalizeCb(); err != nil {
+			if err := finalizeCb(clusterInfo); err != nil {
 				logrus.Errorf("Failed finalizing init: %s", err.Error())
 				return err
 			}
@@ -1111,13 +1109,11 @@ func (c *ClusterManager) initListeners(
 
 func (c *ClusterManager) initializeAndStartHeartbeat(
 	kvdb kvdb.Kvdb,
-	clusterMaxSize int,
 	exist *bool,
 	nodeInitialized bool,
 ) (uint64, error) {
 	lastIndex, clusterInfo, err := c.initListeners(
 		kvdb,
-		clusterMaxSize,
 		exist,
 		nodeInitialized,
 	)
@@ -1157,19 +1153,16 @@ func (c *ClusterManager) setupManagers(config *cluster.ClusterServerConfiguratio
 
 // Start initiates the cluster manager and the cluster state machine
 func (c *ClusterManager) Start(
-	clusterMaxSize int,
 	nodeInitialized bool,
 	gossipPort string,
 ) error {
 	return c.StartWithConfiguration(
-		clusterMaxSize,
 		nodeInitialized,
 		gossipPort,
 		&cluster.ClusterServerConfiguration{})
 }
 
 func (c *ClusterManager) StartWithConfiguration(
-	clusterMaxSize int,
 	nodeInitialized bool,
 	gossipPort string,
 	config *cluster.ClusterServerConfiguration,
@@ -1232,7 +1225,6 @@ func (c *ClusterManager) StartWithConfiguration(
 	var exist bool
 	lastIndex, err := c.initializeAndStartHeartbeat(
 		kv,
-		clusterMaxSize,
 		&exist,
 		nodeInitialized,
 	)
@@ -1417,7 +1409,7 @@ func (c *ClusterManager) updateNodeEntryDB(
 	currentState.NodeEntries[nodeEntry.Id] = nodeEntry
 
 	if checkCbBeforeUpdate != nil {
-		err = checkCbBeforeUpdate(currentState)
+		err = checkCbBeforeUpdate(&currentState)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/cluster/manager/manager_test.go
+++ b/cluster/manager/manager_test.go
@@ -65,7 +65,7 @@ func TestUpdateSchedulerNodeName(t *testing.T) {
 		SchedulerNodeName: "old-sched-name",
 	})
 
-	err := inst.Start(1, false, "0")
+	err := inst.Start(false, "0")
 	assert.NoError(t, err)
 
 	node, err := inst.Inspect(nodeID)

--- a/cluster/mock/cluster.mock.go
+++ b/cluster/mock/cluster.mock.go
@@ -585,27 +585,27 @@ func (mr *MockClusterMockRecorder) Shutdown() *gomock.Call {
 }
 
 // Start mocks base method
-func (m *MockCluster) Start(arg0 int, arg1 bool, arg2 string) error {
-	ret := m.ctrl.Call(m, "Start", arg0, arg1, arg2)
+func (m *MockCluster) Start(arg0 bool, arg1 string) error {
+	ret := m.ctrl.Call(m, "Start", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Start indicates an expected call of Start
-func (mr *MockClusterMockRecorder) Start(arg0, arg1, arg2 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockCluster)(nil).Start), arg0, arg1, arg2)
+func (mr *MockClusterMockRecorder) Start(arg0, arg1 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockCluster)(nil).Start), arg0, arg1)
 }
 
 // StartWithConfiguration mocks base method
-func (m *MockCluster) StartWithConfiguration(arg0 int, arg1 bool, arg2 string, arg3 *cluster.ClusterServerConfiguration) error {
-	ret := m.ctrl.Call(m, "StartWithConfiguration", arg0, arg1, arg2, arg3)
+func (m *MockCluster) StartWithConfiguration(arg0 bool, arg1 string, arg2 *cluster.ClusterServerConfiguration) error {
+	ret := m.ctrl.Call(m, "StartWithConfiguration", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StartWithConfiguration indicates an expected call of StartWithConfiguration
-func (mr *MockClusterMockRecorder) StartWithConfiguration(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWithConfiguration", reflect.TypeOf((*MockCluster)(nil).StartWithConfiguration), arg0, arg1, arg2, arg3)
+func (mr *MockClusterMockRecorder) StartWithConfiguration(arg0, arg1, arg2 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWithConfiguration", reflect.TypeOf((*MockCluster)(nil).StartWithConfiguration), arg0, arg1, arg2)
 }
 
 // UpdateData mocks base method

--- a/cmd/osd/main.go
+++ b/cmd/osd/main.go
@@ -309,7 +309,6 @@ func start(c *cli.Context) error {
 			return fmt.Errorf("Unable to find cluster instance: %v", err)
 		}
 		if err := cm.StartWithConfiguration(
-			0,
 			false,
 			"9002",
 			&cluster.ClusterServerConfiguration{

--- a/csi/csisanity_test.go
+++ b/csi/csisanity_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/libopenstorage/openstorage/api"
 	clustermanager "github.com/libopenstorage/openstorage/cluster/manager"
 	"github.com/libopenstorage/openstorage/config"
-	"github.com/libopenstorage/openstorage/volume/drivers"
+	volumedrivers "github.com/libopenstorage/openstorage/volume/drivers"
 
 	"github.com/kubernetes-csi/csi-test/pkg/sanity"
 	"github.com/sirupsen/logrus"
@@ -48,7 +48,7 @@ func TestCSISanity(t *testing.T) {
 	})
 	cm, err := clustermanager.Inst()
 	go func() {
-		cm.Start(0, false, "9002")
+		cm.Start(false, "9002")
 	}()
 	defer cm.Shutdown()
 	if err := volumedrivers.Register("fake", map[string]string{}); err != nil {


### PR DESCRIPTION
- Let the Storage Listeners decide the maximum no. of nodes that can be
  added to the cluster.
- Add a new StorageListener API CanNodeJoin that gets invoked before joining a node
  to a cluster.

Signed-off-by: Aditya Dani <aditya@portworx.com>

