### PR TITLE
Support CSI Cloning

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -46,6 +46,15 @@ func (s *OsdCsiServer) ControllerGetCapabilities(
 	req *csi.ControllerGetCapabilitiesRequest,
 ) (*csi.ControllerGetCapabilitiesResponse, error) {
 
+	// Cloning: creation of volumes from snapshots, supported
+	capClone := &csi.ControllerServiceCapability{
+		Type: &csi.ControllerServiceCapability_Rpc{
+			Rpc: &csi.ControllerServiceCapability_RPC{
+				Type: csi.ControllerServiceCapability_RPC_CLONE_VOLUME,
+			},
+		},
+	}
+
 	// Creating and deleting volumes supported
 	capCreateDeleteVolume := &csi.ControllerServiceCapability{
 		Type: &csi.ControllerServiceCapability_Rpc{
@@ -75,6 +84,7 @@ func (s *OsdCsiServer) ControllerGetCapabilities(
 
 	return &csi.ControllerGetCapabilitiesResponse{
 		Capabilities: []*csi.ControllerServiceCapability{
+			capClone,
 			capCreateDeleteVolume,
 			capExpandVolume,
 			capCreateDeleteSnapshot,


### PR DESCRIPTION
**What this PR does / why we need it**:
The code to support volume cloning is in the CSI driver, but
it did not advertise that it supported it. This patch informs
the caller that the driver supports volume cloning.


Cloning support:

https://github.com/libopenstorage/openstorage/blob/8c189664c0d92099b83e6d97809074f522669fa1/csi/controller.go#L280-L288