### PR TITLE
Fix label match in enumerate

### DIFF
--- a/volume/drivers/common/default_store_enumerator.go
+++ b/volume/drivers/common/default_store_enumerator.go
@@ -177,8 +177,12 @@ func hasSubset(set map[string]string, subset map[string]string) bool {
 	if set == nil {
 		return false
 	}
-	for k := range subset {
-		if _, ok := set[k]; !ok {
+	for k, subv := range subset {
+		if v, ok := set[k]; ok {
+			if v != subv {
+				return false
+			}
+		} else {
 			return false
 		}
 	}

--- a/volume/drivers/common/default_store_enumerator_test.go
+++ b/volume/drivers/common/default_store_enumerator_test.go
@@ -69,6 +69,12 @@ func TestEnumerate(t *testing.T) {
 	assert.NoError(t, err, "Failed in Enumerate")
 	assert.Equal(t, 0, len(volumes), "Number of volumes returned in enumerate should be 1")
 
+	volumes, err = testEnumerator.Enumerate(&api.VolumeLocator{VolumeLabels: map[string]string{
+		"Foo": "ANOTHER VALUE",
+	}}, nil)
+	assert.NoError(t, err, "Failed in Enumerate")
+	assert.Equal(t, len(volumes), 0, "Number of volumes returned in enumerate should be 1")
+
 	volumes, err = testEnumerator.Enumerate(&api.VolumeLocator{VolumeLabels: testLabels}, nil)
 	assert.NoError(t, err, "Failed in Enumerate")
 	assert.Equal(t, len(volumes), 1, "Number of volumes returned in enumerate should be 1")


### PR DESCRIPTION
**What this PR does / why we need it**:
The default enumerator has a bug where it only checked the keys not the values.

