### PR TITLE
Allow caller to override the CSI driver name

### DIFF
--- a/csi/csi.go
+++ b/csi/csi.go
@@ -41,6 +41,10 @@ type OsdCsiServerConfig struct {
 	DriverName string
 	Cluster    cluster.Cluster
 	SdkUds     string
+
+	// Name to be reported back to the CO. If not provided,
+	// the name will be in the format of <driver>.openstorage.org
+	CsiDriverName string
 }
 
 // OsdCsiServer is a OSD CSI compliant server which
@@ -51,12 +55,13 @@ type OsdCsiServer struct {
 	csi.IdentityServer
 
 	*grpcserver.GrpcServer
-	specHandler spec.SpecHandler
-	driver      volume.VolumeDriver
-	cluster     cluster.Cluster
-	sdkUds      string
-	conn        *grpc.ClientConn
-	mu          sync.Mutex
+	specHandler   spec.SpecHandler
+	driver        volume.VolumeDriver
+	cluster       cluster.Cluster
+	sdkUds        string
+	conn          *grpc.ClientConn
+	mu            sync.Mutex
+	csiDriverName string
 }
 
 // NewOsdCsiServer creates a gRPC CSI complient server on the
@@ -88,11 +93,12 @@ func NewOsdCsiServer(config *OsdCsiServerConfig) (grpcserver.Server, error) {
 	}
 
 	return &OsdCsiServer{
-		specHandler: spec.NewSpecHandler(),
-		GrpcServer:  gServer,
-		driver:      d,
-		cluster:     config.Cluster,
-		sdkUds:      config.SdkUds,
+		specHandler:   spec.NewSpecHandler(),
+		GrpcServer:    gServer,
+		driver:        d,
+		cluster:       config.Cluster,
+		sdkUds:        config.SdkUds,
+		csiDriverName: config.CsiDriverName,
 	}, nil
 }
 

