### PR TITLE
Add api to sched package

### DIFF
--- a/pkg/sched/intervals.go
+++ b/pkg/sched/intervals.go
@@ -314,6 +314,44 @@ func ScheduleIntervalSummary(items []Interval, policyTags *PolicyTags) string {
 	return summary
 }
 
+func ScheduleIntervalsPerDay(items []RetainInterval, policyTags *PolicyTags) uint32 {
+	if len(items) == 0 {
+		return 0
+	}
+	var intervalsPerDay uint32
+	for _, iv := range items {
+		var perDay uint32
+		switch iv.Spec().Freq {
+		case PeriodicType:
+			period := time.Duration(iv.Spec().Period).Minutes()
+			if period < float64(60*24) {
+				perDay = uint32(float64(60*24) / period)
+			} else {
+				perDay = uint32(1)
+			}
+		case DailyType:
+			perDay = uint32(1)
+		case WeeklyType:
+			perDay = uint32(1)
+		case MonthlyType:
+			perDay = uint32(1)
+		}
+		intervalsPerDay += perDay
+	}
+	return intervalsPerDay
+}
+
+func ScheduleTotalRetains(items []RetainInterval, policyTags *PolicyTags) uint32 {
+	if len(items) == 0 {
+		return 0
+	}
+	var totalRetains uint32
+	for _, iv := range items {
+		totalRetains += iv.RetainNumber()
+	}
+	return totalRetains
+}
+
 func ScheduleSummary(items []RetainInterval, policyTags *PolicyTags) string {
 	summary := ""
 	if policyTags != nil {

--- a/pkg/sched/sched_test.go
+++ b/pkg/sched/sched_test.go
@@ -3,6 +3,7 @@ package sched
 import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -184,10 +185,10 @@ func TestScheduleStrings(t *testing.T) {
 		}
 	}
 	for i, sched := range dockSched {
-		ivs, tags, err := ParseScheduleAndPolicies(sched)
+		ivs, _, err := ParseScheduleAndPolicies(sched)
 		require.Equal(t, err, nil, "Parsing policy %s, err: %v", sched, err)
 		require.NoError(t, err)
-		perDay := ScheduleIntervalsPerDay(ivs, tags)
+		perDay := MaxPerDayInstances(ivs)
 		if len(ivs) == 0 || i >= origLen {
 			continue
 		}
@@ -203,13 +204,10 @@ func TestScheduleStrings(t *testing.T) {
 			require.Equal(t, perDay, uint32(1), "Incorrect Monthly intervals per day")
 		}
 	}
-	cumulativeSched := dockSched[0] + scheduleSeparator +
-		dockSched[1] + scheduleSeparator +
-		dockSched[2] + scheduleSeparator +
-		dockSched[3]
-	ivs, tags, err := ParseScheduleAndPolicies(cumulativeSched)
+	cumulativeSched := strings.Join(dockSched[0:4], scheduleSeparator)
+	ivs, _, err := ParseScheduleAndPolicies(cumulativeSched)
 	require.NoError(t, err)
-	perDay := ScheduleIntervalsPerDay(ivs, tags)
+	perDay := MaxPerDayInstances(ivs)
 	require.Equal(t, perDay, uint32(147), "Unexpcted number of intervals per day")
 
 }


### PR DESCRIPTION
Returns number of intervals per day for given schedule items.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Adds new api to sched package that returns the number intervals per day.
Useful  for estimating number of times the schedule would be exercised per day.
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

