### PR TITLE
Automated cherry pick of #1382: Update public user to use RBAC negation for volume creation

### DIFF
--- a/pkg/role/sdkserviceapi.go
+++ b/pkg/role/sdkserviceapi.go
@@ -32,64 +32,99 @@ import (
 const (
 	rolePrefix   = "cluster/roles"
 	invalidChars = "/ "
+	negMatchChar = "!"
+
+	systemAdminRoleName  = "system.admin"
+	systemViewRoleName   = "system.view"
+	systemUserRoleName   = "system.user"
+	systemPublicRoleName = "system.public"
 )
+
+type defaultRole struct {
+	rules   []*api.SdkRule
+	mutable bool
+}
 
 var (
 	// Default roles. Should be prefixed by `system.` to avoid collisions
-	defaultRoles = map[string][]*api.SdkRule{
+	defaultRoles = map[string]*defaultRole{
 		// system:admin role can run any command
-		"system.admin": {
-			&api.SdkRule{
-				Services: []string{"*"},
-				Apis:     []string{"*"},
+		systemAdminRoleName: &defaultRole{
+			rules: []*api.SdkRule{
+				&api.SdkRule{
+					Services: []string{"*"},
+					Apis:     []string{"*"},
+				},
 			},
+			mutable: false,
 		},
 
 		// system:view role can only run read-only commands
-		"system.view": {
-			&api.SdkRule{
-				Services: []string{"*"},
-				Apis: []string{
-					"*enumerate*",
-					"inspect*",
-					"stats",
-					"status",
-					"validate",
-					"capacityusage",
+		systemViewRoleName: &defaultRole{
+			rules: []*api.SdkRule{
+				&api.SdkRule{
+					Services: []string{"*"},
+					Apis: []string{
+						"*enumerate*",
+						"inspect*",
+						"stats",
+						"status",
+						"validate",
+						"capacityusage",
+					},
+				},
+				&api.SdkRule{
+					Services: []string{"identity"},
+					Apis:     []string{"*"},
 				},
 			},
-			&api.SdkRule{
-				Services: []string{"identity"},
-				Apis:     []string{"*"},
+			mutable: false,
+		},
+		// system:user role can only access volume lifecycle commands
+		systemUserRoleName: &defaultRole{
+			rules: []*api.SdkRule{
+				&api.SdkRule{
+					Services: []string{
+						"volume",
+						"cloudbackup",
+						"credentials",
+						"objectstore",
+						"schedulepolicy",
+						"mountattach",
+						"migrate",
+					},
+					Apis: []string{"*"},
+				},
+				&api.SdkRule{
+					Services: []string{"identity"},
+					Apis:     []string{"*"},
+				},
+				&api.SdkRule{
+					Services: []string{"policy"},
+					Apis: []string{
+						"*enumerate*",
+						// This will allow system.user to view default policy also
+						"*inspect*",
+					},
+				},
 			},
+			mutable: false,
 		},
 
-		// system:user role can only access volume lifecycle commands
-		"system.user": {
-			&api.SdkRule{
-				Services: []string{
-					"volume",
-					"cloudbackup",
-					"credentials",
-					"objectstore",
-					"schedulepolicy",
-					"mountattach",
-					"migrate",
+		// system:public role is used for any unauthenticated user.
+		// They can only use standard volume lifecycle commands.
+		systemPublicRoleName: &defaultRole{
+			rules: []*api.SdkRule{
+				&api.SdkRule{
+					Services: []string{"mountattach", "volume", "cloudbackup", "migrate"},
+					Apis:     []string{"*"},
 				},
-				Apis: []string{"*"},
-			},
-			&api.SdkRule{
-				Services: []string{"identity"},
-				Apis:     []string{"*"},
-			},
-			&api.SdkRule{
-				Services: []string{"policy"},
-				Apis: []string{
-					"*enumerate*",
-					// This will allow system.user to view default policy also
-					"*inspect*",
+				&api.SdkRule{
+					Services: []string{"identity"},
+					Apis:     []string{"version"},
 				},
 			},
+			mutable: true,
 		},
 	}
 )
@@ -155,13 +190,22 @@ func NewSdkRoleManager(kv kvdb.Kvdb) (*SdkRoleManager, error) {
 	}
 
 	// Load all default roles
-	for k, v := range defaultRoles {
-		role := &api.SdkRole{
-			Name:  k,
-			Rules: v,
+	for roleName, defaultRole := range defaultRoles {
+		roleExists := false
+		if _, err := kv.Get(prefixWithName(roleName)); err == nil {
+			roleExists = true
 		}
-		if _, err := kv.Put(prefixWithName(k), role, 0); err != nil {
-			return nil, err
+
+		// always re-initialize immutable default roles.
+		// if the role is mutable and does exist, skip kvdb put.
+		if !roleExists || !defaultRole.mutable {
+			role := &api.SdkRole{
+				Name:  roleName,
+				Rules: defaultRole.rules,
+			}
+			if _, err := kv.Put(prefixWithName(roleName), role, 0); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -291,8 +335,9 @@ func (r *SdkRoleManager) Update(
 		return nil, err
 	}
 
-	// Determine if there is collision with default roles
-	if _, ok := defaultRoles[req.GetRole().GetName()]; ok {
+	// Determine if there is collision with default roles.
+	// We can still update mutable default roles.
+	if defaultRole, ok := defaultRoles[req.GetRole().GetName()]; ok && !defaultRole.mutable {
 		return nil, status.Errorf(
 			codes.InvalidArgument,
 			"System role %s cannot be updated", req.GetRole().GetName())

--- a/pkg/role/sdkserviceapi_test.go
+++ b/pkg/role/sdkserviceapi_test.go
@@ -197,11 +197,11 @@ func TestSdkRuleCreateCollisionSystemRole(t *testing.T) {
 	s, err := NewSdkRoleManager(kv)
 	assert.NoError(t, err)
 
-	for systemRole, rules := range defaultRoles {
+	for roleName, defaultRole := range defaultRoles {
 		req := &api.SdkRoleCreateRequest{
 			Role: &api.SdkRole{
-				Name:  systemRole,
-				Rules: rules,
+				Name:  roleName,
+				Rules: defaultRole.rules,
 			},
 		}
 		_, err := s.Create(context.Background(), req)
@@ -451,19 +451,23 @@ func TestSdkRuleUpdateCollisionSystemRole(t *testing.T) {
 	s, err := NewSdkRoleManager(kv)
 	assert.NoError(t, err)
 
-	for systemRole, rules := range defaultRoles {
+	for roleName, defaultRole := range defaultRoles {
 		req := &api.SdkRoleUpdateRequest{
 			Role: &api.SdkRole{
-				Name:  systemRole,
-				Rules: rules,
+				Name:  roleName,
+				Rules: defaultRole.rules,
 			},
 		}
 		_, err := s.Update(context.Background(), req)
-		assert.Error(t, err)
-		serverError, ok := status.FromError(err)
-		assert.True(t, ok)
-		assert.Equal(t, serverError.Code(), codes.InvalidArgument)
-		assert.Contains(t, serverError.Message(), "System role")
+		if defaultRole.mutable {
+			assert.NoError(t, err)
+		} else {
+			assert.Error(t, err)
+			serverError, ok := status.FromError(err)
+			assert.True(t, ok)
+			assert.Equal(t, serverError.Code(), codes.InvalidArgument)
+			assert.Contains(t, serverError.Message(), "System role")
+		}
 	}
 
 }

--- a/vendor/github.com/hashicorp/go-multierror/go.mod
+++ b/vendor/github.com/hashicorp/go-multierror/go.mod
@@ -1,3 +1,5 @@
 module github.com/hashicorp/go-multierror
 
 require github.com/hashicorp/errwrap v1.0.0
+
+go 1.13


### PR DESCRIPTION
Cherry pick of #1382 on release-7.0.

#1382: Update public user to use RBAC negation for volume creation

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.