### PR TITLE
Do not mask post-attach inspect errors

### DIFF
--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -429,11 +429,19 @@ func (vd *volAPI) volumeSet(w http.ResponseWriter, r *http.Request) {
 	})
 	if err2 != nil {
 		resp.Volume = &api.Volume{}
+		if req.Action.IsAttach() {
+			resp.VolumeResponse = &api.VolumeResponse{
+				Error: responseStatus(err2),
+			}
+		}
 	} else {
 		resp.Volume = resVol.GetVolume()
 	}
-	resp.VolumeResponse = &api.VolumeResponse{
-		Error: responseStatus(err),
+	// Do not clear inspect err for attach
+	if err != nil {
+		resp.VolumeResponse = &api.VolumeResponse{
+			Error: responseStatus(err),
+		}
 	}
 	json.NewEncoder(w).Encode(resp)
 


### PR DESCRIPTION
Signed-off-by: veda <veda@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
During attach, avoid api client panic on post attach inspect failure as error is ignored and volume structure remains empty on that case.
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

