### PR TITLE
Add api to sched package (#1395)

### DIFF
--- a/pkg/sched/intervals.go
+++ b/pkg/sched/intervals.go
@@ -13,6 +13,7 @@ import (
 const (
 	scheduleSeparator    = ";"
 	nonYamlTypeSeparator = "="
+	MinutesPerDay        = float64(60 * 24)
 	DailyType            = "daily"
 	MonthlyType          = "monthly"
 	WeeklyType           = "weekly"
@@ -312,6 +313,39 @@ func ScheduleIntervalSummary(items []Interval, policyTags *PolicyTags) string {
 		summary += iv.String()
 	}
 	return summary
+}
+
+func MaxPerDayInstances(items []RetainInterval) uint32 {
+	var intervalsPerDay uint32
+	for _, iv := range items {
+		var perDay uint32
+		switch iv.Spec().Freq {
+		case PeriodicType:
+			perDay = uint32(1)
+			period := time.Duration(iv.Spec().Period).Minutes()
+			if period == 0 {
+				perDay = 0
+			} else if period < MinutesPerDay {
+				perDay = uint32(MinutesPerDay / period)
+			}
+		case DailyType:
+			perDay = uint32(1)
+		case WeeklyType:
+			perDay = uint32(1)
+		case MonthlyType:
+			perDay = uint32(1)
+		}
+		intervalsPerDay += perDay
+	}
+	return intervalsPerDay
+}
+
+func ScheduleRetainSum(items []RetainInterval) uint32 {
+	var totalRetains uint32
+	for _, iv := range items {
+		totalRetains += iv.RetainNumber()
+	}
+	return totalRetains
 }
 
 func ScheduleSummary(items []RetainInterval, policyTags *PolicyTags) string {


### PR DESCRIPTION
* Add new api to sched package

Returns number of intervals per day for given schedule items.

Signed-off-by: veda <veda@portworx.com>

* Address Review comments

Signed-off-by: veda <veda@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

Cherry-pick from master