### PR TITLE
Fix api client request body length 0

### DIFF
--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -1,12 +1,20 @@
 package client
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/libopenstorage/openstorage/api"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+)
+
+var (
+	attemptLock sync.Mutex
 )
 
 func TestRetryClient(t *testing.T) {
@@ -16,6 +24,7 @@ func TestRetryClient(t *testing.T) {
 			count++
 			w.Header().Add("Retry-After", "5")
 			http.Error(w, "Unavailable", http.StatusServiceUnavailable)
+			return
 		}
 	}))
 
@@ -28,4 +37,52 @@ func TestRetryClient(t *testing.T) {
 	now := time.Now()
 	elapsed := now.Sub(start)
 	require.True(t, elapsed >= time.Duration(5*time.Second))
+}
+
+func TestRetryDDosClient(t *testing.T) {
+	attempts := 0
+	var wg sync.WaitGroup
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attemptLock.Lock()
+		defer attemptLock.Unlock()
+		attempts++
+		if attempts < 980 {
+			w.Header().Add("Retry-After", "1")
+			http.Error(w, "Unavailable", http.StatusServiceUnavailable)
+			return
+		}
+
+		var dcRes api.VolumeCreateResponse
+		dcRes.VolumeResponse = &api.VolumeResponse{Error: ""}
+
+		json.NewEncoder(w).Encode(&dcRes)
+	}))
+
+	defer ts.Close()
+	clnt, _ := NewClient(ts.URL, "pxd", "")
+
+	var outputErr error
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			outputErr = post(clnt)
+		}()
+	}
+
+	wg.Wait()
+
+	assert.NoError(t, outputErr)
+}
+
+func post(clnt *Client) error {
+	request := &api.VolumeCreateRequest{}
+	response := &api.VolumeCreateResponse{}
+	err := clnt.Post().Body(request).Do().Unmarshal(response)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/api/client/client_test.go
+++ b/api/client/client_test.go
@@ -13,10 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	attemptLock sync.Mutex
-)
-
 func TestRetryClient(t *testing.T) {
 	count := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -42,6 +38,7 @@ func TestRetryClient(t *testing.T) {
 func TestRetryDDosClient(t *testing.T) {
 	attempts := 0
 	var wg sync.WaitGroup
+	var attemptLock sync.Mutex
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		attemptLock.Lock()


### PR DESCRIPTION
Signed-off-by: Paul <paul@portworx.com>

**What this PR does / why we need it**:
Moving the creation of the request inside of the for-loop.
After doing some research on the web regarding
` http: ContentLength=xxx  with Body length 0`

It seems that all these issues happen when the request's body buffer has been read.
So we're now creating a new request for every retry and filling it with the body buffer from the original call. (this one has not been read)
