### PR TITLE
Fix to add PVC Metadata to VolumeLabels

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -334,9 +334,12 @@ func (s *OsdCsiServer) CreateVolume(
 	// Get PVC Metadata and add to locator.VolumeLabels
 	pvcMetadata, err := getPVCMetadata(req.GetParameters())
 	if err != nil {
-		for k, v := range pvcMetadata {
-			locator.VolumeLabels[k] = v
-		}
+		return nil, status.Errorf(
+			codes.Internal,
+			"Unable to get PVC Metadata: %v", err)
+	}
+	for k, v := range pvcMetadata {
+		locator.VolumeLabels[k] = v
 	}
 
 	// Get parent ID from request: snapshot or volume


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
* Adds PVC Metadata to VolumeLabels

**Which issue(s) this PR fixes** (optional)
Closes #1207

**Special notes for your reviewer**:

