### PR TITLE
CSI: Add req.Secrets encryption info to locator.VolumeLabels

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -332,6 +332,7 @@ func (s *OsdCsiServer) CreateVolume(
 	}
 
 	// Get PVC Metadata and add to locator.VolumeLabels
+	// This will override any storage class secrets added above.
 	pvcMetadata, err := getPVCMetadata(req.GetParameters())
 	if err != nil {
 		return nil, status.Errorf(
@@ -341,6 +342,9 @@ func (s *OsdCsiServer) CreateVolume(
 	for k, v := range pvcMetadata {
 		locator.VolumeLabels[k] = v
 	}
+
+	// Add encryption secret information to VolumeLabels
+	locator.VolumeLabels = s.addEncryptionInfoToLabels(locator.VolumeLabels, req.GetSecrets())
 
 	// Get parent ID from request: snapshot or volume
 	if req.GetVolumeContentSource() != nil {

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -1438,10 +1438,16 @@ func TestControllerCreateVolume(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
+	secretKeyForLabels := "key123"
+	secretValForLabels := "val123"
 
 	// Setup request
 	name := "myvol"
 	size := int64(1234)
+	secretsMap := map[string]string{
+		authsecrets.SecretTokenKey: systemUserToken,
+		secretKeyForLabels:         secretValForLabels,
+	}
 	req := &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
@@ -1450,7 +1456,7 @@ func TestControllerCreateVolume(t *testing.T) {
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: size,
 		},
-		Secrets: map[string]string{authsecrets.SecretTokenKey: systemUserToken},
+		Secrets: secretsMap,
 	}
 
 	// Setup mock functions
@@ -1483,7 +1489,8 @@ func TestControllerCreateVolume(t *testing.T) {
 				&api.Volume{
 					Id: id,
 					Locator: &api.VolumeLocator{
-						Name: name,
+						Name:         name,
+						VolumeLabels: secretsMap,
 					},
 					Spec: &api.VolumeSpec{
 						Size: uint64(size),

--- a/csi/csi_test.go
+++ b/csi/csi_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/libopenstorage/openstorage/config"
 	"github.com/libopenstorage/openstorage/pkg/auth"
 	"github.com/libopenstorage/openstorage/pkg/grpcserver"
+	"github.com/libopenstorage/openstorage/pkg/options"
 	"github.com/libopenstorage/openstorage/pkg/role"
 	"github.com/libopenstorage/openstorage/pkg/storagepolicy"
 	"github.com/libopenstorage/openstorage/volume"
@@ -381,4 +382,22 @@ func TestNewCSIServerBadParameters(t *testing.T) {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Unable to setup server")
 	os.Remove(tester.uds)
+}
+
+func TestAddEncryptionInfoToLabels(t *testing.T) {
+	s := OsdCsiServer{}
+
+	secrets := map[string]string{
+		options.OptionsSecret:        "secret",
+		options.OptionsSecretContext: "context",
+		options.OptionsSecretKey:     "key",
+	}
+	labels := map[string]string{
+		"test": "val",
+	}
+	labels = s.addEncryptionInfoToLabels(labels, secrets)
+
+	assert.Equal(t, labels[options.OptionsSecret], "secret")
+	assert.Equal(t, labels[options.OptionsSecretContext], "context")
+	assert.Equal(t, labels[options.OptionsSecretKey], "key")
 }

--- a/csi/node.go
+++ b/csi/node.go
@@ -97,6 +97,9 @@ func (s *OsdCsiServer) NodePublishVolume(
 			req.GetVolumeContext())
 	}
 
+	// Get volume encryption info from req.Secrets
+	driverOpts := s.addEncryptionInfoToLabels(make(map[string]string), req.GetSecrets())
+
 	// prepare for mount/attaching
 	mounts := api.NewOpenStorageMountAttachClient(conn)
 	opts := &api.SdkVolumeAttachOptions{
@@ -104,8 +107,9 @@ func (s *OsdCsiServer) NodePublishVolume(
 	}
 	if driverType == api.DriverType_DRIVER_TYPE_BLOCK {
 		if _, err = mounts.Attach(ctx, &api.SdkVolumeAttachRequest{
-			VolumeId: req.GetVolumeId(),
-			Options:  opts,
+			VolumeId:      req.GetVolumeId(),
+			Options:       opts,
+			DriverOptions: driverOpts,
 		}); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
* For CSI secrets compatibility, this adds all req.Secrets to locator.VolumeLabels.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