--- a/csi/csi_test.go
+++ b/csi/csi_test.go
@@ -131,12 +131,25 @@ func setupMockDriver(tester *testServer, t *testing.T) {
 }
 
 func newTestServer(t *testing.T) *testServer {
+	return newTestServerWithConfig(t, &OsdCsiServerConfig{
+		DriverName: mockDriverName,
+		Net:        "tcp",
+		Address:    "127.0.0.1:0",
+		SdkUds:     testSdkSock,
+	})
+}
+
+func newTestServerWithConfig(t *testing.T, config *OsdCsiServerConfig) *testServer {
 	tester := &testServer{}
 
 	// Add driver to registry
 	tester.mc = gomock.NewController(&utils.SafeGoroutineTester{})
 	tester.m = mockdriver.NewMockVolumeDriver(tester.mc)
 	tester.c = mockcluster.NewMockCluster(tester.mc)
+
+	if config.Cluster == nil {
+		config.Cluster = tester.c
+	}
 
 	setupMockDriver(tester, t)
 
@@ -147,13 +160,7 @@ func newTestServer(t *testing.T) *testServer {
 	assert.NoError(t, err)
 
 	// Setup simple driver
-	tester.server, err = NewOsdCsiServer(&OsdCsiServerConfig{
-		DriverName: mockDriverName,
-		Net:        "tcp",
-		Address:    "127.0.0.1:0",
-		Cluster:    tester.c,
-		SdkUds:     testSdkSock,
-	})
+	tester.server, err = NewOsdCsiServer(config)
 	assert.Nil(t, err)
 	err = tester.server.Start()
 	assert.Nil(t, err)

--- a/csi/identity.go
+++ b/csi/identity.go
@@ -70,8 +70,15 @@ func (s *OsdCsiServer) GetPluginInfo(
 	ctx context.Context,
 	req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 
+	var name string
+	if len(s.csiDriverName) != 0 {
+		name = s.csiDriverName
+	} else {
+		name = fmt.Sprintf(csiDriverNameFormat, s.driver.Name())
+	}
+
 	return &csi.GetPluginInfoResponse{
-		Name:          fmt.Sprintf(csiDriverNameFormat, s.driver.Name()),
+		Name:          name,
 		VendorVersion: csiDriverVersion,
 
 		// As OSD CSI Driver matures, add here more information

--- a/csi/identity_test.go
+++ b/csi/identity_test.go
@@ -50,3 +50,30 @@ func TestNewCSIServerGetPluginInfo(t *testing.T) {
 	assert.Len(t, manifest, 1)
 	assert.Equal(t, manifest["driver"], "mock")
 }
+
+func TestNewCSIServerGetPluginInfoWithOverrideName(t *testing.T) {
+
+	// Create server and client connection
+	s := newTestServerWithConfig(t, &OsdCsiServerConfig{
+		DriverName:    mockDriverName,
+		Net:           "tcp",
+		Address:       "127.0.0.1:0",
+		SdkUds:        testSdkSock,
+		CsiDriverName: "override",
+	})
+	defer s.Stop()
+
+	// Setup mock
+	s.MockDriver().EXPECT().Name().Return("mock").Times(1)
+
+	// Setup client
+	c := csi.NewIdentityClient(s.Conn())
+
+	// Get info
+	r, err := c.GetPluginInfo(context.Background(), &csi.GetPluginInfoRequest{})
+	assert.NoError(t, err)
+
+	// Verify
+	name := r.GetName()
+	assert.Equal(t, name, "override")
+}

--- a/csi/v0.3/csi.go
+++ b/csi/v0.3/csi.go
@@ -36,6 +36,10 @@ type OsdCsiServerConfig struct {
 	Address    string
 	DriverName string
 	Cluster    cluster.Cluster
+
+	// Name to be reported back to the CO. If not provided,
+	// the name will be in the format of <driver>.openstorage.org
+	CsiDriverName string
 }
 
 // OsdCsiServer is a OSD CSI compliant server which
@@ -46,9 +50,10 @@ type OsdCsiServer struct {
 	csi.IdentityServer
 
 	*grpcserver.GrpcServer
-	specHandler spec.SpecHandler
-	driver      volume.VolumeDriver
-	cluster     cluster.Cluster
+	specHandler   spec.SpecHandler
+	driver        volume.VolumeDriver
+	cluster       cluster.Cluster
+	csiDriverName string
 }
 
 // NewOsdCsiServer creates a gRPC CSI complient server on the
@@ -76,10 +81,11 @@ func NewOsdCsiServer(config *OsdCsiServerConfig) (grpcserver.Server, error) {
 	}
 
 	return &OsdCsiServer{
-		specHandler: spec.NewSpecHandler(),
-		GrpcServer:  gServer,
-		driver:      d,
-		cluster:     config.Cluster,
+		specHandler:   spec.NewSpecHandler(),
+		GrpcServer:    gServer,
+		driver:        d,
+		cluster:       config.Cluster,
+		csiDriverName: config.CsiDriverName,
 	}, nil
 }
 

--- a/csi/v0.3/identity.go
+++ b/csi/v0.3/identity.go
@@ -63,8 +63,15 @@ func (s *OsdCsiServer) GetPluginInfo(
 	ctx context.Context,
 	req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 
+	var name string
+	if len(s.csiDriverName) != 0 {
+		name = s.csiDriverName
+	} else {
+		name = fmt.Sprintf(csiDriverNameFormat, s.driver.Name())
+	}
+
 	return &csi.GetPluginInfoResponse{
-		Name:          fmt.Sprintf(csiDriverNameFormat, s.driver.Name()),
+		Name:          name,
 		VendorVersion: csiDriverVersion,
 
 		// As OSD CSI Driver matures, add here more information


### PR DESCRIPTION
**What this PR does / why we need it**:

It may be necessary for the driver caller to use a different
name other than `<driver name>.openstorage.org`

For example, in Portworx we could use something like:

`csi.portworx.com`

