### PR TITLE
Automated cherry pick of #1513: Fix FsType resolution to use PX FsType by default

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -49,6 +49,9 @@ const (
 	volumeCapabilityMessageReadOnlyVolume     = "Volume is read only"
 	volumeCapabilityMessageNotReadOnlyVolume  = "Volume is not read only"
 	defaultCSIVolumeSize                      = uint64(1024 * 1024 * 1024)
+
+	// csi-external-provisioner defaults to ext4
+	defaultFsType = "ext4"
 )
 
 // ControllerGetCapabilities is a CSI API functions which returns to the caller
@@ -570,9 +573,10 @@ func getSpecFromCSI(spec *api.VolumeSpec, req *csi.CreateVolumeRequest) (*api.Vo
 		spec.Sharedv4 = shared
 	}
 
-	// Override any FsType parameter in the storage class parameter
-	// only if an FsType was was provided by CSI
-	if fsType != "" {
+	// PX and CSI both default to ext4 FsType. We only honor the CSI parameter if it
+	// is a non-default value and PX is the default value.
+	if fsType != "" && fsType != defaultFsType && spec.Format == api.FSType_FS_TYPE_EXT4 {
+		// If CSI is provided, but PX is the default, use CSI
 		format, err := api.FSTypeSimpleValueOf(fsType)
 		if err != nil {
 			return spec, err

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -2309,7 +2309,9 @@ func TestGetSpecFromCSI(t *testing.T) {
 					},
 				},
 			},
-			existingSpec: &api.VolumeSpec{},
+			existingSpec: &api.VolumeSpec{
+				Format: api.FSType_FS_TYPE_EXT4,
+			},
 
 			expectedSpec: &api.VolumeSpec{
 				Format:   api.FSType_FS_TYPE_XFS,
@@ -2317,7 +2319,7 @@ func TestGetSpecFromCSI(t *testing.T) {
 			},
 		},
 		{
-			name: "Should override with the CSI parameter if both are provided",
+			name: "Should override with the PX parameter if both are provided",
 			req: &csi.CreateVolumeRequest{
 				VolumeCapabilities: []*csi.VolumeCapability{
 					&csi.VolumeCapability{
@@ -2336,16 +2338,44 @@ func TestGetSpecFromCSI(t *testing.T) {
 			},
 			// for cases when the storage class parameter has fsType: EXT4 and this is already parsed out.
 			existingSpec: &api.VolumeSpec{
-				Format: api.FSType_FS_TYPE_EXT4,
+				Format: api.FSType_FS_TYPE_BTRFS,
 			},
 
-			// We should override with CSI provided parameter.
+			// We should override with PX provided parameter.
 			expectedSpec: &api.VolumeSpec{
-				Format:   api.FSType_FS_TYPE_XFS,
+				Format:   api.FSType_FS_TYPE_BTRFS,
 				Sharedv4: true,
 			},
 		},
+		{
+			name: "Should use the PX parameter if CSI has the default fsType",
+			req: &csi.CreateVolumeRequest{
+				VolumeCapabilities: []*csi.VolumeCapability{
+					&csi.VolumeCapability{
+						AccessType: &csi.VolumeCapability_Mount{
+							Mount: &csi.VolumeCapability_MountVolume{
+								FsType: "ext4",
+							},
+						},
+					},
+					&csi.VolumeCapability{
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+						},
+					},
+				},
+			},
+			// for cases when the storage class parameter has fsType: EXT4 and this is already parsed out.
+			existingSpec: &api.VolumeSpec{
+				Format: api.FSType_FS_TYPE_BTRFS,
+			},
 
+			// We should override with PX provided parameter.
+			expectedSpec: &api.VolumeSpec{
+				Format:   api.FSType_FS_TYPE_BTRFS,
+				Sharedv4: true,
+			},
+		},
 		{
 			name: "Should accept shared instead of sharedv4 if explicitly provided already",
 			req: &csi.CreateVolumeRequest{
@@ -2365,6 +2395,7 @@ func TestGetSpecFromCSI(t *testing.T) {
 				},
 			},
 			existingSpec: &api.VolumeSpec{
+				Format: api.FSType_FS_TYPE_EXT4,
 				Shared: true,
 			},
 
@@ -2391,7 +2422,9 @@ func TestGetSpecFromCSI(t *testing.T) {
 					},
 				},
 			},
-			existingSpec: &api.VolumeSpec{},
+			existingSpec: &api.VolumeSpec{
+				Format: api.FSType_FS_TYPE_EXT4,
+			},
 
 			expectedError: "no openstorage.FS_TYPE for badfs",
 		},


### PR DESCRIPTION
Cherry pick of #1513 on release-8.0.

#1513: Fix FsType resolution to use PX FsType by default

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.