### PR TITLE
Automated cherry pick of #1198: Fix test port conflicts

### DIFF
--- a/api/server/sdk/cluster_test.go
+++ b/api/server/sdk/cluster_test.go
@@ -56,7 +56,7 @@ func TestNewSdkServerBadParameters(t *testing.T) {
 	s, err = New(&ServerConfig{
 		Net:           "test",
 		Socket:        "blah",
-		RestPort:      testRESTPort,
+		RestPort:      "2344",
 		AccessOutput:  ioutil.Discard,
 		AuditOutput:   ioutil.Discard,
 		StoragePolicy: sp,
@@ -77,7 +77,7 @@ func TestNewSdkServerBadParameters(t *testing.T) {
 		Net:          "test",
 		Address:      "blah",
 		DriverName:   "mock",
-		RestPort:     testRESTPort,
+		RestPort:     "2345",
 		AccessOutput: ioutil.Discard,
 		AuditOutput:  ioutil.Discard,
 	})

--- a/api/server/sdk/sdk_test.go
+++ b/api/server/sdk/sdk_test.go
@@ -18,11 +18,14 @@ package sdk
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/kubernetes-csi/csi-test/utils"
@@ -51,8 +54,6 @@ import (
 const (
 	mockDriverName = "mock"
 	testUds        = "/tmp/sdk-test.sock"
-	testHttpsPort  = "34000"
-	testRESTPort   = "34001"
 )
 
 // testServer is a simple struct used abstract
@@ -66,6 +67,8 @@ type testServer struct {
 	s      *mockapi.MockOpenStoragePoolServer
 	mc     *gomock.Controller
 	gw     *httptest.Server
+	port   string
+	gwport string
 }
 
 func init() {
@@ -86,6 +89,7 @@ func setupMockDriver(tester *testServer, t *testing.T) {
 
 func newTestServer(t *testing.T) *testServer {
 	tester := &testServer{}
+	tester.setPorts()
 
 	// Add driver to registry
 	tester.mc = gomock.NewController(&utils.SafeGoroutineTester{})
@@ -109,8 +113,8 @@ func newTestServer(t *testing.T) *testServer {
 	tester.server, err = New(&ServerConfig{
 		DriverName:          mockDriverName,
 		Net:                 "tcp",
-		Address:             ":" + testHttpsPort,
-		RestPort:            testRESTPort,
+		Address:             ":" + tester.port,
+		RestPort:            tester.gwport,
 		Socket:              testUds,
 		Cluster:             tester.c,
 		StoragePolicy:       sp,
@@ -133,7 +137,7 @@ func newTestServer(t *testing.T) *testServer {
 	assert.Nil(t, err)
 
 	// Setup a connection to the driver
-	tester.conn, err = grpcserver.Connect("localhost:"+testHttpsPort, []grpc.DialOption{grpc.WithTransportCredentials(grpccreds)})
+	tester.conn, err = grpcserver.Connect("localhost:"+tester.port, []grpc.DialOption{grpc.WithTransportCredentials(grpccreds)})
 	assert.Nil(t, err)
 
 	// Setup REST gateway
@@ -143,6 +147,15 @@ func newTestServer(t *testing.T) *testServer {
 	tester.gw = httptest.NewServer(mux)
 
 	return tester
+}
+
+func (s *testServer) setPorts() {
+	source := rand.NewSource(time.Now().UnixNano())
+	r := rand.New(source)
+	port := r.Intn(2999) + 8000
+
+	s.port = fmt.Sprintf("%d", port)
+	s.gwport = fmt.Sprintf("%d", port+1)
 }
 
 func (s *testServer) MockDriver() *mockdriver.MockVolumeDriver {
@@ -271,11 +284,11 @@ func TestSdkWithNoVolumeDriverThenAddOne(t *testing.T) {
 	tester := &testServer{}
 	tester.mc = gomock.NewController(&utils.SafeGoroutineTester{})
 	tester.s = mockapi.NewMockOpenStoragePoolServer(tester.mc)
-
+	tester.setPorts()
 	server, err := New(&ServerConfig{
 		Net:                 "tcp",
-		Address:             ":" + testHttpsPort,
-		RestPort:            testRESTPort,
+		Address:             ":" + tester.port,
+		RestPort:            tester.gwport,
 		Socket:              testUds,
 		Cluster:             cm,
 		StoragePolicy:       sp,
@@ -293,13 +306,15 @@ func TestSdkWithNoVolumeDriverThenAddOne(t *testing.T) {
 	assert.Nil(t, err)
 	err = server.Start()
 	assert.Nil(t, err)
-	defer server.Stop()
+	defer func() {
+		server.Stop()
+	}()
 
 	grpccreds, err := credentials.NewClientTLSFromFile("test_certs/server-cert.pem", "")
 	assert.Nil(t, err)
 
 	// Setup a connection to the driver
-	conn, err := grpc.Dial("localhost:"+testHttpsPort, grpc.WithTransportCredentials(grpccreds))
+	conn, err := grpc.Dial("localhost:"+tester.port, grpc.WithTransportCredentials(grpccreds))
 
 	// Setup API names that depend on the volume driver
 	// To get the names, look at api.pb.go and search for grpc.Invoke or c.cc.Invoke

--- a/api/server/testutils_test.go
+++ b/api/server/testutils_test.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -61,12 +63,14 @@ var (
 // testServer is a simple struct used abstract
 // the creation and setup of the gRPC CSI service and REST server
 type testServer struct {
-	conn *grpc.ClientConn
-	m    *mockdriver.MockVolumeDriver
-	c    cluster.Cluster
-	s    *mockapi.MockOpenStoragePoolServer
-	mc   *gomock.Controller
-	sdk  *sdk.Server
+	conn   *grpc.ClientConn
+	m      *mockdriver.MockVolumeDriver
+	c      cluster.Cluster
+	s      *mockapi.MockOpenStoragePoolServer
+	mc     *gomock.Controller
+	sdk    *sdk.Server
+	port   string
+	gwport string
 }
 
 // Struct used for creation and setup of cluster api testing
@@ -127,6 +131,7 @@ func setupFakeDriver() {
 
 func newTestServerSdkNoAuth(t *testing.T) *testServer {
 	tester := &testServer{}
+	tester.setPorts()
 
 	// Add driver to registry
 	tester.mc = gomock.NewController(&utils.SafeGoroutineTester{})
@@ -147,8 +152,8 @@ func newTestServerSdkNoAuth(t *testing.T) *testServer {
 	tester.sdk, err = sdk.New(&sdk.ServerConfig{
 		DriverName:        "fake",
 		Net:               "tcp",
-		Address:           ":8123",
-		RestPort:          "8124",
+		Address:           ":" + tester.port,
+		RestPort:          tester.gwport,
 		StoragePolicy:     stp,
 		StoragePoolServer: tester.s,
 		Cluster:           tester.c,
@@ -174,7 +179,7 @@ func newTestServerSdkNoAuth(t *testing.T) *testServer {
 	tester.sdk.UseVolumeDrivers(driverMap)
 
 	// Setup a connection to the driver
-	tester.conn, err = grpcserver.Connect("localhost:8123", []grpc.DialOption{grpc.WithInsecure()})
+	tester.conn, err = grpcserver.Connect("localhost:"+tester.port, []grpc.DialOption{grpc.WithInsecure()})
 	assert.Nil(t, err)
 
 	return tester
@@ -182,6 +187,7 @@ func newTestServerSdkNoAuth(t *testing.T) *testServer {
 
 func newTestServerSdk(t *testing.T) *testServer {
 	tester := &testServer{}
+	tester.setPorts()
 
 	// Add driver to registry
 	tester.mc = gomock.NewController(&utils.SafeGoroutineTester{})
@@ -212,8 +218,8 @@ func newTestServerSdk(t *testing.T) *testServer {
 	tester.sdk, err = sdk.New(&sdk.ServerConfig{
 		DriverName:        "fake",
 		Net:               "tcp",
-		Address:           ":8123",
-		RestPort:          "8124",
+		Address:           ":" + tester.port,
+		RestPort:          tester.gwport,
 		Cluster:           tester.c,
 		Socket:            testSdkSock,
 		StoragePolicy:     stp,
@@ -232,7 +238,7 @@ func newTestServerSdk(t *testing.T) *testServer {
 	assert.Nil(t, err)
 
 	// Setup a connection to the driver
-	tester.conn, err = grpcserver.Connect("localhost:8123", []grpc.DialOption{grpc.WithInsecure()})
+	tester.conn, err = grpcserver.Connect("localhost:"+tester.port, []grpc.DialOption{grpc.WithInsecure()})
 	assert.Nil(t, err)
 
 	// Create credential for cloudBackup testing
@@ -289,6 +295,15 @@ func newTestServer(t *testing.T) *testServer {
 	return tester
 }
 
+func (s *testServer) setPorts() {
+	source := rand.NewSource(time.Now().UnixNano())
+	r := rand.New(source)
+	port := r.Intn(2999) + 8000
+
+	s.port = fmt.Sprintf("%d", port)
+	s.gwport = fmt.Sprintf("%d", port+1)
+}
+
 func (s *testServer) MockDriver() *mockdriver.MockVolumeDriver {
 	return s.m
 }
@@ -332,6 +347,9 @@ func testRestServer(t *testing.T) (*httptest.Server, *testServer) {
 }
 
 func testRestServerSdkNoAuth(t *testing.T) (*httptest.Server, *testServer) {
+	os.Remove(testSdkSock)
+	testVolDriver := newTestServerSdkNoAuth(t)
+
 	vapi := newVolumeAPI(mockDriverName, testSdkSock)
 	router := mux.NewRouter()
 	// Register all routes from the App
@@ -343,11 +361,13 @@ func testRestServerSdkNoAuth(t *testing.T) (*httptest.Server, *testServer) {
 	}
 
 	ts := httptest.NewServer(router)
-	testVolDriver := newTestServerSdkNoAuth(t)
 	return ts, testVolDriver
 }
 
 func testRestServerSdk(t *testing.T) (*httptest.Server, *testServer) {
+	os.Remove(testSdkSock)
+	testVolDriver := newTestServerSdk(t)
+
 	vapi := newVolumeAPI("fake", testSdkSock)
 	router := mux.NewRouter()
 	// Register all routes from the App
@@ -359,7 +379,6 @@ func testRestServerSdk(t *testing.T) (*httptest.Server, *testServer) {
 	}
 
 	ts := httptest.NewServer(router)
-	testVolDriver := newTestServerSdk(t)
 	return ts, testVolDriver
 }
 

--- a/csi/csi_test.go
+++ b/csi/csi_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package csi
 
 import (
+	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"testing"
 	"time"
@@ -51,7 +53,6 @@ import (
 const (
 	mockDriverName   = "mock"
 	testSharedSecret = "mysecret"
-	testSdkSock      = "/tmp/sdk.sock"
 	fakeWithSched    = "fake-sched"
 )
 
@@ -74,6 +75,9 @@ type testServer struct {
 	s      *mockapi.MockOpenStoragePoolServer
 	mc     *gomock.Controller
 	sdk    *sdk.Server
+	port   string
+	gwport string
+	uds    string
 }
 
 func setupFakeDriver() {
@@ -134,14 +138,12 @@ func setupMockDriver(tester *testServer, t *testing.T) {
 func newTestServer(t *testing.T) *testServer {
 	return newTestServerWithConfig(t, &OsdCsiServerConfig{
 		DriverName: mockDriverName,
-		Net:        "tcp",
-		Address:    "127.0.0.1:0",
-		SdkUds:     testSdkSock,
 	})
 }
 
 func newTestServerWithConfig(t *testing.T, config *OsdCsiServerConfig) *testServer {
 	tester := &testServer{}
+	tester.setPorts()
 
 	// Add driver to registry
 	tester.mc = gomock.NewController(&utils.SafeGoroutineTester{})
@@ -161,12 +163,6 @@ func newTestServerWithConfig(t *testing.T, config *OsdCsiServerConfig) *testServ
 	rm, err := role.NewSdkRoleManager(kv)
 	assert.NoError(t, err)
 
-	// Setup simple driver
-	tester.server, err = NewOsdCsiServer(config)
-	assert.Nil(t, err)
-	err = tester.server.Start()
-	assert.Nil(t, err)
-
 	// Setup storage policy
 	kv, err = kvdb.New(mem.Name, "test", []string{}, nil, kvdb.LogFatalErrorCB)
 	assert.NoError(t, err)
@@ -177,7 +173,6 @@ func newTestServerWithConfig(t *testing.T, config *OsdCsiServerConfig) *testServ
 	}
 	assert.NotNil(t, stp)
 
-	os.Remove(testSdkSock)
 	selfsignedJwt, err := auth.NewJwtAuth(&auth.JwtAuthConfig{
 		SharedSecret:  []byte(testSharedSecret),
 		UsernameClaim: auth.UsernameClaimTypeName,
@@ -187,10 +182,10 @@ func newTestServerWithConfig(t *testing.T, config *OsdCsiServerConfig) *testServ
 	tester.sdk, err = sdk.New(&sdk.ServerConfig{
 		DriverName:        "fake",
 		Net:               "tcp",
-		Address:           ":8123",
-		RestPort:          "8124",
+		Address:           ":" + tester.port,
+		RestPort:          tester.gwport,
 		Cluster:           tester.c,
-		Socket:            testSdkSock,
+		Socket:            tester.uds,
 		StoragePolicy:     stp,
 		StoragePoolServer: tester.s,
 		AccessOutput:      ioutil.Discard,
@@ -210,6 +205,15 @@ func newTestServerWithConfig(t *testing.T, config *OsdCsiServerConfig) *testServ
 		"default": tester.m,
 	})
 
+	// Setup CSI simple driver
+	config.Net = "tcp"
+	config.Address = "127.0.0.1:0"
+	config.SdkUds = tester.uds
+	tester.server, err = NewOsdCsiServer(config)
+	assert.Nil(t, err)
+	err = tester.server.Start()
+	assert.Nil(t, err)
+
 	// Setup a connection to the driver
 	tester.conn, err = grpc.Dial(tester.server.Address(), grpc.WithInsecure())
 	assert.Nil(t, err)
@@ -227,6 +231,16 @@ func newTestServerWithConfig(t *testing.T, config *OsdCsiServerConfig) *testServ
 	volumedrivers.Register(fakeWithSched, nil)
 	*/
 	return tester
+}
+
+func (s *testServer) setPorts() {
+	source := rand.NewSource(time.Now().UnixNano())
+	r := rand.New(source)
+	port := r.Intn(2999) + 8000
+
+	s.port = fmt.Sprintf("%d", port)
+	s.gwport = fmt.Sprintf("%d", port+1)
+	s.uds = fmt.Sprintf("/tmp/osd-csi-ut-%d.sock", port)
 }
 
 func (s *testServer) MockDriver() *mockdriver.MockVolumeDriver {
@@ -296,7 +310,9 @@ func TestCSIServerStop(t *testing.T) {
 }
 
 func TestNewCSIServerBadParameters(t *testing.T) {
-	setupMockDriver(&testServer{}, t)
+	tester := &testServer{}
+	tester.setPorts()
+	setupMockDriver(tester, t)
 	s, err := NewOsdCsiServer(nil)
 	assert.Nil(t, s)
 	assert.NotNil(t, err)
@@ -308,7 +324,7 @@ func TestNewCSIServerBadParameters(t *testing.T) {
 
 	s, err = NewOsdCsiServer(&OsdCsiServerConfig{
 		Net:    "test",
-		SdkUds: testSdkSock,
+		SdkUds: tester.uds,
 	})
 	assert.Nil(t, s)
 	assert.NotNil(t, err)
@@ -317,7 +333,7 @@ func TestNewCSIServerBadParameters(t *testing.T) {
 	s, err = NewOsdCsiServer(&OsdCsiServerConfig{
 		Net:     "test",
 		Address: "blah",
-		SdkUds:  testSdkSock,
+		SdkUds:  tester.uds,
 	})
 	assert.Nil(t, s)
 	assert.NotNil(t, err)
@@ -327,7 +343,7 @@ func TestNewCSIServerBadParameters(t *testing.T) {
 		Net:        "test",
 		Address:    "blah",
 		DriverName: "name",
-		SdkUds:     testSdkSock,
+		SdkUds:     tester.uds,
 	})
 	assert.Nil(t, s)
 	assert.NotNil(t, err)
@@ -354,11 +370,12 @@ func TestNewCSIServerBadParameters(t *testing.T) {
 		Net:        "test",
 		Address:    "blah",
 		DriverName: "mock",
-		SdkUds:     testSdkSock,
+		SdkUds:     tester.uds,
 	})
 	assert.Nil(t, s)
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Unable to setup server")
+	os.Remove(tester.uds)
 }
 
 func TestAddEncryptionInfoToLabels(t *testing.T) {

--- a/csi/identity_test.go
+++ b/csi/identity_test.go
@@ -58,7 +58,7 @@ func TestNewCSIServerGetPluginInfoWithOverrideName(t *testing.T) {
 		DriverName:    mockDriverName,
 		Net:           "tcp",
 		Address:       "127.0.0.1:0",
-		SdkUds:        testSdkSock,
+		SdkUds:        "/tmp/notnecessary",
 		CsiDriverName: "override",
 	})
 	defer s.Stop()


### PR DESCRIPTION
Cherry pick of #1198 on release-7.0.

#1198: Fix test port conflicts

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.