### PR TITLE
Pretty print the error ErrStoragePoolResizeInProgress.

### DIFF
--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/libopenstorage/openstorage/api"
+	"github.com/libopenstorage/openstorage/pkg/parser"
 )
 
 // ErrNotFound error type for objects not found
@@ -45,11 +46,11 @@ type ErrStoragePoolResizeInProgress struct {
 }
 
 func (e *ErrStoragePoolResizeInProgress) Error() string {
-	errMsg := fmt.Sprintf("a resize for pool: %s is already in progress.", e.Pool.GetUuid())
+	errMsg := fmt.Sprintf("resize for pool %s is already in progress.", e.Pool.GetUuid())
 	if e.Pool.LastOperation != nil {
 		op := e.Pool.LastOperation
 		if op.Type == api.SdkStoragePool_OPERATION_RESIZE {
-			errMsg = fmt.Sprintf("%s %s %s", errMsg, op.Msg, op.Params)
+			errMsg = fmt.Sprintf("%s %s %s", errMsg, op.Msg, parser.LabelsToString(op.Params))
 		}
 	}
 


### PR DESCRIPTION


**What this PR does / why we need it**:
error ErrStoragePoolResizeInProgress would print a golang map in its Error method.
- Convert the Params map to a string of k=v pairs.

Signed-off-by: Aditya Dani <aditya@portworx.com>

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

