### PR TITLE
WIP: DEBUG Trace interceptor

### DIFF
--- a/api/server/sdk/server_interceptors.go
+++ b/api/server/sdk/server_interceptors.go
@@ -18,6 +18,7 @@ package sdk
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/libopenstorage/openstorage/pkg/auth"
@@ -109,14 +110,25 @@ func (s *sdkGrpcServer) loggerServerInterceptor(
 		"reqid":  reqid,
 	})
 
-	logger.Info("Start")
+	buf, err := json.Marshal(req)
+	if err != nil {
+		buf = []byte("{}")
+	}
+
+	logger.WithFields(logrus.Fields{"request": string(buf)}).Info("Start")
 	ts := time.Now()
 	i, err := handler(ctx, req)
 	duration := time.Now().Sub(ts)
+
+	buf, err = json.Marshal(i)
+	if err != nil {
+		buf = []byte("{}")
+	}
+
 	if err != nil {
 		logger.WithFields(logrus.Fields{"duration": duration}).Infof("Failed: %v", err)
 	} else {
-		logger.WithFields(logrus.Fields{"duration": duration}).Info("Successful")
+		logger.WithFields(logrus.Fields{"response": string(buf), "duration": duration}).Info("Successful")
 	}
 
 	return i, err

--- a/cmd/osd/main.go
+++ b/cmd/osd/main.go
@@ -36,7 +36,6 @@ import (
 	"github.com/codegangsta/cli"
 	"github.com/docker/docker/pkg/reexec"
 	"github.com/libopenstorage/openstorage/api"
-	"github.com/libopenstorage/openstorage/api/flexvolume"
 	"github.com/libopenstorage/openstorage/api/server"
 	"github.com/libopenstorage/openstorage/api/server/sdk"
 	osdcli "github.com/libopenstorage/openstorage/cli"
@@ -510,10 +509,6 @@ func start(c *cli.Context) error {
 
 	if cfg.Osd.ClusterConfig.DefaultDriver != "" && !isDefaultSet {
 		return fmt.Errorf("Invalid OSD config file: Default Driver specified but driver not initialized")
-	}
-
-	if err := flexvolume.StartFlexVolumeAPI(config.FlexVolumePort, cfg.Osd.ClusterConfig.DefaultDriver); err != nil {
-		return fmt.Errorf("Unable to start flexvolume API: %v", err)
 	}
 
 	// Start the graph drivers.


### PR DESCRIPTION
This is a WIP investigation on how to trace request and responses in gRPC. Seems like it works very well.

See result:

```
time="2020-03-11T18:39:02-07:00" level=info msg=Start method=/openstorage.api.OpenStorageVolume/Create reqid=4d24b3fd-dc9a-4f7f-89c8-cf999f4f042e request="{\"name\":\"basde\",\"spec\":{\"size\":21345,\"format\":2,\"ha_level\":1},\"labels\":{\"asdf\":\"asdfdfasdf:\"}}"
time="2020-03-11T18:39:02-07:00" level=info msg=Successful duration="421.018µs" method=/openstorage.api.OpenStorageVolume/Create reqid=4d24b3fd-dc9a-4f7f-89c8-cf999f4f042e response="{\"volume_id\":\"6d9e4829-d454-4d60-8880-cd470640655b\"}"
```

This will have to be done carefully so that no private information is saved to the logs.