### PR TITLE
[Cherry-pick] Add clusterConfig.HWType to selfNode when calling getCurrentNode

### DIFF
--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -380,7 +380,9 @@ func (c *ClusterManager) getCurrentState() *api.Node {
 
 	c.selfNode.Cpu, _, _ = c.system.CpuUsage()
 	c.selfNode.MemTotal, c.selfNode.MemUsed, c.selfNode.MemFree = c.system.MemUsage()
-
+	if c.selfNode.HWType == api.HardwareType_UnknownMachine {
+		c.selfNode.HWType = c.config.HWType
+	}
 	c.selfNode.Timestamp = time.Now()
 
 	for e := c.listeners.Front(); e != nil; e = e.Next() {


### PR DESCRIPTION
When calling Inspect() or GetData() on ClusterConfig the NodeMap returned from the
Nodeentries in the KV store did not have HWType. This was causing the HWType for all the
nodes to be Unknown thus messing up the identification of the nodes underlying HW.

Signed-off-by: Tapas Sharma <tapas@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

