### PR TITLE
Automated cherry pick of #1280: Add support for ReadOnlyMany volume creation

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -531,7 +531,8 @@ func csiRequestsSharedVolume(req *csi.CreateVolumeRequest) bool {
 		// Check access mode is setup correctly
 		mode := cap.GetAccessMode().GetMode()
 		if mode == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER ||
-			mode == csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER {
+			mode == csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER ||
+			mode == csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY {
 			return true
 		}
 	}


### PR DESCRIPTION
Cherry pick of #1280 on release-6.1.

#1280: Add support for ReadOnlyMany volume creation

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.