### PR TITLE
Add remaining secrets providers for auth token_secret support

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -18,6 +18,7 @@ const (
 	Name                     = "name"
 	Token                    = "token"
 	TokenSecret              = "token_secret"
+	TokenSecretNamespace     = "token_secret_namespace"
 	SpecNodes                = "nodes"
 	SpecParent               = "parent"
 	SpecEphemeral            = "ephemeral"
@@ -1140,4 +1141,11 @@ func (m *VolumeStateAction) IsMount() bool {
 
 func (m *VolumeStateAction) IsUnMount() bool {
 	return m.GetMount() == VolumeActionParam_VOLUME_ACTION_PARAM_OFF
+}
+
+// TokenSecretContext contains all nessesary information to get a
+// token secret from any provider
+type TokenSecretContext struct {
+	SecretName      string
+	SecretNamespace string
 }

--- a/api/server/server.go
+++ b/api/server/server.go
@@ -105,7 +105,7 @@ func StartVolumePluginAPI(
 	authProviderType secrets.AuthTokenProviders,
 	authProvider osecrets.Secrets,
 ) error {
-	var secretsStore secrets.Auth
+	var secretsStore *secrets.Auth
 	var err error
 
 	// Only initialize secrets store if we have a valid auth provider.

--- a/api/spec/spec_handler_test.go
+++ b/api/spec/spec_handler_test.go
@@ -239,38 +239,47 @@ func TestGetTokenFromString(t *testing.T) {
 
 }
 
-func TestGetTokenSecretFromString(t *testing.T) {
+func TestGetTokenSecretContextFromString(t *testing.T) {
 	s := NewSpecHandler()
 
 	tt := []struct {
-		InputSecret    string
-		ExpectedSecret string
-		Successful     bool
+		InputName       string
+		ExpectedRequest api.TokenSecretContext
+		Successful      bool
 	}{
 		{
-			"/px/secrets/alpha/token1",
-			"px/secrets/alpha/token1",
+			"name=abcd,token_secret=/px/secrets/alpha/token1," +
+				"token_secret_namespace=ns2,abcd=sd,token_secret_public_data=y," +
+				"token_secret_custom_data=n",
+			api.TokenSecretContext{
+				SecretName:      "px/secrets/alpha/token1",
+				SecretNamespace: "ns2",
+			},
 			true,
 		}, {
-			"abcd/secrets/alpha//token1/",
-			"abcd/secrets/alpha//token1",
+			"name=abcd,token_secret=abcd/secrets/alpha//token1/",
+			api.TokenSecretContext{
+				SecretName:      "abcd/secrets/alpha//token1",
+				SecretNamespace: "",
+			},
 			true,
 		}, {
-			"simplekey",
-			"simplekey",
+			"name=abcd,token_secret=simplekey",
+			api.TokenSecretContext{
+				SecretName:      "simplekey",
+				SecretNamespace: "",
+			},
 			true,
 		},
 	}
 
 	for _, tc := range tt {
-		str := "name=abcd,token_secret=" + tc.InputSecret + ",token="
-		secretParsed, ok := s.GetTokenSecretFromString(str)
-		require.Equal(t, tc.ExpectedSecret, secretParsed)
-		require.Equal(t, ok, tc.Successful)
+		secretParsed, ok := s.GetTokenSecretContextFromString(tc.InputName)
+		require.Equal(t, tc.Successful, ok)
+		require.Equal(t, tc.ExpectedRequest, *secretParsed)
 	}
 
-	secretParsed, ok := s.GetTokenSecretFromString(fmt.Sprintf("toabcbn_secret=abcd"))
-	require.Equal(t, "", secretParsed)
-	require.Equal(t, ok, false)
+	_, ok := s.GetTokenSecretContextFromString(fmt.Sprintf("toabcbn_secret=abcd"))
+	require.Equal(t, false, ok)
 
 }

--- a/pkg/auth/secrets/secrets_test.go
+++ b/pkg/auth/secrets/secrets_test.go
@@ -4,116 +4,178 @@ import (
 	"testing"
 
 	gomock "github.com/golang/mock/gomock"
+	"github.com/libopenstorage/openstorage/api"
 	"github.com/libopenstorage/secrets"
-	"github.com/libopenstorage/secrets/k8s"
 	"github.com/libopenstorage/secrets/mock"
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewAuthOnError(t *testing.T) {
+func TestNewAuth(t *testing.T) {
 	a, err := NewAuth(TypeK8s, nil)
 	require.EqualError(t, ErrSecretsNotInitialized, err.Error(), "Expected an error on NewAuth")
 	require.Nil(t, a, "Expected auth object to be nil")
 
 	secretsInstance, _ := getSecretsMock(t)
-	a, err = NewAuth(5, secretsInstance)
+	a, err = NewAuth(111, secretsInstance)
 	require.Error(t, err, "Expected an error on NewAuth")
 	require.Nil(t, a, "Expected auth object to be nil")
 }
 
-func TestK8sGetToken(t *testing.T) {
-	s, mockSecret := getSecretsMock(t)
-	a, err := NewAuth(TypeK8s, s)
-	require.NoError(t, err, "Expected no error on auth")
-	name := "secret-name"
-	namespace := "ns"
-	token := "auth-token"
-	mockSecret.EXPECT().
-		GetSecret(
-			name,
-			map[string]string{
-				k8s.SecretNamespace: namespace,
-			}).
-		Return(map[string]interface{}{SecretTokenKey: token}, nil).
-		Times(1)
-	gotToken, err := a.GetToken(name, namespace)
-	require.NoError(t, err, "Unexpected error on GetToken")
-	require.Equal(t, gotToken, token, "Unexpected token returned")
-}
+func TestGetToken(t *testing.T) {
+	tt := []struct {
+		testName string
 
-func TestK8sGetTokenWithEmptyTokent(t *testing.T) {
-	s, mockSecret := getSecretsMock(t)
-	a, err := NewAuth(TypeK8s, s)
-	require.NoError(t, err, "Expected no error on auth")
-	name := "secret-name"
-	namespace := "ns"
-	mockSecret.EXPECT().
-		GetSecret(
-			name,
-			map[string]string{
-				k8s.SecretNamespace: namespace,
-			}).
-		Return(map[string]interface{}{}, nil).
-		Times(1)
-	_, err = a.GetToken(name, namespace)
-	require.EqualError(t, ErrAuthTokenNotFound, err.Error(), "Unexpected error on GetToken")
-}
+		secretType      AuthTokenProviders
+		secretName      string
+		secretNamespace string
+		token           string
+		publicData      bool
+		customData      bool
 
-func TestDCOSGetToken(t *testing.T) {
-	s, mockSecret := getSecretsMock(t)
-	a, err := NewAuth(TypeDCOS, s)
-	require.NoError(t, err, "Expected no error on auth")
-	name := "secret-name"
-	namespace := "ns"
-	token := "auth-token"
-	key := namespace + "/" + name
-	mockSecret.EXPECT().
-		GetSecret(
-			key,
-			nil,
-		).
-		Return(map[string]interface{}{key: token}, nil).
-		Times(1)
-	gotToken, err := a.GetToken(name, namespace)
-	require.NoError(t, err, "Unexpected error on GetToken")
-	require.Equal(t, gotToken, token, "Unexpected token returned")
-}
+		expectError   bool
+		expectedError string
+		expectedToken string
+	}{
+		{
+			testName: "k8s get token",
 
-func TestDCOSGetTokenWithNoNamespace(t *testing.T) {
-	s, mockSecret := getSecretsMock(t)
-	a, err := NewAuth(TypeDCOS, s)
-	require.NoError(t, err, "Expected no error on auth")
-	name := "secret-name"
-	token := "auth-token"
-	key := name
-	mockSecret.EXPECT().
-		GetSecret(
-			key,
-			nil,
-		).
-		Return(map[string]interface{}{key: token}, nil).
-		Times(1)
-	gotToken, err := a.GetToken(name, "")
-	require.NoError(t, err, "Unexpected error on GetToken")
-	require.Equal(t, gotToken, token, "Unexpected token returned")
-}
+			secretType:      TypeK8s,
+			secretName:      "secret-name-k8s",
+			secretNamespace: "ns",
+			token:           "auth-token",
 
-func TestDCOSGetTokenWithEmptyToken(t *testing.T) {
-	s, mockSecret := getSecretsMock(t)
-	a, err := NewAuth(TypeDCOS, s)
-	require.NoError(t, err, "Expected no error on auth")
-	name := "secret-name"
-	namespace := "ns"
-	key := namespace + "/" + name
-	mockSecret.EXPECT().
-		GetSecret(
-			key,
-			nil,
-		).
-		Return(map[string]interface{}{}, nil).
-		Times(1)
-	_, err = a.GetToken(name, namespace)
-	require.EqualError(t, ErrAuthTokenNotFound, err.Error(), "Unexpected error on GetToken")
+			expectError: false,
+		},
+		{
+			testName: "k8s empty token",
+
+			secretType:      TypeK8s,
+			secretName:      "secret-name-k8s-empty",
+			secretNamespace: "ns",
+			token:           "",
+
+			expectError:   true,
+			expectedError: ErrAuthTokenNotFound.Error(),
+		},
+		{
+			testName: "dcos get token",
+
+			secretType:      TypeDCOS,
+			secretName:      "secret-name-dcos",
+			secretNamespace: "ns",
+			token:           "auth-token",
+
+			expectError:   false,
+			expectedToken: "ns/secret-name-dcos",
+		},
+		{
+			testName: "dcos empty token",
+
+			secretType:      TypeDCOS,
+			secretName:      "secret-name-dcos-empty",
+			secretNamespace: "ns",
+			token:           "",
+
+			expectError:   true,
+			expectedError: ErrAuthTokenNotFound.Error(),
+		},
+		{
+			testName: "dcos empty namespace",
+
+			secretType:      TypeDCOS,
+			secretName:      "secret-name-dcos-no-ns",
+			secretNamespace: "",
+			token:           "abcd",
+
+			expectError: false,
+		},
+		{
+			testName: "vault get token",
+
+			secretType: TypeVault,
+			secretName: "secret-name-vault",
+			token:      "auth-token",
+
+			expectError: false,
+		},
+		{
+			testName: "docker get token",
+
+			secretType: TypeDocker,
+			secretName: "secret-name-docker",
+			token:      "auth-token",
+
+			expectError: false,
+		},
+		{
+			testName: "kvdb get token",
+
+			secretType: TypeKVDB,
+			secretName: "secret-name-kvdb",
+			token:      "auth-token",
+
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tt {
+		secretContext := make(map[string]string)
+		if tc.secretNamespace != "" {
+			secretContext[SecretNamespaceKey] = tc.secretNamespace
+		}
+		if tc.publicData {
+			secretContext[secrets.PublicSecretData] = "true"
+		}
+		if tc.customData {
+			secretContext[secrets.CustomSecretData] = "true"
+		}
+		s, mockSecret := getSecretsMock(t)
+		a, err := NewAuth(tc.secretType, s)
+		require.NoError(t, err, "Expected no error on auth")
+		expectedTokenResponse := make(map[string]interface{})
+		if !tc.expectError {
+			switch tc.secretType {
+			case TypeDCOS:
+				key := tc.secretName
+				if tc.secretNamespace != "" {
+					key = tc.secretNamespace + "/" + key
+				}
+				expectedTokenResponse[key] = tc.expectedToken
+			case TypeK8s:
+				expectedTokenResponse[SecretTokenKey] = tc.expectedToken
+			default:
+				expectedTokenResponse[SecretNameKey] = tc.expectedToken
+			}
+		}
+		mockSecret.EXPECT().
+			GetSecret(
+				gomock.Any(),
+				gomock.Any(),
+			).
+			Return(expectedTokenResponse, nil).
+			Times(1)
+
+		req := &api.TokenSecretContext{
+			SecretName:      tc.secretName,
+			SecretNamespace: tc.secretNamespace,
+		}
+		gotToken, err := a.GetToken(req)
+		if tc.expectError {
+			if err == nil {
+				t.Errorf("[%s]: Expected error on GetToken, but got nil", tc.testName)
+			}
+			if err != nil && err.Error() != tc.expectedError {
+				t.Errorf("[%s]: Expected error '%s' on GetToken, but got '%s'", tc.testName, err.Error(), tc.expectedError)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("[%s]: Expected no error on GetToken, but got '%s'", tc.testName, err.Error())
+			}
+			if gotToken != tc.expectedToken {
+				t.Errorf("[%s]: Expected token '%s' on GetToken, but got '%s'", tc.testName, tc.expectedToken, gotToken)
+			}
+		}
+	}
 }
 
 func getSecretsMock(t *testing.T) (secrets.Secrets, *mock.MockSecrets) {


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
* We need auth token support for the remaining secrets providers

**Which issue(s) this PR fixes** (optional)
Closes #1195

**Special notes for your reviewer**:
* I reworked `pkg/auth/secrets` to only use a single `Auth` struct, as the implementation for each cloud provider seemed very similar. For providers that have edge cases (DCOS/K8s), we handle those in `Auth.GetToken()`
* SecretPublicData and SecretCustomData are for supporting the various cloud secrets providers. I.e. these fields are required for GCloud and AWS to name a few.
* I changed `api/spec/spec_handler.go` to allow for these fields to be passed in and parsed. 
* There's potentially quite a bit of integration testing involved before we merge this. That said, if github.com/libopenstorage/secrets has already been tested then that should cover that work.
