### PR TITLE
Automated cherry pick of #1331: CSI: Fix panic in NodeUnpublishVolume when err is nil

### DIFF
--- a/csi/node.go
+++ b/csi/node.go
@@ -162,11 +162,14 @@ func (s *OsdCsiServer) NodeUnpublishVolume(
 		if err == kvdb.ErrNotFound {
 			logrus.Infof("Volume %s was deleted or cannot be found: %s", req.GetVolumeId(), err.Error())
 			return &csi.NodeUnpublishVolumeResponse{}, nil
+		} else if err != nil {
+			return nil, status.Errorf(codes.NotFound, "Volume id %s not found: %s",
+				req.GetVolumeId(),
+				err.Error())
+		} else {
+			return nil, status.Errorf(codes.NotFound, "Volume id %s not found: Inspect returned no volumes",
+				req.GetVolumeId())
 		}
-
-		return nil, status.Errorf(codes.NotFound, "Volume id %s not found: %s",
-			req.GetVolumeId(),
-			err.Error())
 	}
 	vol := vols[0]
 


### PR DESCRIPTION
Cherry pick of #1331 on release-7.0.

#1331: CSI: Fix panic in NodeUnpublishVolume when err is nil

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.