### PR TITLE
update kvdb package.

### DIFF
--- a/alert/alert_kvdb_test.go
+++ b/alert/alert_kvdb_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/libopenstorage/openstorage/pkg/proto/time"
 	"github.com/portworx/kvdb"
 	"github.com/portworx/kvdb/mem"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,7 +44,7 @@ func TestAll(t *testing.T) {
 func setup(t *testing.T) {
 	kv := kvdb.Instance()
 	if kv == nil {
-		kv, err := kvdb.New(mem.Name, kvdbDomain+"/"+clusterName, []string{}, nil, logrus.Panicf)
+		kv, err := kvdb.New(mem.Name, kvdbDomain+"/"+clusterName, []string{}, nil, kvdb.LogFatalErrorCB)
 		if err != nil {
 			t.Fatalf("Failed to set default KV store : (%v): %v", mem.Name, err)
 		}

--- a/api/server/sdk/sdk_test.go
+++ b/api/server/sdk/sdk_test.go
@@ -100,7 +100,7 @@ func newTestServer(t *testing.T) *testServer {
 
 	setupMockDriver(tester, t)
 
-	kv, err := kvdb.New(mem.Name, "policy", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "policy", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 	// Init storage policy manager
 	_, err = policy.Init(kv)
@@ -251,7 +251,7 @@ func TestSdkGateway(t *testing.T) {
 }
 
 func TestSdkWithNoVolumeDriverThenAddOne(t *testing.T) {
-	kv, err := kvdb.New(mem.Name, "fake_test", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "fake_test", []string{}, nil, kvdb.LogFatalErrorCB)
 	if err != nil {
 		logrus.Panicf("Failed to initialize KVDB")
 	}

--- a/api/server/sdk/volume_ops_test.go
+++ b/api/server/sdk/volume_ops_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/kubernetes-csi/csi-test/utils"
-	"github.com/sirupsen/logrus"
 
 	"github.com/golang/mock/gomock"
 	"github.com/libopenstorage/openstorage/api"
@@ -40,7 +39,7 @@ import (
 )
 
 func init() {
-	kv, _ := kvdb.New(mem.Name, "policyvolopstest", []string{}, nil, logrus.Panicf)
+	kv, _ := kvdb.New(mem.Name, "policyvolopstest", []string{}, nil, kvdb.LogFatalErrorCB)
 	policy.Init(kv)
 }
 
@@ -1420,7 +1419,7 @@ func TestSdkVolumeCreateDefaultPolicyOwnership(t *testing.T) {
 	mc := gomock.NewController(&utils.SafeGoroutineTester{})
 	mv := mockdriver.NewMockVolumeDriver(mc)
 	mcluster := mockcluster.NewMockCluster(mc)
-	kv, err := kvdb.New(mem.Name, "policy", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "policy", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 
 	// Init storage policy manager
@@ -1650,7 +1649,7 @@ func TestSdkVolumeUpdatePolicyOwnership(t *testing.T) {
 	mv := mockdriver.NewMockVolumeDriver(mc)
 	mcluster := mockcluster.NewMockCluster(mc)
 
-	kv, err := kvdb.New(mem.Name, "policy", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "policy", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 
 	// Init storage policy manager

--- a/api/server/testutils_test.go
+++ b/api/server/testutils_test.go
@@ -106,7 +106,7 @@ func newTestCluster(t *testing.T) *testCluster {
 }
 
 func setupFakeDriver() {
-	kv, err := kvdb.New(mem.Name, "fake_test", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "fake_test", []string{}, nil, kvdb.LogFatalErrorCB)
 	if err != nil {
 		logrus.Panicf("Failed to initialize KVDB")
 	}
@@ -139,7 +139,7 @@ func newTestServerSdkNoAuth(t *testing.T) *testServer {
 	tester.c = mockcluster.NewMockCluster(tester.mc)
 	tester.s = mockapi.NewMockOpenStoragePoolServer(tester.mc)
 
-	kv, err := kvdb.New(mem.Name, "test", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "test", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 	stp, err := storagepolicy.Init(kv)
 	if err != nil {
@@ -195,7 +195,7 @@ func newTestServerSdk(t *testing.T) *testServer {
 	tester.s = mockapi.NewMockOpenStoragePoolServer(tester.mc)
 
 	// Create a role manager
-	kv, err := kvdb.New(mem.Name, "test", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "test", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 	rm, err := role.NewSdkRoleManager(kv)
 	assert.NoError(t, err)
@@ -336,7 +336,7 @@ func testRestServer(t *testing.T) (*httptest.Server, *testServer) {
 	ts := httptest.NewServer(router)
 	testVolDriver := newTestServer(t)
 	// Initialise storage policy manager
-	kv, err := kvdb.New(mem.Name, "policy", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "policy", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 	_, err = storagepolicy.Init(kv)
 

--- a/cluster/manager/manager_test.go
+++ b/cluster/manager/manager_test.go
@@ -40,7 +40,7 @@ var (
 
 func init() {
 	var err error
-	kv, err = kvdb.New(mem.Name, "manager_test/"+testClusterId, []string{}, nil, logrus.Panicf)
+	kv, err = kvdb.New(mem.Name, "manager_test/"+testClusterId, []string{}, nil, kvdb.LogFatalErrorCB)
 	if err != nil {
 		logrus.Panicf("Failed to initialize KVDB")
 	}

--- a/cmd/osd/main.go
+++ b/cmd/osd/main.go
@@ -320,7 +320,7 @@ func start(c *cli.Context) error {
 	scheme := u.Scheme
 	u.Scheme = "http"
 
-	kv, err := kvdb.New(scheme, "openstorage", []string{u.String()}, nil, logrus.Panicf)
+	kv, err := kvdb.New(scheme, "openstorage", []string{u.String()}, nil, kvdb.LogFatalErrorCB)
 	if err != nil {
 		return fmt.Errorf("Failed to initialize KVDB: %v (%v)\nSupported datastores: %v", scheme, err, datastores)
 	}

--- a/csi/csi_test.go
+++ b/csi/csi_test.go
@@ -81,7 +81,7 @@ type testServer struct {
 }
 
 func setupFakeDriver() {
-	kv, err := kvdb.New(mem.Name, "fake_test", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "fake_test", []string{}, nil, kvdb.LogFatalErrorCB)
 	if err != nil {
 		logrus.Panicf("Failed to initialize KVDB")
 	}
@@ -158,13 +158,13 @@ func newTestServerWithConfig(t *testing.T, config *OsdCsiServerConfig) *testServ
 	setupMockDriver(tester, t)
 
 	// Initialise storage policy manager
-	kv, err := kvdb.New(mem.Name, "policy", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "policy", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 	rm, err := role.NewSdkRoleManager(kv)
 	assert.NoError(t, err)
 
 	// Setup storage policy
-	kv, err = kvdb.New(mem.Name, "test", []string{}, nil, logrus.Panicf)
+	kv, err = kvdb.New(mem.Name, "test", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 	stp, err := storagepolicy.Init(kv)
 	if err != nil {

--- a/csi/csisanity_test.go
+++ b/csi/csisanity_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/libopenstorage/openstorage/pkg/storagepolicy"
 	"github.com/portworx/kvdb"
 	"github.com/portworx/kvdb/mem"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/kubernetes-csi/csi-test/pkg/sanity"
@@ -57,7 +56,7 @@ func TestCSISanity(t *testing.T) {
 	defer cm.Shutdown()
 
 	// Setup sdk server
-	kv, err := kvdb.New(mem.Name, "test", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "test", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 	stp, err := storagepolicy.Init(kv)
 	if err != nil {

--- a/csi/v0.3/csi_test.go
+++ b/csi/v0.3/csi_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/portworx/kvdb"
 	"github.com/portworx/kvdb/mem"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 
@@ -86,7 +85,7 @@ func newTestServerWithConfig(t *testing.T, config *OsdCsiServerConfig) *testServ
 
 	setupMockDriver(tester, t)
 	// Initialise storage policy manager
-	kv, err := kvdb.New(mem.Name, "policy", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "policy", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 	_, err = policy.Init(kv)
 

--- a/objectstore/fake.go
+++ b/objectstore/fake.go
@@ -37,7 +37,7 @@ type fakeObjectstoreMgr struct {
 func NewfakeObjectstore() *fakeObjectstoreMgr {
 	// This instance of the KVDB is Always in memory and created for each instance of the fake driver
 	// It is not necessary to run a single instance, and it helps tests create a new kvdb on each test
-	kv, err := kvdb.New(mem.Name, "fake_objectstore", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "fake_objectstore", []string{}, nil, kvdb.LogFatalErrorCB)
 	if err != nil {
 		logrus.Fatalf("Failed to create kv: %v", err)
 		return nil

--- a/pkg/dbg/log.go
+++ b/pkg/dbg/log.go
@@ -6,8 +6,19 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+func LogErrorAndPanicf(err error, format string, args ...interface{}) {
+	logrus.Errorf("LogErrorAndPanicf: error: %v", err)
+	panicf(format, args...)
+
+}
+
 // Panicf outputs error message, dumps threads and exits.
 func Panicf(format string, args ...interface{}) {
+	panicf(format, args...)
+}
+
+// Panicf outputs error message, dumps threads and exits.
+func panicf(format string, args ...interface{}) {
 	logrus.Warnf(format, args...)
 	err := DumpGoProfile()
 	if err != nil {

--- a/pkg/role/sdkserviceapi_test.go
+++ b/pkg/role/sdkserviceapi_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/portworx/kvdb"
 	"github.com/portworx/kvdb/mem"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/libopenstorage/openstorage/api"
@@ -106,7 +105,7 @@ func TestMatchRule(t *testing.T) {
 }
 
 func TestSdkRuleCreateBadArguments(t *testing.T) {
-	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 
 	s, err := NewSdkRoleManager(kv)
@@ -192,7 +191,7 @@ func TestSdkRuleCreateBadArguments(t *testing.T) {
 }
 
 func TestSdkRuleCreateCollisionSystemRole(t *testing.T) {
-	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 
 	s, err := NewSdkRoleManager(kv)
@@ -216,7 +215,7 @@ func TestSdkRuleCreateCollisionSystemRole(t *testing.T) {
 }
 
 func TestSdkRuleCreate(t *testing.T) {
-	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 
 	s, err := NewSdkRoleManager(kv)
@@ -267,7 +266,7 @@ func TestSdkRuleCreate(t *testing.T) {
 }
 
 func TestSdkRuleEnumerate(t *testing.T) {
-	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 
 	s, err := NewSdkRoleManager(kv)
@@ -299,7 +298,7 @@ func TestSdkRuleEnumerate(t *testing.T) {
 }
 
 func TestSdkRuleInspectBadArgument(t *testing.T) {
-	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 
 	s, err := NewSdkRoleManager(kv)
@@ -325,7 +324,7 @@ func TestSdkRuleInspectBadArgument(t *testing.T) {
 }
 
 func TestSdkRuleInspectDelete(t *testing.T) {
-	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 
 	s, err := NewSdkRoleManager(kv)
@@ -371,7 +370,7 @@ func TestSdkRuleInspectDelete(t *testing.T) {
 }
 
 func TestSdkRuleDeleteCollisionSystemRole(t *testing.T) {
-	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 
 	s, err := NewSdkRoleManager(kv)
@@ -392,7 +391,7 @@ func TestSdkRuleDeleteCollisionSystemRole(t *testing.T) {
 }
 
 func TestSdkRuleUpdateBadArguments(t *testing.T) {
-	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 
 	s, err := NewSdkRoleManager(kv)
@@ -446,7 +445,7 @@ func TestSdkRuleUpdateBadArguments(t *testing.T) {
 }
 
 func TestSdkRuleUpdateCollisionSystemRole(t *testing.T) {
-	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 
 	s, err := NewSdkRoleManager(kv)
@@ -470,7 +469,7 @@ func TestSdkRuleUpdateCollisionSystemRole(t *testing.T) {
 }
 
 func TestSdkRuleUpdate(t *testing.T) {
-	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 
 	s, err := NewSdkRoleManager(kv)
@@ -585,7 +584,7 @@ func TestSdkRoleVerifyRules(t *testing.T) {
 		},
 	}
 
-	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 
 	s, err := NewSdkRoleManager(kv)

--- a/pkg/storagepolicy/sdkstorage_policy_ownership_test.go
+++ b/pkg/storagepolicy/sdkstorage_policy_ownership_test.go
@@ -27,14 +27,13 @@ import (
 	"github.com/libopenstorage/openstorage/pkg/auth"
 	"github.com/portworx/kvdb"
 	"github.com/portworx/kvdb/mem"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 func TestVolSpecToSdkStoragePolicy(t *testing.T) {
-	kv, err := kvdb.New(mem.Name, "policy", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "policy", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 
 	m := jsonpb.Marshaler{OrigName: true}
@@ -83,7 +82,7 @@ func TestVolSpecToSdkStoragePolicy(t *testing.T) {
 	assert.Equal(t, resp.GetStoragePolicy().GetPolicy().GetSize(), volSpec.GetSize())
 }
 func TestSdkStoragePolicyDeleteWithOwnership(t *testing.T) {
-	kv, err := kvdb.New(mem.Name, "policy", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "policy", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 	_, err = Init(kv)
 

--- a/pkg/storagepolicy/sdkstoragepolicy_test.go
+++ b/pkg/storagepolicy/sdkstoragepolicy_test.go
@@ -29,7 +29,6 @@ import (
 
 	"github.com/portworx/kvdb"
 	"github.com/portworx/kvdb/mem"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,7 +37,7 @@ func TestPrefixWithName(t *testing.T) {
 }
 
 func TestSdkStoragePolicyCreate(t *testing.T) {
-	kv, err := kvdb.New(mem.Name, "policy", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "policy", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
 	_, err = Init(kv)
 

--- a/schedpolicy/fake.go
+++ b/schedpolicy/fake.go
@@ -34,7 +34,7 @@ type fakeSchedMgr struct {
 func NewFakeScheduler() *fakeSchedMgr {
 	// This instance of the KVDB is Always in memory and created for each instance of the fake driver
 	// It is not necessary to run a single instance, and it helps tests create a new kvdb on each test
-	kv, err := kvdb.New(mem.Name, "fake_sched", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "fake_sched", []string{}, nil, kvdb.LogFatalErrorCB)
 	if err != nil {
 		logrus.Fatalf("Failed to create kv: %v", err)
 		return nil

--- a/vendor/github.com/portworx/kvdb/Dockerfile.kvdb
+++ b/vendor/github.com/portworx/kvdb/Dockerfile.kvdb
@@ -20,7 +20,7 @@ RUN curl -s -L https://dl.google.com/go/go1.10.7.linux-amd64.tar.gz | tar -C /us
   mkdir -p /tmp/test-etcd && tar xzvf /tmp/etcd-v3.2.15-linux-amd64.tar.gz -C /tmp/test-etcd --strip-components=1 && cp /tmp/test-etcd/etcd /usr/local/bin  && \
   curl -s -L https://releases.hashicorp.com/consul/1.0.0/consul_1.0.0_linux_amd64.zip -o /tmp/consul.zip && \
   mkdir -p /tmp/test-consul && unzip /tmp/consul.zip -d /tmp/test-consul && cp /tmp/test-consul/consul /usr/local/bin/ && \
-  curl -s -L https://apache.org/dist/zookeeper/zookeeper-3.4.13/zookeeper-3.4.13.tar.gz -o /tmp/zookeeper-3.4.13.tar.gz && \
+  curl -s -L https://archive.apache.org/dist/zookeeper/zookeeper-3.4.13/zookeeper-3.4.13.tar.gz -o /tmp/zookeeper-3.4.13.tar.gz && \
   mkdir -p /tmp/test-zookeeper && tar -xvf /tmp/zookeeper-3.4.13.tar.gz -C /tmp/test-zookeeper --strip-components=1 && mkdir -p /data/zookeeper
 
 ENV PATH /usr/local/go/bin:/usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin

--- a/vendor/github.com/portworx/kvdb/common/common.go
+++ b/vendor/github.com/portworx/kvdb/common/common.go
@@ -84,7 +84,7 @@ func (b *BaseKvdb) LockTimedout(key string) {
 
 // lockTimedout function is invoked if lock is held past configured timeout.
 func (b *BaseKvdb) lockTimedout(key string) {
-	b.FatalCb("Lock %s hold timeout triggered", key)
+	b.FatalCb(kvdb.ErrLockHoldTimeoutTriggered, "Lock %s hold timeout triggered", key)
 }
 
 // SerializeAll Serializes all key value pairs to a byte array.

--- a/vendor/github.com/portworx/kvdb/etcd/common/common.go
+++ b/vendor/github.com/portworx/kvdb/etcd/common/common.go
@@ -47,10 +47,11 @@ type EtcdCommon interface {
 
 // EtcdLock combines Mutex and channel
 type EtcdLock struct {
-	Done     chan struct{}
-	Unlocked bool
-	Err      error
-	Tag      string
+	Done            chan struct{}
+	Unlocked        bool
+	Err             error
+	Tag             string
+	AcquisitionTime time.Time
 	sync.Mutex
 }
 

--- a/vendor/github.com/portworx/kvdb/etcd/v2/kv_etcd.go
+++ b/vendor/github.com/portworx/kvdb/etcd/v2/kv_etcd.go
@@ -397,6 +397,7 @@ func (kv *etcdKV) LockWithTimeout(
 		return nil, err
 	}
 	kvPair.TTL = int64(time.Duration(ttl) * time.Second)
+	lock.AcquisitionTime = time.Now()
 	kvPair.Lock = lock
 	go kv.refreshLock(kvPair, lockerID, lockHoldDuration)
 
@@ -584,10 +585,10 @@ func (kv *etcdKV) refreshLock(
 				)
 				currentRefresh = time.Now()
 				if err != nil {
-					kv.FatalCb(
-						"Error refreshing lock. [Key %v] [Err: %v]"+
+					kv.FatalCb(kvdb.ErrLockRefreshFailed,
+						"Error refreshing lock. [Key %v] [Err: %v] [Acquisition Time: %v]"+
 							" [Current Refresh: %v] [Previous Refresh: %v]",
-						keyString, err, currentRefresh, prevRefresh,
+						keyString, err, l.AcquisitionTime, currentRefresh, prevRefresh,
 					)
 					l.Err = err
 					l.Unlock()

--- a/vendor/github.com/portworx/kvdb/etcd/v3/kv_etcd.go
+++ b/vendor/github.com/portworx/kvdb/etcd/v3/kv_etcd.go
@@ -104,7 +104,7 @@ type etcdKV struct {
 	common.BaseKvdb
 	kvClient          *e.Client
 	authClient        e.Auth
-	maintenanceClient e.Maintenance
+	maintenanceClient *e.Client
 	domain            string
 	ec.EtcdCommon
 }
@@ -169,7 +169,7 @@ func New(
 		common.BaseKvdb{FatalCb: fatalErrorCb},
 		kvClient,
 		e.NewAuth(kvClient),
-		e.NewMaintenance(mClient),
+		mClient,
 		domain,
 		etcdCommon,
 	}, nil
@@ -528,7 +528,8 @@ func (et *etcdKV) CompareAndSet(
 			if kvPair.ModifiedIndex == kvp.ModifiedIndex {
 				// update did not succeed, retry
 				if i == (timeoutMaxRetry - 1) {
-					et.FatalCb("Too many server retries for CAS: %v", *kvp)
+					et.FatalCb(kvdb.ErrNoConnection, "Too many server retries for CAS: %v", *kvp)
+					return nil, txnErr
 				}
 				continue
 			} else if bytes.Compare(kvp.Value, kvPair.Value) == 0 {
@@ -601,7 +602,8 @@ func (et *etcdKV) CompareAndDelete(
 				return nil, txnErr
 			}
 			if i == (timeoutMaxRetry - 1) {
-				et.FatalCb("Too many server retries for CAD: %v", *kvp)
+				et.FatalCb(kvdb.ErrNoConnection, "Too many server retries for CAD: %v", *kvp)
+				return nil, txnErr
 			}
 			continue
 		}
@@ -687,7 +689,7 @@ func (et *etcdKV) LockWithTimeout(
 		return nil, err
 	}
 	kvPair.TTL = int64(ttl)
-	kvPair.Lock = &ec.EtcdLock{Done: make(chan struct{})}
+	kvPair.Lock = &ec.EtcdLock{Done: make(chan struct{}), AcquisitionTime: time.Now()}
 	go et.refreshLock(kvPair, lockerID, lockHoldDuration)
 	return kvPair, err
 }
@@ -700,10 +702,20 @@ func (et *etcdKV) Unlock(kvp *kvdb.KVPair) error {
 	l.Lock()
 	// Don't modify kvp here, CompareAndDelete does that.
 	_, err := et.CompareAndDelete(kvp, kvdb.KVFlags(0))
-	if err == nil {
+	connectionError := false
+	if err != nil {
+		connectionError, _ = isRetryNeeded(err, "Unlock", kvp.Key, 300)
+	}
+	if err == nil || connectionError {
 		l.Unlocked = true
+		closeChan := l.Err == nil
 		l.Unlock()
-		l.Done <- struct{}{}
+		// stopping lock refresh will automatically release
+		// the lock, so even if we have connection errors we don't
+		// need to report error.
+		if closeChan {
+			l.Done <- struct{}{}
+		}
 		return nil
 	}
 	l.Unlock()
@@ -872,11 +884,10 @@ func (et *etcdKV) refreshLock(
 				)
 				currentRefresh = time.Now()
 				if err != nil {
-					et.FatalCb(
-						"Error refreshing lock. [Tag %v] [Err: %v]"+
-							" [Current Refresh: %v] [Previous Refresh: %v]"+
-							" [Modified Index: %v]",
-						lockMsgString, err, currentRefresh, prevRefresh, kvPair.ModifiedIndex,
+					et.FatalCb(kvdb.ErrLockRefreshFailed,
+						"Error refreshing lock. [Tag %v] [Err: %v] [Acquisition Time: %v]"+
+							" [Current Refresh: %v] [Previous Refresh: %v] [Modified Index: %v]",
+						lockMsgString, err, l.AcquisitionTime, currentRefresh, prevRefresh, kvPair.ModifiedIndex,
 					)
 					l.Err = err
 					l.Unlock()
@@ -945,10 +956,13 @@ func (et *etcdKV) watchStart(
 				continue
 			}
 			if wresp.Canceled == true {
-				// Watch is canceled. Notify the watcher
-				logrus.Errorf("Watch on key %v cancelled. Error: %v", key,
+				logrus.Errorf("Watch on key %v cancelled. Error: %v %v", key,
 					wresp.Err())
-				watchQ.enqueue(key, nil, kvdb.ErrWatchStopped)
+				retError := kvdb.ErrWatchStopped
+				if strings.Contains(rpctypes.ErrGRPCCompacted.Error(), wresp.Err().Error()) {
+					retError = kvdb.ErrWatchRevisionCompacted
+				}
+				watchQ.enqueue(key, nil, retError)
 				return
 			} else {
 				for _, ev := range wresp.Events {
@@ -1374,6 +1388,7 @@ func (et *etcdKV) RemoveMember(
 	nodeName string,
 	nodeIP string,
 ) error {
+	fn := "RemoveMember"
 	ctx, cancel := et.MaintenanceContextWithLeader()
 	memberListResponse, err := et.kvClient.MemberList(ctx)
 	cancel()
@@ -1403,11 +1418,32 @@ func (et *etcdKV) RemoveMember(
 		}
 	}
 	et.kvClient.SetEndpoints(newClientUrls...)
-	ctx, cancel = et.MaintenanceContextWithLeader()
-	_, err = et.kvClient.MemberRemove(ctx, removeMemberID)
-	cancel()
-	if err != nil {
-		return err
+	et.maintenanceClient.SetEndpoints(newClientUrls...)
+	removeMemberRetries := 5
+	for i := 0; i < removeMemberRetries; i++ {
+		ctx, cancel = et.MaintenanceContextWithLeader()
+		_, err := et.kvClient.MemberRemove(ctx, removeMemberID)
+		cancel()
+
+		if err != nil {
+			// Check if the error is member not found
+			etcdErr, ok := err.(rpctypes.EtcdError)
+			if ok && etcdErr == rpctypes.ErrMemberNotFound {
+				return nil
+			}
+			// Check if we need to retry
+			retry, err := isRetryNeeded(err, fn, nodeName, i)
+			if !retry {
+				// For all others return immediately
+				return err
+			}
+			if i == (removeMemberRetries - 1) {
+				return fmt.Errorf("Too many retries for RemoveMember: %v %v", nodeName, nodeIP)
+			}
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		break
 	}
 	return nil
 }
@@ -1478,6 +1514,7 @@ func (et *etcdKV) Deserialize(b []byte) (kvdb.KVPairs, error) {
 
 func (et *etcdKV) SetEndpoints(endpoints []string) error {
 	et.kvClient.SetEndpoints(endpoints...)
+	et.maintenanceClient.SetEndpoints(endpoints...)
 	return nil
 }
 

--- a/vendor/github.com/portworx/kvdb/kvdb.go
+++ b/vendor/github.com/portworx/kvdb/kvdb.go
@@ -112,6 +112,8 @@ var (
 	ErrIllegal = errors.New("Illegal operation")
 	// ErrValueMismatch raised if existing KVDB value mismatches with user provided value
 	ErrValueMismatch = errors.New("Value mismatch")
+	// ErrEmptyValue raised if the value is empty
+	ErrEmptyValue = errors.New("Value cannot be empty")
 	// ErrModified raised during an atomic operation if the index does not match the one in the store
 	ErrModified = errors.New("Key Index mismatch")
 	// ErrSetTTLFailed raised if unable to set ttl value for a key create/put/update action
@@ -131,6 +133,14 @@ var (
 	// ErrMemberDoesNotExist returned when an operation fails for a member
 	// which does not exist
 	ErrMemberDoesNotExist = errors.New("Kvdb member does not exist")
+	// ErrWatchRevisionCompacted requested watch version has been compacted
+	ErrWatchRevisionCompacted = errors.New("Kvdb watch revision compacted")
+	// ErrLockRefreshFailed could not refresh lock key so exclusive access to lock may be lost
+	ErrLockRefreshFailed = errors.New("Failed to refresh lock")
+	// ErrLockHoldTimeoutTriggered triggers if lock is held beyond configured timeout
+	ErrLockHoldTimeoutTriggered = errors.New("Lock held beyond configured timeout")
+	// ErrNoConnection no connection to server
+	ErrNoConnection = errors.New("No server connection")
 )
 
 // KVAction specifies the action on a KV pair. This is useful to make decisions
@@ -149,7 +159,7 @@ type PermissionType int
 type WatchCB func(prefix string, opaque interface{}, kvp *KVPair, err error) error
 
 // FatalErrorCB callback is invoked incase of fatal errors
-type FatalErrorCB func(format string, args ...interface{})
+type FatalErrorCB func(err error, format string, args ...interface{})
 
 // DatastoreInit is called to activate a backend KV store.
 type DatastoreInit func(domain string, machines []string, options map[string]string,
@@ -387,4 +397,9 @@ type Controller interface {
 	// Defragment defrags the underlying database for the given endpoint
 	// with a timeout specified in seconds
 	Defragment(endpoint string, timeout int) error
+}
+
+func LogFatalErrorCB(err error, format string, args ...interface{}) {
+	logrus.Errorf("encountered fatal error: %v", err)
+	logrus.Panicf(format, args...)
 }

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -1725,46 +1725,46 @@
 			"revisionTime": "2016-01-10T10:55:54Z"
 		},
 		{
-			"checksumSHA1": "oBGNzW6ZhxLatxckBRRQz4u1C/k=",
+			"checksumSHA1": "Wmdxnz4Jvz5tYfJ0m1RK3vHBl9w=",
 			"path": "github.com/portworx/kvdb",
-			"revision": "2083b561383ee1a84e5b5db7ae3c703f0f57197c",
-			"revisionTime": "2019-02-06T21:41:16Z"
+			"revision": "33681441a0fd3f669c97c69e65579511b9019418",
+			"revisionTime": "2019-11-12T21:56:44Z"
 		},
 		{
-			"checksumSHA1": "rN1JFwq374WRZj615tVh6SlS/Ys=",
+			"checksumSHA1": "GYSqVGs+p56AaZQsk8HTw6w7paQ=",
 			"path": "github.com/portworx/kvdb/common",
-			"revision": "2083b561383ee1a84e5b5db7ae3c703f0f57197c",
-			"revisionTime": "2019-02-06T21:41:16Z"
+			"revision": "33681441a0fd3f669c97c69e65579511b9019418",
+			"revisionTime": "2019-11-12T21:56:44Z"
 		},
 		{
-			"checksumSHA1": "EosuVTtgW3M/OX7pgUemrURMYgs=",
+			"checksumSHA1": "az1Se1cWhDglHa1OJbhsFAnhvwA=",
 			"path": "github.com/portworx/kvdb/consul",
-			"revision": "2083b561383ee1a84e5b5db7ae3c703f0f57197c",
-			"revisionTime": "2019-02-06T21:41:16Z"
+			"revision": "33681441a0fd3f669c97c69e65579511b9019418",
+			"revisionTime": "2019-11-12T21:56:44Z"
 		},
 		{
-			"checksumSHA1": "ryXZRVSvinmVHB+Gkxi1tQmBW+s=",
+			"checksumSHA1": "qUVn3r8W8LP/98gTVP8RR/oCYhM=",
 			"path": "github.com/portworx/kvdb/etcd/common",
-			"revision": "2083b561383ee1a84e5b5db7ae3c703f0f57197c",
-			"revisionTime": "2019-02-06T21:41:16Z"
+			"revision": "33681441a0fd3f669c97c69e65579511b9019418",
+			"revisionTime": "2019-11-12T21:56:44Z"
 		},
 		{
-			"checksumSHA1": "fO8U1sXlukEF3V6Nv1WaH62CeKc=",
+			"checksumSHA1": "ndEnH8xgjEpPU+uXp7Wrzt28Ih0=",
 			"path": "github.com/portworx/kvdb/etcd/v2",
-			"revision": "2083b561383ee1a84e5b5db7ae3c703f0f57197c",
-			"revisionTime": "2019-02-06T21:41:16Z"
+			"revision": "33681441a0fd3f669c97c69e65579511b9019418",
+			"revisionTime": "2019-11-12T21:56:44Z"
 		},
 		{
-			"checksumSHA1": "56JvP2Cpc/bg9/8DgDALy/vk/90=",
+			"checksumSHA1": "On+c62XclkR7O3o2RGknY2wwZGU=",
 			"path": "github.com/portworx/kvdb/etcd/v3",
-			"revision": "2083b561383ee1a84e5b5db7ae3c703f0f57197c",
-			"revisionTime": "2019-02-06T21:41:16Z"
+			"revision": "33681441a0fd3f669c97c69e65579511b9019418",
+			"revisionTime": "2019-11-12T21:56:44Z"
 		},
 		{
 			"checksumSHA1": "0b6/oCPIwILHdZgdwNp5Y4SVT7g=",
 			"path": "github.com/portworx/kvdb/mem",
-			"revision": "2083b561383ee1a84e5b5db7ae3c703f0f57197c",
-			"revisionTime": "2019-02-06T21:41:16Z"
+			"revision": "33681441a0fd3f669c97c69e65579511b9019418",
+			"revisionTime": "2019-11-12T21:56:44Z"
 		},
 		{
 			"checksumSHA1": "yQHXOi/RDYa/8J/1980OPmJtUUE=",

--- a/volume/drivers/common/default_store_enumerator_test.go
+++ b/volume/drivers/common/default_store_enumerator_test.go
@@ -18,7 +18,7 @@ var (
 )
 
 func init() {
-	kv, err := kvdb.New(mem.Name, "driver_test", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "driver_test", []string{}, nil, kvdb.LogFatalErrorCB)
 	if err != nil {
 		logrus.Panicf("Failed to initialize KVDB")
 	}

--- a/volume/drivers/fake/fake.go
+++ b/volume/drivers/fake/fake.go
@@ -19,11 +19,8 @@ package fake
 import (
 	"encoding/json"
 	"fmt"
-	"time"
-
-	"github.com/sirupsen/logrus"
-
 	"strings"
+	"time"
 
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/libopenstorage/openstorage/api"
@@ -34,6 +31,7 @@ import (
 	"github.com/pborman/uuid"
 	"github.com/portworx/kvdb"
 	"github.com/portworx/kvdb/mem"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -82,7 +80,7 @@ func newFakeDriver(params map[string]string) (*driver, error) {
 
 	// This instance of the KVDB is Always in memory and created for each instance of the fake driver
 	// It is not necessary to run a single instance, and it helps tests create a new kvdb on each test
-	kv, err := kvdb.New(mem.Name, "fake_test", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "fake_test", []string{}, nil, kvdb.LogFatalErrorCB)
 	if err != nil {
 		return nil, err
 	}

--- a/volume/drivers/fake/fake_test.go
+++ b/volume/drivers/fake/fake_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func init() {
-	kv, err := kvdb.New(mem.Name, "fake_test", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "fake_test", []string{}, nil, kvdb.LogFatalErrorCB)
 	if err != nil {
 		logrus.Panicf("Failed to initialize KVDB")
 	}

--- a/volume/drivers/test/driver.go
+++ b/volume/drivers/test/driver.go
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	kv, err := kvdb.New(mem.Name, "driver_test", []string{}, nil, logrus.Panicf)
+	kv, err := kvdb.New(mem.Name, "driver_test", []string{}, nil, kvdb.LogFatalErrorCB)
 	if err != nil {
 		logrus.Panicf("Failed to intialize KVDB")
 	}


### PR DESCRIPTION
update kvdb package and fix the fatalCB - use the one provided in kvdb package (equivalent to logrus.Panicf). 

Signed-off-by: ganesh <ganesh@portworx.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

