### PR TITLE
Automated cherry pick of #1417: Revert removal of csi-driver-path volume mount

### DIFF
--- a/hack/osd-csi.yaml
+++ b/hack/osd-csi.yaml
@@ -220,6 +220,8 @@ spec:
           securityContext:
             privileged: true
           volumeMounts:
+          - name: csi-driver-path
+            mountPath: /var/lib/kubelet/plugins/osd.openstorage.org
           - name: csi-kubelet-path
             mountPath: /var/lib/kubelet
         - name: csi-node-driver-registrar
@@ -253,4 +255,8 @@ spec:
         - name: csi-kubelet-path
           hostPath:
             path: /var/lib/kubelet
+            type: DirectoryOrCreate
+        - name: csi-driver-path
+          hostPath:
+            path: /var/lib/kubelet/plugins/osd.openstorage.org
             type: DirectoryOrCreate


### PR DESCRIPTION
Cherry pick of #1417 on release-7.0.

#1417: Revert removal of csi-driver-path volume mount

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.