### PR TITLE
Add a PreJoin API to ClusterListener interface.

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -109,6 +109,9 @@ type ClusterListener interface {
 	// Init is called when this node is joining an existing cluster for the first time.
 	Init(self *api.Node, state *ClusterInfo) (FinalizeInitCb, error)
 
+	// PreJoin is called before the node joins an existing cluster
+	PreJoin(self *api.Node) error
+
 	// Join is called when this node is joining an existing cluster.
 	Join(self *api.Node, state *ClusterInitState) error
 
@@ -412,6 +415,12 @@ func (nc *NullClusterListener) NodeInspect(node *api.Node) error {
 func (nc *NullClusterListener) Halt(
 	self *api.Node,
 	clusterInfo *ClusterInfo) error {
+	return nil
+}
+
+func (nc *NullClusterListener) PreJoin(
+	self *api.Node,
+) error {
 	return nil
 }
 

--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -638,12 +638,24 @@ func (c *ClusterManager) initNodeInCluster(
 func (c *ClusterManager) joinCluster(
 	self *api.Node,
 ) error {
+	// Alert all listeners that we are joining the cluster.
+	for e := c.listeners.Front(); e != nil; e = e.Next() {
+		err := e.Value.(cluster.ClusterListener).PreJoin(self)
+		if err != nil {
+			logrus.Warnf("Failed to execute PreJoin %s: %v",
+				e.Value.(cluster.ClusterListener).String(), err)
+			logrus.Errorln("Failed to join cluster.", err)
+			return err
+		}
+	}
+
 	// Listeners may update initial state, so snap again.
 	// The cluster db may have diverged since we waited for quorum
 	// in between. Snapshot is created under cluster db lock to make
 	// sure cluster db updates do not happen during snapshot, otherwise
 	// there may be a mismatch between db updates from listeners and
 	// cluster db state.
+
 	kvdb := kvdb.Instance()
 	kvlock, err := kvdb.LockWithID(clusterLockKey, c.config.NodeId)
 	if err != nil {
@@ -677,9 +689,20 @@ func (c *ClusterManager) joinCluster(
 			return err
 		}
 	}
+
 	selfNodeEntry, ok := initState.ClusterInfo.NodeEntries[c.config.NodeId]
 	if !ok {
 		logrus.Panicln("Fatal, Unable to find self node entry in local cache")
+	}
+
+	prevNonQuorumMemberState := selfNodeEntry.NonQuorumMember
+	selfNodeEntry.NonQuorumMember =
+		selfNodeEntry.Status == api.Status_STATUS_DECOMMISSION ||
+			!c.quorumMember()
+	if selfNodeEntry.NonQuorumMember != prevNonQuorumMemberState {
+		if !selfNodeEntry.NonQuorumMember {
+			logrus.Infof("This node now participates in quorum decisions")
+		}
 	}
 
 	updateCallbackFn := func(db *cluster.ClusterInfo) (bool, error) {


### PR DESCRIPTION

**What this PR does / why we need it**:
- Invoke the PreJoin API on all the listeners before joining a node into a cluster.
- Update the node's NonQuorumMember property after invoking the Join API.

Signed-off-by: Aditya Dani <aditya@portworx.com>

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

