### PR TITLE
Fix disk information in Node.Inspect

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -849,7 +849,10 @@ func (s *Node) ToStorageNode() *StorageNode {
 
 	node.Disks = make(map[string]*StorageResource)
 	for k, v := range s.Disks {
-		node.Disks[k] = &v
+		// need to take the address of a local variable and not of v
+		// since its address does not change
+		vv := v
+		node.Disks[k] = &vv
 	}
 
 	node.NodeLabels = make(map[string]string)

--- a/api/server/sdk/node_test.go
+++ b/api/server/sdk/node_test.go
@@ -211,10 +211,16 @@ func TestSdkNodeInspect(t *testing.T) {
 		Status:            api.Status_STATUS_MAX,
 		Disks: map[string]api.StorageResource{
 			"disk1": api.StorageResource{
-				Id:     "12345",
+				Id:     "disk1",
 				Path:   "mymount",
 				Medium: api.StorageMedium_STORAGE_MEDIUM_SSD,
 				Online: true,
+			},
+			"disk2": api.StorageResource{
+				Id:     "disk2",
+				Path:   "anothermount",
+				Medium: api.StorageMedium_STORAGE_MEDIUM_SSD,
+				Online: false,
 			},
 		},
 		Timestamp: time.Now(),
@@ -249,8 +255,9 @@ func TestSdkNodeInspect(t *testing.T) {
 	assert.Equal(t, rn.GetHWType(), node.HWType)
 
 	// Check Disk
-	assert.Len(t, rn.GetDisks(), 1)
+	assert.Len(t, rn.GetDisks(), 2)
 	assert.Equal(t, *rn.GetDisks()["disk1"], node.Disks["disk1"])
+	assert.Equal(t, *rn.GetDisks()["disk2"], node.Disks["disk2"])
 
 	// Check Labels
 	assert.Len(t, rn.GetNodeLabels(), 1)


### PR DESCRIPTION
The SDK Node.Inspect call was returning the same disk information
for all disks since the address of the value variable was not
changing.

Cherry-pick #1234
