### PR TITLE
SDK will now return a volume only if it is ready

### DIFF
--- a/api/server/sdk/sdk_test.go
+++ b/api/server/sdk/sdk_test.go
@@ -147,7 +147,7 @@ func newTestServer(t *testing.T) *testServer {
 func (s *testServer) setPorts() {
 	source := rand.NewSource(time.Now().UnixNano())
 	r := rand.New(source)
-	port := r.Intn(2999) + 8000
+	port := r.Intn(20000) + 10000
 
 	s.port = fmt.Sprintf("%d", port)
 	s.gwport = fmt.Sprintf("%d", port+1)

--- a/api/server/testutils_test.go
+++ b/api/server/testutils_test.go
@@ -291,7 +291,7 @@ func newTestServer(t *testing.T) *testServer {
 func (s *testServer) setPorts() {
 	source := rand.NewSource(time.Now().UnixNano())
 	r := rand.New(source)
-	port := r.Intn(2999) + 8000
+	port := r.Intn(20000) + 10000
 
 	s.port = fmt.Sprintf("%d", port)
 	s.gwport = fmt.Sprintf("%d", port+1)

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -859,6 +859,30 @@ func TestControllerCreateVolumeFoundByVolumeFromNameConflict(t *testing.T) {
 						Locator: &api.VolumeLocator{
 							Name: "size",
 						},
+						Status: api.VolumeStatus_VOLUME_STATUS_UP,
+						Spec: &api.VolumeSpec{
+
+							// Size is different
+							Size: 10,
+						},
+					}}, nil).
+					Times(1),
+
+				s.MockDriver().
+					EXPECT().
+					Inspect([]string{"size"}).
+					Return(nil, fmt.Errorf("not found")).
+					Times(1),
+
+				s.MockDriver().
+					EXPECT().
+					Enumerate(&api.VolumeLocator{Name: "size"}, nil).
+					Return([]*api.Volume{&api.Volume{
+						Id: "size",
+						Locator: &api.VolumeLocator{
+							Name: "size",
+						},
+						Status: api.VolumeStatus_VOLUME_STATUS_UP,
 						Spec: &api.VolumeSpec{
 
 							// Size is different
@@ -991,6 +1015,30 @@ func TestControllerCreateVolumeFoundByVolumeFromName(t *testing.T) {
 					Locator: &api.VolumeLocator{
 						Name: name,
 					},
+					Status: api.VolumeStatus_VOLUME_STATUS_UP,
+					Spec: &api.VolumeSpec{
+						Size: uint64(size),
+					},
+				},
+			}, nil).
+			Times(1),
+
+		s.MockDriver().
+			EXPECT().
+			Inspect([]string{name}).
+			Return(nil, fmt.Errorf("not found")).
+			Times(1),
+
+		s.MockDriver().
+			EXPECT().
+			Enumerate(&api.VolumeLocator{Name: name}, nil).
+			Return([]*api.Volume{
+				&api.Volume{
+					Id: name,
+					Locator: &api.VolumeLocator{
+						Name: name,
+					},
+					Status: api.VolumeStatus_VOLUME_STATUS_UP,
 					Spec: &api.VolumeSpec{
 						Size: uint64(size),
 					},
@@ -1008,6 +1056,7 @@ func TestControllerCreateVolumeFoundByVolumeFromName(t *testing.T) {
 				Locator: &api.VolumeLocator{
 					Name: name,
 				},
+				Status: api.VolumeStatus_VOLUME_STATUS_UP,
 				Spec: &api.VolumeSpec{
 					Size: uint64(1234),
 				},

--- a/csi/csi_test.go
+++ b/csi/csi_test.go
@@ -232,7 +232,7 @@ func newTestServerWithConfig(t *testing.T, config *OsdCsiServerConfig) *testServ
 func (s *testServer) setPorts() {
 	source := rand.NewSource(time.Now().UnixNano())
 	r := rand.New(source)
-	port := r.Intn(2999) + 8000
+	port := r.Intn(20000) + 10000
 
 	s.port = fmt.Sprintf("%d", port)
 	s.gwport = fmt.Sprintf("%d", port+1)

--- a/pkg/util/wait.go
+++ b/pkg/util/wait.go
@@ -1,9 +1,55 @@
+/*
+Package sdk is the gRPC implementation of the SDK gRPC server
+Copyright 2018 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package util
 
 import (
-	"fmt"
+	"context"
 	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
+
+// WaitForWithContext waits for a function to complete work with a default timeout or
+// a deadline from the context if provided
+func WaitForWithContext(
+	ctx context.Context,
+	minTimeout, maxTimeout, defaultTimeout time.Duration,
+	period time.Duration,
+	f func() (bool, error),
+) error {
+	var timeout time.Duration
+
+	// Check if the caller provided a deadline
+	d, ok := ctx.Deadline()
+	if !ok {
+		timeout = defaultTimeout
+	} else {
+		timeout = d.Sub(time.Now())
+
+		// Determine if it is too short or too long
+		if timeout < minTimeout || timeout > minTimeout {
+			return status.Errorf(codes.InvalidArgument,
+				"Deadline must be between %v and %v; was: %v", minTimeout, maxTimeout, timeout)
+		}
+	}
+
+	return WaitFor(timeout, period, f)
+}
 
 // WaitFor() waits until f() returns false or err != nil
 // f() returns <wait as bool, or err>.
@@ -16,7 +62,7 @@ func WaitFor(timeout time.Duration, period time.Duration, f func() (bool, error)
 	for wait {
 		select {
 		case <-timeoutChan:
-			return fmt.Errorf("Timed out")
+			return status.Errorf(codes.DeadlineExceeded, "Timed out")
 		default:
 			wait, err = f()
 			if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
With this fix, any call creating a volume and noticing it already
exists now checks to make sure that the volume is UP and ready
before returning.

**Which issue(s) this PR fixes** (optional)
Closes #1180

**Special notes for your reviewer**:

* Updated the test port randomizer 
* Added a new wait call to `pkg/util` called `WaitForWithContext` which will automatically use the passed default value or the Deadline (WithTimeout) value passed in the context by the caller.