### PR TITLE
Revert "CSI: Add req.Secrets to SDK calls for volume encryption (#1226)"

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -333,7 +333,6 @@ func (s *OsdCsiServer) CreateVolume(
 	}
 
 	// Get PVC Metadata and add to locator.VolumeLabels
-	// This will override any storage class secrets added above.
 	pvcMetadata, err := getPVCMetadata(req.GetParameters())
 	if err != nil {
 		return nil, status.Errorf(
@@ -343,9 +342,6 @@ func (s *OsdCsiServer) CreateVolume(
 	for k, v := range pvcMetadata {
 		locator.VolumeLabels[k] = v
 	}
-
-	// Add encryption secret information to VolumeLabels
-	locator.VolumeLabels = s.addEncryptionInfoToLabels(locator.VolumeLabels, req.GetSecrets())
 
 	// Get parent ID from request: snapshot or volume
 	if req.GetVolumeContentSource() != nil {

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -1521,16 +1521,10 @@ func TestControllerCreateVolume(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
-	secretKeyForLabels := "key123"
-	secretValForLabels := "val123"
 
 	// Setup request
 	name := "myvol"
 	size := int64(1234)
-	secretsMap := map[string]string{
-		authsecrets.SecretTokenKey: systemUserToken,
-		secretKeyForLabels:         secretValForLabels,
-	}
 	req := &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
@@ -1539,7 +1533,7 @@ func TestControllerCreateVolume(t *testing.T) {
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: size,
 		},
-		Secrets: secretsMap,
+		Secrets: map[string]string{authsecrets.SecretTokenKey: systemUserToken},
 	}
 
 	// Setup mock functions
@@ -1572,8 +1566,7 @@ func TestControllerCreateVolume(t *testing.T) {
 				&api.Volume{
 					Id: id,
 					Locator: &api.VolumeLocator{
-						Name:         name,
-						VolumeLabels: secretsMap,
+						Name: name,
 					},
 					Spec: &api.VolumeSpec{
 						Size: uint64(size),

--- a/csi/csi.go
+++ b/csi/csi.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
-	"github.com/libopenstorage/openstorage/pkg/options"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -126,33 +125,9 @@ func (s *OsdCsiServer) setupContextWithToken(ctx context.Context, csiSecrets map
 		md := metadata.New(map[string]string{
 			"authorization": "bearer " + token,
 		})
-
 		return metadata.NewOutgoingContext(ctx, md)
 	}
-
 	return ctx
-}
-
-// addEncryptionInfoToLabels adds the needed secret encryption
-// fields to locator.VolumeLabels.
-func (s *OsdCsiServer) addEncryptionInfoToLabels(labels, csiSecrets map[string]string) map[string]string {
-	if len(csiSecrets) == 0 {
-		return labels
-	}
-
-	if s, exists := csiSecrets[options.OptionsSecret]; exists {
-		labels[options.OptionsSecret] = s
-
-		if context, exists := csiSecrets[options.OptionsSecretContext]; exists {
-			labels[options.OptionsSecretContext] = context
-		}
-
-		if secretKey, exists := csiSecrets[options.OptionsSecretKey]; exists {
-			labels[options.OptionsSecretKey] = secretKey
-		}
-	}
-
-	return labels
 }
 
 // Start is used to start the server.

--- a/csi/csi_test.go
+++ b/csi/csi_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/libopenstorage/openstorage/config"
 	"github.com/libopenstorage/openstorage/pkg/auth"
 	"github.com/libopenstorage/openstorage/pkg/grpcserver"
-	"github.com/libopenstorage/openstorage/pkg/options"
 	"github.com/libopenstorage/openstorage/pkg/role"
 	"github.com/libopenstorage/openstorage/pkg/storagepolicy"
 	"github.com/libopenstorage/openstorage/volume"
@@ -365,22 +364,4 @@ func TestNewCSIServerBadParameters(t *testing.T) {
 	assert.Nil(t, s)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Unable to setup server")
-}
-
-func TestAddEncryptionInfoToLabels(t *testing.T) {
-	s := OsdCsiServer{}
-
-	secrets := map[string]string{
-		options.OptionsSecret:        "secret",
-		options.OptionsSecretContext: "context",
-		options.OptionsSecretKey:     "key",
-	}
-	labels := map[string]string{
-		"test": "val",
-	}
-	labels = s.addEncryptionInfoToLabels(labels, secrets)
-
-	assert.Equal(t, labels[options.OptionsSecret], "secret")
-	assert.Equal(t, labels[options.OptionsSecretContext], "context")
-	assert.Equal(t, labels[options.OptionsSecretKey], "key")
 }

--- a/csi/node.go
+++ b/csi/node.go
@@ -97,9 +97,6 @@ func (s *OsdCsiServer) NodePublishVolume(
 			req.GetVolumeContext())
 	}
 
-	// Get volume encryption info from req.Secrets
-	driverOpts := s.addEncryptionInfoToLabels(make(map[string]string), req.GetSecrets())
-
 	// prepare for mount/attaching
 	mounts := api.NewOpenStorageMountAttachClient(conn)
 	opts := &api.SdkVolumeAttachOptions{
@@ -107,9 +104,8 @@ func (s *OsdCsiServer) NodePublishVolume(
 	}
 	if driverType == api.DriverType_DRIVER_TYPE_BLOCK {
 		if _, err = mounts.Attach(ctx, &api.SdkVolumeAttachRequest{
-			VolumeId:      req.GetVolumeId(),
-			Options:       opts,
-			DriverOptions: driverOpts,
+			VolumeId: req.GetVolumeId(),
+			Options:  opts,
 		}); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Removing this from release-6.1 as it will only be in release-7.0

Reverts libopenstorage/openstorage#1236