### PR TITLE
Handle gossip port updates.

### DIFF
--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -717,12 +717,6 @@ func (c *ClusterManager) startHeartBeat(
 			// Do not add nodes with mismatched version
 			continue
 		}
-		nodeIp := nodeEntry.DataIp + ":" + c.gossipPort
-		gossipConfig.Nodes[types.NodeId(nodeId)] = types.GossipNodeConfiguration{
-			KnownUrl:      nodeIp,
-			ClusterDomain: nodeEntry.ClusterDomain,
-		}
-
 		gossipPort := nodeEntry.GossipPort
 		if gossipPort == "" {
 			// The cluster DB does not have the gossip port value
@@ -732,6 +726,13 @@ func (c *ClusterManager) startHeartBeat(
 			// node pings us, gossip protocol will automatically update the port
 			gossipPort = c.gossipPort
 		}
+
+		nodeIp := nodeEntry.DataIp + ":" + gossipPort
+		gossipConfig.Nodes[types.NodeId(nodeId)] = types.GossipNodeConfiguration{
+			KnownUrl:      nodeIp,
+			ClusterDomain: nodeEntry.ClusterDomain,
+		}
+
 		nodeIps = append(nodeIps, nodeEntry.DataIp+":"+gossipPort)
 	}
 	if len(nodeIps) > 0 {


### PR DESCRIPTION
- Use the port configured in cluster database for peer nodes
  instead of the port used by this node.

Signed-off-by: Aditya Dani <aditya@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

