### PR TITLE
Cherry-pick of #1109

### DIFF
--- a/csi/csi_test.go
+++ b/csi/csi_test.go
@@ -273,7 +273,7 @@ func TestCSIServerStart(t *testing.T) {
 	// Verify
 	name := r.GetName()
 	version := r.GetVendorVersion()
-	assert.Equal(t, name, csiDriverNamePrefix+"mock")
+	assert.Equal(t, name, "mock.openstorage.org")
 	assert.Equal(t, version, csiDriverVersion)
 }
 

--- a/csi/identity.go
+++ b/csi/identity.go
@@ -17,13 +17,18 @@ limitations under the License.
 package csi
 
 import (
+	"fmt"
+
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"golang.org/x/net/context"
 )
 
 const (
-	csiDriverVersion    = "0.2.0"
-	csiDriverNamePrefix = "com.openstorage."
+	// CSI 1.1 compatible
+	csiDriverVersion = "1.1.0"
+
+	// https://tools.ietf.org/html/rfc1035#section-2.3.1
+	csiDriverNameFormat = "%s.openstorage.org"
 )
 
 // GetPluginCapabilities is a CSI API
@@ -59,7 +64,7 @@ func (s *OsdCsiServer) GetPluginInfo(
 	req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 
 	return &csi.GetPluginInfoResponse{
-		Name:          csiDriverNamePrefix + s.driver.Name(),
+		Name:          fmt.Sprintf(csiDriverNameFormat, s.driver.Name()),
 		VendorVersion: csiDriverVersion,
 
 		// As OSD CSI Driver matures, add here more information

--- a/csi/identity_test.go
+++ b/csi/identity_test.go
@@ -43,7 +43,7 @@ func TestNewCSIServerGetPluginInfo(t *testing.T) {
 	// Verify
 	name := r.GetName()
 	version := r.GetVendorVersion()
-	assert.Equal(t, name, csiDriverNamePrefix+"mock")
+	assert.Equal(t, name, "mock.openstorage.org")
 	assert.Equal(t, version, csiDriverVersion)
 
 	manifest := r.GetManifest()

--- a/csi/v0.3/csi_test.go
+++ b/csi/v0.3/csi_test.go
@@ -150,7 +150,7 @@ func TestCSIServerStart(t *testing.T) {
 	// Verify
 	name := r.GetName()
 	version := r.GetVendorVersion()
-	assert.Equal(t, name, csiDriverNamePrefix+"mock")
+	assert.Equal(t, name, "mock.openstorage.org")
 	assert.Equal(t, version, csiDriverVersion)
 }
 

--- a/csi/v0.3/identity.go
+++ b/csi/v0.3/identity.go
@@ -17,13 +17,18 @@ limitations under the License.
 package csi
 
 import (
+	"fmt"
+
 	csi "github.com/libopenstorage/openstorage/csi/v0.3/spec"
 	"golang.org/x/net/context"
 )
 
 const (
-	csiDriverVersion    = "0.2.0"
-	csiDriverNamePrefix = "com.openstorage."
+	// CSI 0.3 compatible
+	csiDriverVersion = "0.3.0"
+
+	// https://tools.ietf.org/html/rfc1035#section-2.3.1
+	csiDriverNameFormat = "%s.openstorage.org"
 )
 
 // GetPluginCapabilities is a CSI API
@@ -59,7 +64,7 @@ func (s *OsdCsiServer) GetPluginInfo(
 	req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 
 	return &csi.GetPluginInfoResponse{
-		Name:          csiDriverNamePrefix + s.driver.Name(),
+		Name:          fmt.Sprintf(csiDriverNameFormat, s.driver.Name()),
 		VendorVersion: csiDriverVersion,
 
 		// As OSD CSI Driver matures, add here more information

--- a/csi/v0.3/identity_test.go
+++ b/csi/v0.3/identity_test.go
@@ -43,7 +43,7 @@ func TestNewCSIServerGetPluginInfo(t *testing.T) {
 	// Verify
 	name := r.GetName()
 	version := r.GetVendorVersion()
-	assert.Equal(t, name, csiDriverNamePrefix+"mock")
+	assert.Equal(t, name, "mock.openstorage.org")
 	assert.Equal(t, version, csiDriverVersion)
 
 	manifest := r.GetManifest()


### PR DESCRIPTION
According to the CSI spec it needs to follow
https://tools.ietf.org/html/rfc1035#section-2.3.1 so, or current name of
"com.openstorage.pxd" should instead be "pxd.openstorage.org" (com to
org changed also because we own openstorage.org not openstorage.com)

