### PR TITLE
Automated cherry pick of #1353: Fix panic in MergeVolumeSpecLabels

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1069,6 +1069,10 @@ func (r *CloudBackupHistoryResponse) ToSdkCloudBackupHistoryResponse() *SdkCloud
 }
 
 func (l *VolumeLocator) MergeVolumeSpecLabels(s *VolumeSpec) *VolumeLocator {
+	if l.VolumeLabels == nil && len(s.GetVolumeLabels()) > 0 {
+		l.VolumeLabels = make(map[string]string)
+	}
+
 	for k, v := range s.GetVolumeLabels() {
 		l.VolumeLabels[k] = v
 	}


### PR DESCRIPTION
Cherry pick of #1353 on release-6.2.

#1353: Fix panic in MergeVolumeSpecLabels

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.