### PR TITLE
Fix a memory leak in pkg/grpcserver.Connect API.

### DIFF
--- a/pkg/grpcserver/grpcutil.go
+++ b/pkg/grpcserver/grpcutil.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/util/metautils"
 	"github.com/libopenstorage/openstorage/pkg/util"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/metadata"
@@ -54,6 +55,10 @@ func Connect(address string, dialOptions []grpc.DialOption) (*grpc.ClientConn, e
 		}
 		return true, nil
 	}); err != nil {
+		// Clean up the connection
+		if err := conn.Close(); err != nil {
+			logrus.Warnf("Failed to close connection to %v: %v", address, err)
+		}
 		return nil, fmt.Errorf("Connection timed out")
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- If the Connect API, is called for an incorrect grpc endpoint
  then the connection never changes to Ready state and the function
  returns a timeout error. However the conn object is never cleaned up.


