### PR TITLE
Fix panic in MergeVolumeSpecLabels

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1057,6 +1057,10 @@ func (r *CloudBackupHistoryResponse) ToSdkCloudBackupHistoryResponse() *SdkCloud
 }
 
 func (l *VolumeLocator) MergeVolumeSpecLabels(s *VolumeSpec) *VolumeLocator {
+	if l.VolumeLabels == nil && len(s.GetVolumeLabels()) > 0 {
+		l.VolumeLabels = make(map[string]string)
+	}
+
 	for k, v := range s.GetVolumeLabels() {
 		l.VolumeLabels[k] = v
 	}


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
Panic occurs under certain circumstances when l.VolumeLabels is nil.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

