### PR TITLE
Cloud Restores to avoid InternalErr for ErrExists (#1192)

### DIFF
--- a/api/server/sdk/cloud_backup.go
+++ b/api/server/sdk/cloud_backup.go
@@ -211,6 +211,9 @@ func (s *CloudBackupServer) Restore(
 		Name:              req.GetTaskId(),
 	})
 	if err != nil {
+		if err == volume.ErrExist {
+			return nil, status.Errorf(codes.AlreadyExists, "Restore task with this name already exists: %v", err)
+		}
 		return nil, status.Errorf(codes.Internal, "Failed to restore backup: %v", err)
 	}
 

--- a/api/server/sdk/cloud_backup_test.go
+++ b/api/server/sdk/cloud_backup_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/golang/protobuf/ptypes"
 	"github.com/libopenstorage/openstorage/api"
+	"github.com/libopenstorage/openstorage/volume"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -206,6 +207,44 @@ func TestSdkCloudRestoreCreate(t *testing.T) {
 	r, err := c.Restore(context.Background(), req)
 	assert.Equal(t, r.GetRestoreVolumeId(), id)
 	assert.NoError(t, err)
+}
+
+func TestSdkCloudRestoreCreateErrorCheck(t *testing.T) {
+
+	// Create server and client connection
+	s := newTestServer(t)
+	defer s.Stop()
+
+	backupid := "backupid"
+	taskId := "restore-task"
+	uuid := "uuid"
+	req := &api.SdkCloudBackupRestoreRequest{
+		BackupId:     backupid,
+		CredentialId: uuid,
+		TaskId:       taskId,
+	}
+
+	// Create response
+	s.MockDriver().
+		EXPECT().
+		CloudBackupRestore(&api.CloudBackupRestoreRequest{
+			ID:             backupid,
+			CredentialUUID: uuid,
+			Name:           taskId,
+		}).
+		Return(nil, volume.ErrExist).
+		Times(1)
+	setupExpectedCredentialsPassing(s, uuid)
+
+	// Setup client
+	c := api.NewOpenStorageCloudBackupClient(s.Conn())
+
+	// Get info
+	_, err := c.Restore(context.Background(), req)
+	serverError, ok := status.FromError(err)
+	assert.True(t, ok)
+	assert.Equal(t, serverError.Code(), codes.AlreadyExists)
+	assert.Contains(t, serverError.Message(), "Restore task with this name already exists")
 }
 
 func TestSdkCloudBackupRestoreBadArguments(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: veda <veda@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

cherry-pick from master