### PR TITLE
In updateClusterStatus prepopulate the cache Node object from gossip info

### DIFF
--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -839,7 +839,17 @@ func (c *ClusterManager) updateClusterStatus() {
 
 			// Notify node status change if required.
 			peerNodeInCache := api.Node{}
+			if gossipNodeInfo.Value != nil {
+				peerNodeInGossip, ok := gossipNodeInfo.Value.(api.Node)
+				if ok {
+					// pre-populate the in cache object with the info
+					// we have from gossip
+					peerNodeInCache = peerNodeInGossip
+				}
+			}
 			peerNodeInCache.Id = string(id)
+
+			// overwrite the cache object with latest data
 			peerNodeInCache.Status = api.Status_STATUS_OK
 
 			// Initialize a no-op notify listeners function


### PR DESCRIPTION


Signed-off-by: Aditya Dani <aditya@portworx.com>


**What this PR does / why we need it**:

- Currently we create an empty Node object and only update the ID and status in it.
- Due to this the cluster listeners do not get other essential Node info such as IP etc
  from the cluster listener updates.
- This change will pre-populate a Node object from gossip if available or resort to creating
  an empty object as before.



