### PR TITLE
Automated cherry pick of #1489: Remove confusing error message for unauthenticated API calls

### DIFF
--- a/api/server/sdk/server_interceptors.go
+++ b/api/server/sdk/server_interceptors.go
@@ -152,6 +152,12 @@ func (s *sdkGrpcServer) authorizationServerInterceptor(
 	// Authorize
 	if err := s.roleServer.Verify(ctx, claims.Roles, info.FullMethod); err != nil {
 		logger.Warning("Access denied")
+		if auth.IsPublic(ctx) {
+			return nil, status.Errorf(
+				codes.PermissionDenied,
+				"Access denied without authentication token")
+		}
+
 		return nil, status.Errorf(
 			codes.PermissionDenied,
 			"Access to %s denied: %v",

--- a/api/server/sdk/server_interceptors_test.go
+++ b/api/server/sdk/server_interceptors_test.go
@@ -50,7 +50,7 @@ func TestAuthorizationServerInterceptorCreate(t *testing.T) {
 			RequestAuthenticated:         false,
 
 			ExpectSuccess: false,
-			ExpectedError: "rpc error: code = PermissionDenied desc = Access to /openstorage.api.OpenStorageVolume/Create denied: rpc error: code = PermissionDenied desc = Access denied to roles: [system.public]",
+			ExpectedError: "rpc error: code = PermissionDenied desc = Access denied without authentication token",
 		},
 		{
 			TestName:                     "2-1: Authenticated volume creation should succeed with public vol creation enabled",


### PR DESCRIPTION
Cherry pick of #1489 on release-7.0.

#1489: Remove confusing error message for unauthenticated API calls

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.