### PR TITLE
Add auth middleware enumerateWithAuth

### DIFF
--- a/api/server/middleware_auth.go
+++ b/api/server/middleware_auth.go
@@ -352,6 +352,61 @@ func (a *authMiddleware) inspectWithAuth(w http.ResponseWriter, r *http.Request,
 	json.NewEncoder(w).Encode(dk)
 }
 
+func (a *authMiddleware) enumerateWithAuth(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	fn := "enumerate"
+
+	d, authRequired := a.isTokenProcessingRequired(r)
+	if !authRequired {
+		next(w, r)
+		return
+	}
+
+	volIDs, ok := r.URL.Query()[api.OptVolumeID]
+	if !ok || len(volIDs[0]) < 1 {
+		a.log("", fn).Error("Failed to parse VolumeID")
+		return
+	}
+	volumeID := volIDs[0]
+
+	vols, err := d.Inspect([]string{volumeID})
+	if err != nil || len(vols) == 0 || vols[0] == nil {
+		a.log(volumeID, fn).WithError(err).Error("Failed to get volume object")
+		next(w, r)
+		return
+	}
+
+	volumeResponse := &api.VolumeResponse{}
+	tokenSecretContext, err := a.parseSecret(vols[0].Spec.VolumeLabels, vols[0].Locator.VolumeLabels, false)
+	if err != nil {
+		a.log(volumeID, fn).WithError(err).Error("failed to parse secret")
+		volumeResponse.Error = "failed to parse secret: " + err.Error()
+		json.NewEncoder(w).Encode(volumeResponse)
+		return
+	}
+	if tokenSecretContext.SecretName == "" {
+		errorMessage := fmt.Sprintf("Error, unable to get secret information from the volume."+
+			" You may need to re-add the following keys as volume labels to point to the secret: %s and %s",
+			osecrets.SecretNameKey, osecrets.SecretNamespaceKey)
+		a.log(volumeID, fn).Error(errorMessage)
+		volumeResponse = &api.VolumeResponse{Error: errorMessage}
+		json.NewEncoder(w).Encode(volumeResponse)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	token, err := osecrets.GetToken(tokenSecretContext)
+	if err != nil {
+		a.log(volumeID, fn).WithError(err).Error("failed to get token")
+		volumeResponse.Error = "failed to get token: " + err.Error()
+		json.NewEncoder(w).Encode(volumeResponse)
+		return
+	} else {
+		a.insertToken(r, token)
+	}
+
+	next(w, r)
+}
+
 func (a *authMiddleware) isTokenProcessingRequired(r *http.Request) (volume.VolumeDriver, bool) {
 	userAgent := r.Header.Get("User-Agent")
 	if len(userAgent) > 0 {

--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -1704,9 +1704,12 @@ func (vd *volAPI) volumeInspectRoute() *Route {
 	return &Route{verb: "GET", path: volPath("/{id}", volume.APIVersion), fn: vd.inspect}
 }
 
+func (vd *volAPI) volumeEnumerateRoute() *Route {
+	return &Route{verb: "GET", path: volPath("", volume.APIVersion), fn: vd.enumerate}
+}
+
 func (vd *volAPI) otherVolumeRoutes() []*Route {
 	return []*Route{
-		{verb: "GET", path: volPath("", volume.APIVersion), fn: vd.enumerate},
 		{verb: "GET", path: volPath("/stats", volume.APIVersion), fn: vd.stats},
 		{verb: "GET", path: volPath("/stats/{id}", volume.APIVersion), fn: vd.stats},
 		{verb: "GET", path: volPath("/usedsize", volume.APIVersion), fn: vd.usedsize},
@@ -1770,7 +1773,7 @@ func (vd *volAPI) snapRoutes() []*Route {
 }
 
 func (vd *volAPI) Routes() []*Route {
-	routes := []*Route{vd.versionRoute(), vd.volumeCreateRoute(), vd.volumeSetRoute(), vd.volumeDeleteRoute(), vd.volumeInspectRoute()}
+	routes := []*Route{vd.versionRoute(), vd.volumeCreateRoute(), vd.volumeSetRoute(), vd.volumeDeleteRoute(), vd.volumeInspectRoute(), vd.volumeEnumerateRoute()}
 	routes = append(routes, vd.otherVolumeRoutes()...)
 	routes = append(routes, vd.snapRoutes()...)
 	routes = append(routes, vd.backupRoutes()...)
@@ -1789,6 +1792,7 @@ func (vd *volAPI) SetupRoutesWithAuth(
 	// - ATTACH/MOUNT
 	// - DETACH/UNMOUNT
 	// - DELETE
+	// - ENUMERATE
 	// For all other routes it is expected that the REST client uses an auth token
 
 	authM := NewAuthMiddleware()
@@ -1820,6 +1824,13 @@ func (vd *volAPI) SetupRoutesWithAuth(
 	inspectRoute := vd.volumeInspectRoute()
 	nSet.UseHandlerFunc(inspectRoute.fn)
 	router.Methods(inspectRoute.verb).Path(inspectRoute.path).Handler(nInspect)
+
+	// Setup middleware for enumerate
+	nEnumerate := negroni.New()
+	nEnumerate.Use(negroni.HandlerFunc(authM.enumerateWithAuth))
+	enumerateRoute := vd.volumeEnumerateRoute()
+	nSet.UseHandlerFunc(enumerateRoute.fn)
+	router.Methods(enumerateRoute.verb).Path(enumerateRoute.path).Handler(nEnumerate)
 
 	routes := []*Route{vd.versionRoute()}
 	routes = append(routes, vd.otherVolumeRoutes()...)
@@ -1924,6 +1935,13 @@ func GetVolumeAPIRoutesWithAuth(
 	inspectRoute := vd.volumeInspectRoute()
 	nInspect.UseHandlerFunc(serverRegisterRoute(inspectRoute.fn, preRouteCheckFn))
 	router.Methods(inspectRoute.verb).Path(inspectRoute.path).Handler(nInspect)
+
+	// Setup middleware for Enumerate
+	nEnumerate := negroni.New()
+	nEnumerate.Use(negroni.HandlerFunc(authM.enumerateWithAuth))
+	enumerateRoute := vd.volumeEnumerateRoute()
+	nEnumerate.UseHandlerFunc(serverRegisterRoute(enumerateRoute.fn, preRouteCheckFn))
+	router.Methods(enumerateRoute.verb).Path(enumerateRoute.path).Handler(nEnumerate)
 
 	routes := []*Route{vd.versionRoute()}
 	routes = append(routes, vd.otherVolumeRoutes()...)


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>
**What this PR does / why we need it**:
Failing enumerate requests from k8s in tree driver are in this format:

> 
> 298869c4599 HTTP/1.1 1 1 map[Content-Type:[application/json] Date:[2020-03-06 03:57:28.262818093 +0000 UTC m=+1940.733020398] Accept-Encoding:[gzip] User-Agent:[pxd-sched/v1]] {} <nil> 0 [] false 10.98.204.209:9001 map[] map[] <nil> map[] 192.168.30.80:54159 /v1/**osd-volumes?VolumeID=pvc-8d61ac20-2956-4193-ad6d-1298869c4599** <nil> <nil> <nil> 0xc422434420}
> 

While the k8s in-tree volume client calls "inspect", the server is treating this as an "enumerate" request. See the following:

client call - GET /osd-volumes?VolumeID=<id>
https://github.com/kubernetes/kubernetes/blob/master/vendor/github.com/libopenstorage/openstorage/api/client/volume/client.go#L148

server receiver GET /osd-volumes?VolumeID=<id>
https://github.com/libopenstorage/openstorage/blob/master/api/server/volume.go#L1709

note - in order to hit the "inspect" server call, a client needs to do `GET /osd-volumes/<vol-id>`:
https://github.com/libopenstorage/openstorage/blob/master/api/server/volume.go#L1704

Because k8s in-tree resizing calls inspect(), it's hitting enumerate (which didn't have auth-middleware setup).


