### PR TITLE
Provide pool and disk information in Node Inspect

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -207,6 +207,9 @@ type ClusterListenerNodeOps interface {
 
 	// Leave is called when this node leaves the cluster.
 	Leave(node *api.Node) error
+
+	// Inspect updates listener specific data like pool and disk information
+	Inspect(node *api.Node) error
 }
 
 // ClusterListenerCallbacks defines APIs that a listener can invoke
@@ -399,6 +402,10 @@ func (nc *NullClusterListener) CleanupInit(
 }
 
 func (nc *NullClusterListener) Enumerate(cluster api.Cluster) error {
+	return nil
+}
+
+func (nc *NullClusterListener) Inspect(node *api.Node) error {
 	return nil
 }
 

--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -272,7 +272,20 @@ func (c *ClusterManager) getNodeEntry(nodeID string, clustDBRef *cluster.Cluster
 func (c *ClusterManager) Inspect(nodeID string) (api.Node, error) {
 	c.nodeCacheLock.Lock()
 	defer c.nodeCacheLock.Unlock()
-	return c.getNodeEntry(nodeID, &cluster.ClusterInfo{})
+	nodeState, err := c.getNodeEntry(nodeID, &cluster.ClusterInfo{})
+	if err != nil {
+		return nodeState, err
+	}
+
+	// Allow listeners to add/modify data
+	for e := c.listeners.Front(); e != nil; e = e.Next() {
+		if err := e.Value.(cluster.ClusterListener).Inspect(&nodeState); err != nil {
+			logrus.Warnf("listener %s inspect failed: %v",
+				e.Value.(cluster.ClusterListener).String(), err)
+			continue
+		}
+	}
+	return nodeState, nil
 }
 
 // AddEventListener adds a new listener


### PR DESCRIPTION
**What this PR does / why we need it**:
Node inspect call should go to a listener to update the node
status object if needed. This will allow the cluster listener
to update the node status with pool and disk information.

