### PR TITLE
Update listeners when the node is NotInQUorum

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -414,7 +414,8 @@ func (nc *NullClusterListener) NodeInspect(node *api.Node) error {
 
 func (nc *NullClusterListener) Halt(
 	self *api.Node,
-	clusterInfo *ClusterInfo) error {
+	clusterInfo *ClusterInfo,
+) error {
 	return nil
 }
 


### PR DESCRIPTION
- Whenever a node's status changes to NotInQuorum, Update all the listeners.

Signed-off-by: Aditya Dani <aditya@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

