### PR TITLE
Update NotInQuorum self node state to listeners.

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -414,7 +414,8 @@ func (nc *NullClusterListener) NodeInspect(node *api.Node) error {
 
 func (nc *NullClusterListener) Halt(
 	self *api.Node,
-	clusterInfo *ClusterInfo) error {
+	clusterInfo *ClusterInfo,
+) error {
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- Whenever a node's status changes to NotInQuorum, Update all the listeners.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

