### PR TITLE
Automated cherry pick of #1318: Switch all access checks to use Enumerate when auth is

### DIFF
--- a/api/server/sdk/cloud_backup_test.go
+++ b/api/server/sdk/cloud_backup_test.go
@@ -97,15 +97,6 @@ func TestSdkCloudBackupCreate(t *testing.T) {
 	// Create response
 	s.MockDriver().
 		EXPECT().
-		Inspect([]string{id}).
-		Return([]*api.Volume{
-			&api.Volume{
-				Id: id,
-			},
-		}, nil).
-		Times(2)
-	s.MockDriver().
-		EXPECT().
 		CloudBackupCreate(&api.CloudBackupCreateRequest{
 			VolumeID:       id,
 			CredentialUUID: uuid,
@@ -601,15 +592,6 @@ func TestSdkCloudBackupStatus(t *testing.T) {
 	// Create response
 	s.MockDriver().
 		EXPECT().
-		Inspect([]string{id}).
-		Return([]*api.Volume{
-			&api.Volume{
-				Id: id,
-			},
-		}, nil).
-		Times(3)
-	s.MockDriver().
-		EXPECT().
 		CloudBackupStatus(&api.CloudBackupStatusRequest{
 			SrcVolumeID: id,
 			Local:       false,
@@ -750,15 +732,6 @@ func TestSdkCloudBackupHistory(t *testing.T) {
 	// Create response
 	s.MockDriver().
 		EXPECT().
-		Inspect([]string{id}).
-		Return([]*api.Volume{
-			&api.Volume{
-				Id: id,
-			},
-		}, nil).
-		Times(1)
-	s.MockDriver().
-		EXPECT().
 		CloudBackupHistory(&api.CloudBackupHistoryRequest{
 			SrcVolumeID: id,
 		}).
@@ -853,15 +826,6 @@ func TestSdkCloudBackupStateChange(t *testing.T) {
 
 	for _, test := range tests {
 		// Create response
-		s.MockDriver().
-			EXPECT().
-			Inspect([]string{id}).
-			Return([]*api.Volume{
-				&api.Volume{
-					Id: id,
-				},
-			}, nil).
-			Times(1)
 		s.MockDriver().
 			EXPECT().
 			CloudBackupStatus(&api.CloudBackupStatusRequest{
@@ -971,15 +935,6 @@ func TestSdkCloudBackupSchedCreate(t *testing.T) {
 	// Create response
 	s.MockDriver().
 		EXPECT().
-		Inspect([]string{id}).
-		Return([]*api.Volume{
-			&api.Volume{
-				Id: id,
-			},
-		}, nil).
-		Times(1)
-	s.MockDriver().
-		EXPECT().
 		CloudBackupSchedCreate(&mockReq).
 		Return(&api.CloudBackupSchedCreateResponse{UUID: "uuid"}, nil).
 		Times(1)
@@ -1071,15 +1026,6 @@ func TestSdkCloudBackupSchedUpdate(t *testing.T) {
 		EXPECT().
 		CloudBackupSchedEnumerate().
 		Return(schedList, nil).
-		Times(1)
-	s.MockDriver().
-		EXPECT().
-		Inspect([]string{id}).
-		Return([]*api.Volume{
-			&api.Volume{
-				Id: id,
-			},
-		}, nil).
 		Times(1)
 	s.MockDriver().
 		EXPECT().

--- a/api/server/sdk/volume_migrate_test.go
+++ b/api/server/sdk/volume_migrate_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc/codes"
@@ -39,16 +38,6 @@ func TestVolumeMigrate_StartVolumeSuccess(t *testing.T) {
 			},
 		},
 	}
-
-	resp := &api.Volume{
-		Locator: &api.VolumeLocator{
-			Name: "Target",
-		},
-	}
-
-	s.MockDriver().EXPECT().
-		Inspect(gomock.Any()).
-		Return([]*api.Volume{resp}, nil)
 
 	resp2 := &api.CloudMigrateStartResponse{
 		TaskId: "1",
@@ -226,18 +215,6 @@ func TestVolumeMigrate_StartVolumeFailure(t *testing.T) {
 			},
 		},
 	}
-
-	resp := &api.Volume{
-		Id: "Target",
-		Locator: &api.VolumeLocator{
-			Name: "Target",
-		},
-	}
-
-	// Inspect volumes to get their ownership
-	s.MockDriver().EXPECT().
-		Inspect(gomock.Any()).
-		Return([]*api.Volume{resp}, nil)
 
 	s.MockDriver().EXPECT().
 		CloudMigrateStart(&api.CloudMigrateStartRequest{


### PR DESCRIPTION
Cherry pick of #1318 on release-7.0.

#1318: Switch all access checks to use Enumerate when auth is

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.