### PR TITLE
Fix cloud migration status auth filtering

### DIFF
--- a/api/server/sdk/volume_migrate.go
+++ b/api/server/sdk/volume_migrate.go
@@ -252,7 +252,9 @@ func (s *VolumeServer) filterStatusResponseForPermissions(
 	filteredResp.Info = make(map[string]*api.CloudMigrateInfoList)
 	for clusterId, cluster := range resp.Info {
 		filteredCluster := api.CloudMigrateInfoList{}
-		filteredCluster.List = make([]*api.CloudMigrateInfo, 0)
+		if filteredCluster.List == nil {
+			filteredCluster.List = make([]*api.CloudMigrateInfo, 0)
+		}
 
 		for _, migrateInfo := range cluster.List {
 			if found := volAccessPermitted[migrateInfo.GetLocalVolumeId()]; found {


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
* Migration status was returning empty in an auth enabled cluster.
* Tested this fix and it's working as expected now.
