### PR TITLE
Deep inspect for volume set

### DIFF
--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -423,9 +423,9 @@ func (vd *volAPI) volumeSet(w http.ResponseWriter, r *http.Request) {
 
 	resVol, err2 := volumes.Inspect(ctx, &api.SdkVolumeInspectRequest{
 		VolumeId: volumeID,
-		Options: &api.VolumeInspectOptions{	
-			 Deep: true,
-			 },			 
+		Options: &api.VolumeInspectOptions{
+			Deep: true,
+		},
 	})
 	if err2 != nil {
 		resp.Volume = &api.Volume{}

--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -423,6 +423,9 @@ func (vd *volAPI) volumeSet(w http.ResponseWriter, r *http.Request) {
 
 	resVol, err2 := volumes.Inspect(ctx, &api.SdkVolumeInspectRequest{
 		VolumeId: volumeID,
+		Options: &api.VolumeInspectOptions{	
+			 Deep: true,
+			 },			 
 	})
 	if err2 != nil {
 		resp.Volume = &api.Volume{}


### PR DESCRIPTION
When attaching an encrypted volume the volume info SecureDevicePath was not being set.  A
deep inspect ensures this gets set.


