### PR TITLE
Handle gossip port updates.

### DIFF
--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -771,12 +771,6 @@ func (c *ClusterManager) startHeartBeat(
 			// Do not add nodes with mismatched version
 			continue
 		}
-		nodeIp := nodeEntry.DataIp + ":" + c.gossipPort
-		gossipConfig.Nodes[types.NodeId(nodeId)] = types.GossipNodeConfiguration{
-			KnownUrl:      nodeIp,
-			ClusterDomain: nodeEntry.ClusterDomain,
-		}
-
 		gossipPort := nodeEntry.GossipPort
 		if gossipPort == "" {
 			// The cluster DB does not have the gossip port value
@@ -786,6 +780,13 @@ func (c *ClusterManager) startHeartBeat(
 			// node pings us, gossip protocol will automatically update the port
 			gossipPort = c.gossipPort
 		}
+
+		nodeIp := nodeEntry.DataIp + ":" + gossipPort
+		gossipConfig.Nodes[types.NodeId(nodeId)] = types.GossipNodeConfiguration{
+			KnownUrl:      nodeIp,
+			ClusterDomain: nodeEntry.ClusterDomain,
+		}
+
 		nodeIps = append(nodeIps, nodeEntry.DataIp+":"+gossipPort)
 	}
 	if len(nodeIps) > 0 {


### PR DESCRIPTION


**What this PR does / why we need it**:
- Use the port configured in cluster database for peer nodes
  instead of the port used by this node.

Signed-off-by: Aditya Dani <aditya@portworx.com>

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

