### PR TITLE
Change volume migration to use Enumerate instead of Inspect

### DIFF
--- a/api/server/sdk/volume_migrate_test.go
+++ b/api/server/sdk/volume_migrate_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
@@ -46,7 +47,7 @@ func TestVolumeMigrate_StartVolumeSuccess(t *testing.T) {
 	}
 
 	s.MockDriver().EXPECT().
-		Inspect([]string{"Target"}).
+		Inspect(gomock.Any()).
 		Return([]*api.Volume{resp}, nil)
 
 	resp2 := &api.CloudMigrateStartResponse{
@@ -235,7 +236,7 @@ func TestVolumeMigrate_StartVolumeFailure(t *testing.T) {
 
 	// Inspect volumes to get their ownership
 	s.MockDriver().EXPECT().
-		Inspect([]string{"Target"}).
+		Inspect(gomock.Any()).
 		Return([]*api.Volume{resp}, nil)
 
 	s.MockDriver().EXPECT().
@@ -394,14 +395,6 @@ func TestVolumeMigrate_StatusSucess(t *testing.T) {
 		CloudMigrateStatus(&api.CloudMigrateStatusRequest{}).
 		Return(resp, nil)
 
-	inspectResp := &api.Volume{
-		Id: vId,
-	}
-	s.MockDriver().EXPECT().
-		Inspect([]string{vId}).
-		Return([]*api.Volume{inspectResp}, nil)
-
-	// Setup client
 	c := api.NewOpenStorageMigrateClient(s.Conn())
 	r, err := c.Status(context.Background(), req)
 	assert.NoError(t, err)


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
Volume migration is taking a while, stuck `filterStatusResponseForPermissions`.

This change makes volume migration use Enumerate over inspect, which should be more efficient.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

