### PR TITLE
Fix role enumerate to return superstrings

### DIFF
--- a/pkg/role/sdkserviceapi.go
+++ b/pkg/role/sdkserviceapi.go
@@ -218,14 +218,14 @@ func (r *SdkRoleManager) Enumerate(
 	ctx context.Context,
 	req *api.SdkRoleEnumerateRequest,
 ) (*api.SdkRoleEnumerateResponse, error) {
-	keys, err := r.kv.Keys(rolePrefix, "/")
+	kvPairs, err := r.kv.Enumerate(rolePrefix + "/")
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Failed to access roles from database: %v", err)
 	}
 
-	names := make([]string, len(keys))
-	for i, key := range keys {
-		names[i] = strings.TrimPrefix(key, rolePrefix+"/")
+	var names []string
+	for _, kvPair := range kvPairs {
+		names = append(names, strings.TrimPrefix(kvPair.Key, rolePrefix+"/"))
 	}
 
 	return &api.SdkRoleEnumerateResponse{


### PR DESCRIPTION
**What this PR does / why we need it**:
- For some reason, kv.Keys only returns "1st-level" keys. This
does not include superstrings. i.e. if we made a role test.view,
test.view1, and test.view2, then only test.view would appear.
- Once test.view was deleted, test.view1 and test.view2 appear
as one is not a substring of the other.
- kv.Enumerate differs from kv.Keys, as it will return all keys and values.


