### PR TITLE
Skip ownership checks for failed cloud restores. (#1174)

### DIFF
--- a/api/server/sdk/cloud_backup.go
+++ b/api/server/sdk/cloud_backup.go
@@ -264,6 +264,13 @@ func (s *CloudBackupServer) Status(
 	// Get volume id from task id
 	// remove the volumes that dont belong to caller
 	for key, sts := range r.Statuses {
+		// Allow failed restores to be seen by all
+		if sts.OpType == api.CloudRestoreOp &&
+			(sts.Status == api.CloudBackupStatusFailed ||
+				sts.Status == api.CloudBackupStatusAborted ||
+				sts.Status == api.CloudBackupStatusStopped) {
+			continue
+		}
 		if err := checkAccessFromDriverForVolumeId(ctx, s.driver(ctx), sts.SrcVolumeID, api.Ownership_Read); err != nil {
 			delete(r.Statuses, key)
 		}


### PR DESCRIPTION
Signed-off-by: veda <veda@portworx.com>

Failed restores may delete the destination volume, there by ownership checks
filter them out to all(including owner). This commit removes the check for
failed restores, so that they are visible to all including caller.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Cherry-pick from master
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

