### PR TITLE
Fix token in middleware server

### DIFF
--- a/api/server/middleware_auth.go
+++ b/api/server/middleware_auth.go
@@ -321,6 +321,13 @@ func (a *authMiddleware) enumerateWithAuth(w http.ResponseWriter, r *http.Reques
 }
 
 func (a *authMiddleware) isTokenProcessingRequired(r *http.Request) (volume.VolumeDriver, bool) {
+	// If a token has been passed, then return here
+	if len(r.Header.Get("Authorization")) > 0 {
+		return nil, false
+	}
+
+	// No token has been passed in the request. Determine
+	// if the request is from Kubernetes
 	userAgent := r.Header.Get("User-Agent")
 	if len(userAgent) > 0 {
 		// Check if the request is coming from a container orchestrator

--- a/api/server/middleware_auth_test.go
+++ b/api/server/middleware_auth_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/libopenstorage/openstorage/pkg/auth"
 	"github.com/libopenstorage/openstorage/pkg/auth/systemtoken"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type mockAuthenticator struct {
@@ -229,4 +231,40 @@ func TestNewSecurityMiddlewareCall(t *testing.T) {
 			t.Errorf("Wrong code expected %d actual %d", testCase.expectedHttpCode, rec.Code)
 		}
 	}
+}
+
+func TestAuthMiddlewareIsTokenProcessingRequired(t *testing.T) {
+	orig := OverrideSchedDriverName
+	defer func() {
+		OverrideSchedDriverName = orig
+	}()
+	OverrideSchedDriverName = "fake"
+
+	a := NewAuthMiddleware()
+	assert.NotNil(t, a)
+
+	rNoToken, err := http.NewRequest("GET", "http://localhost:80", nil)
+	assert.NoError(t, err)
+	rWithToken, err := http.NewRequest("GET", "http://localhost:80", nil)
+	assert.NoError(t, err)
+	rWithToken.Header.Set("Authorization", "bearer abcd")
+
+	d, b := a.isTokenProcessingRequired(rNoToken)
+	assert.Nil(t, d)
+	assert.False(t, b)
+
+	d, b = a.isTokenProcessingRequired(rWithToken)
+	assert.Nil(t, d)
+	assert.False(t, b)
+
+	rNoToken.Header.Set("User-Agent", "px-sched")
+	rWithToken.Header.Set("User-Agent", "px-sched")
+
+	d, b = a.isTokenProcessingRequired(rNoToken)
+	assert.NotNil(t, d)
+	assert.True(t, b)
+
+	d, b = a.isTokenProcessingRequired(rWithToken)
+	assert.Nil(t, d)
+	assert.False(t, b)
 }


### PR DESCRIPTION
Cherry-pick of #1538

When a request with a token and a user agent was sent to the
old REST server, the auth middleware assumed that it was from
Kubernetes and tried to get the token for the request, ignoring
the token provided.

This fix makes sure that the token provided is used instead.
