### PR TITLE
Automated cherry pick of #1416: Change setup CSI OSD cluster to use DaemonSet instead of

### DIFF
--- a/cmd/osd/main.go
+++ b/cmd/osd/main.go
@@ -28,6 +28,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -407,6 +408,9 @@ func start(c *cli.Context) error {
 			csisock = fmt.Sprintf("/var/lib/osd/driver/%s-csi.sock", d)
 		}
 		os.Remove(csisock)
+		if err := os.MkdirAll(filepath.Dir(csisock), 0750); err != nil {
+			return err
+		}
 		cm, err := clustermanager.Inst()
 		if err != nil {
 			return fmt.Errorf("Unable to find cluster instance: %v", err)

--- a/hack/osd-csi.yaml
+++ b/hack/osd-csi.yaml
@@ -209,6 +209,19 @@ spec:
       hostNetwork: true
       hostPID: false
       containers:
+        - name: osd
+          image: quay.io/openstorage/osd:latest
+          imagePullPolicy: Never # Manually loaded into KinD (see setup script)
+          args:
+              ["-d","--driver=name=fake", "--csidrivername","osd.openstorage.org"]
+          env:
+            - name: "CSI_ENDPOINT"
+              value: "/var/lib/kubelet/plugins/osd.openstorage.org/csi.sock"
+          securityContext:
+            privileged: true
+          volumeMounts:
+          - name: csi-kubelet-path
+            mountPath: /var/lib/kubelet
         - name: csi-node-driver-registrar
           image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
           args:
@@ -237,7 +250,7 @@ spec:
           hostPath:
             path: /var/lib/kubelet/plugins_registry
             type: DirectoryOrCreate
-        - name: csi-driver-path
+        - name: csi-kubelet-path
           hostPath:
-            path: /var/lib/kubelet/plugins/osd.openstorage.org
+            path: /var/lib/kubelet
             type: DirectoryOrCreate

--- a/hack/setup-kind-csi-cluster.sh
+++ b/hack/setup-kind-csi-cluster.sh
@@ -1,16 +1,23 @@
 #!/bin/bash
+KIND_IMAGE=kindest/node:v1.17.0
 set -x
 cd $GOPATH/src/github.com/libopenstorage/openstorage
+
+# Setup KinD cluster
 if [ $DELETE_CLUSTER ]; then
 	kind delete cluster --name kind-csi 
 fi
-kind create cluster --name kind-csi --config hack/kind.yaml --image kindest/node:v1.17.0
-docker cp $GOPATH/bin/osd kind-csi-worker:/osdkind
-docker exec -ti kind-csi-worker bash -c "chmod 777 /osdkind"
-docker exec -ti kind-csi-worker bash -c "mkdir -p /var/lib/kubelet/plugins/osd.openstorage.org"
-docker exec -ti kind-csi-worker bash -c "pkill osdkind"
-docker exec -tid kind-csi-worker bash -c "CSI_ENDPOINT=/var/lib/kubelet/plugins/osd.openstorage.org/csi.sock /osdkind -d --driver=name=fake --sdkport 9106 --sdkrestport 9116 --csidrivername osd.openstorage.org"
+kind create cluster --name kind-csi --config hack/kind.yaml --image $KIND_IMAGE
+
+# Build OSD
+make docker-build-osd
+
+# Load local OSD image into KinD
+kind load docker-image quay.io/openstorage/osd:latest --name kind-csi
 export KUBECONFIG=$(kind get kubeconfig-path --name kind-csi)
+
+# Start OSD
+kubectl delete -f hack/osd-csi.yaml
 kubectl apply -f hack/osd-csi.yaml
 
 set +x


### PR DESCRIPTION
Cherry pick of #1416 on release-7.0.

#1416: Change setup CSI OSD cluster to use DaemonSet instead of

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.