### PR TITLE
Automated cherry pick of #1402: Add support for CSI ephemeral volume creation

### DIFF
--- a/csi/node_test.go
+++ b/csi/node_test.go
@@ -139,6 +139,8 @@ func TestNodePublishVolumeBadAttribute(t *testing.T) {
 		Return(api.DriverType_DRIVER_TYPE_BLOCK).
 		Times(1)
 
+	os.Mkdir("mypath", 0750)
+	defer os.Remove("mypath")
 	req := &csi.NodePublishVolumeRequest{
 		VolumeId:   name,
 		TargetPath: "mypath",
@@ -186,7 +188,7 @@ func TestNodePublishVolumeInvalidTargetLocation(t *testing.T) {
 		EXPECT().
 		Type().
 		Return(api.DriverType_DRIVER_TYPE_NONE).
-		Times(len(testargs))
+		AnyTimes()
 	req := &csi.NodePublishVolumeRequest{
 		VolumeId: name,
 		VolumeCapability: &csi.VolumeCapability{

--- a/hack/osd-csi.yaml
+++ b/hack/osd-csi.yaml
@@ -169,7 +169,7 @@ metadata:
   name: osd.openstorage.org
 spec:
   attachRequired: false
-  podInfoOnMount: false
+  podInfoOnMount: true
   volumeLifecycleModes:
   - Persistent
   - Ephemeral


### PR DESCRIPTION
Cherry pick of #1402 on release-8.0.

#1402: Add support for CSI ephemeral volume creation

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.