### PR TITLE
Cleanup csi.openstorage.org parameters after adding to VolumeLabels

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -306,6 +306,15 @@ func getPVCMetadata(params map[string]string) (map[string]string, error) {
 	return metadata, nil
 }
 
+func cleanupVolumeLabels(labels map[string]string) map[string]string {
+	delete(labels, osdPvcNameKey)
+	delete(labels, osdPvcNamespaceKey)
+	delete(labels, osdPvcAnnotationsKey)
+	delete(labels, osdPvcLabelsKey)
+
+	return labels
+}
+
 // CreateVolume is a CSI API which creates a volume on OSD
 // This function supports snapshots if the parent volume id is supplied
 // in the parameters.
@@ -364,6 +373,9 @@ func (s *OsdCsiServer) CreateVolume(
 	} else {
 		spec.Size = defaultCSIVolumeSize
 	}
+
+	// cleanup duplicate information after pulling from req.GetParameters
+	locator.VolumeLabels = cleanupVolumeLabels(locator.VolumeLabels)
 
 	// Get grpc connection
 	conn, err := s.getConn()


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
We were leaving csi.openstorage.org parameters around in locator.VolumeLabels. This is not needed,  as we copy these fields directly. These fields are only needed for transporting these values from the our external-provisioner fork to our CSI Driver.


See this example of the existing behavior. Each pvc.Label occurs twice. Once in the `csi.openstorage.org/pvc-labels` field, and once as it's own field.
```
csi.openstorage.org/pvc-labels={"app":"minio"
    "chart":"minio-3.0.1",
    "heritage":"Helm",
    "release":"minio-reliability",
},
csi.openstorage.org/pvc-name=minio-reliability,
csi.openstorage.org/pvc-namespace=minio,
csi.openstorage.org/pvc-annotations={"volume.beta.kubernetes.io/storage-provisioner":"pxd.portworx.com"},
namespace=minio,
pvc=minio-reliability,
release=minio-reliability,
app=minio,
chart=minio-3.0.1,
heritage=Helm
```

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

