### PR TITLE
Handle secure volumes with secret keys for scaled volumes.

### DIFF
--- a/api/server/docker.go
+++ b/api/server/docker.go
@@ -439,11 +439,23 @@ func (d *driver) remove(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(&volumeResponse{})
 }
 
+func (d *driver) updateSpecForScaleCreate(outSpec, inSpec *api.VolumeSpec) {
+	// Copy over the labels from the input spec
+	// to the output spec which will be used for volume creation
+	for k, v := range inSpec.VolumeLabels {
+		outSpec.VolumeLabels[k] = v
+	}
+	// The storage driver is expected to not store the passphrase in the Spec
+	// Get the passphrase recevied in the request / input spec
+	outSpec.Passphrase = inSpec.Passphrase
+}
+
 func (d *driver) scaleUp(
 	ctx context.Context,
 	conn *grpc.ClientConn,
 	method string,
 	vd volume.VolumeDriver,
+	inSpec *api.VolumeSpec,
 	inVol *api.Volume,
 	allVols []*api.Volume,
 	attachOptions map[string]string,
@@ -458,6 +470,7 @@ func (d *driver) scaleUp(
 	// Create new volume if existing volumes are not available.
 	spec := inVol.Spec.Copy()
 	spec.Scale = 1
+	d.updateSpecForScaleCreate(spec, inSpec)
 	spec.ReplicaSet = nil
 	volCount := len(allVols)
 	for i := len(allVols); volCount < int(inVol.Spec.Scale); i++ {
@@ -492,6 +505,7 @@ func (d *driver) attachScale(
 	conn *grpc.ClientConn,
 	method string,
 	vd volume.VolumeDriver,
+	inSpec *api.VolumeSpec,
 	inVol *api.Volume,
 	attachOptions map[string]string,
 ) (
@@ -547,12 +561,13 @@ func (d *driver) attachScale(
 		spec := inVol.Spec.Copy()
 		spec.ReplicaSet = &api.ReplicaSet{Nodes: []string{volume.LocalNode}}
 		spec.Scale = 1
+		d.updateSpecForScaleCreate(spec, inSpec)
 		resp, err := volumeclient.Create(ctx, &api.SdkVolumeCreateRequest{
 			Name: name,
 			Spec: spec,
 		})
 		if err != nil {
-			return d.scaleUp(ctx, conn, method, vd, inVol, allVols, attachOptions)
+			return d.scaleUp(ctx, conn, method, vd, inSpec, inVol, allVols, attachOptions)
 		}
 		id := resp.GetVolumeId()
 		outVol, err := d.volFromName(id)
@@ -569,7 +584,7 @@ func (d *driver) attachScale(
 		// We failed to attach, scaleUp.
 		allVols = append(allVols, outVol)
 	}
-	return d.scaleUp(ctx, conn, method, vd, inVol, allVols, attachOptions)
+	return d.scaleUp(ctx, conn, method, vd, inSpec, inVol, allVols, attachOptions)
 }
 
 func (d *driver) attachVol(
@@ -710,7 +725,7 @@ func (d *driver) mount(w http.ResponseWriter, r *http.Request) {
 		// If volume is scaled up, a new volume is created and
 		// vol will change.
 		if vol.Scaled() {
-			vol, err = d.attachScale(ctx, conn, method, v, vol, attachOptions)
+			vol, err = d.attachScale(ctx, conn, method, v, spec, vol, attachOptions)
 		} else {
 			vol, err = d.attachVol(ctx, conn, method, v, vol, attachOptions)
 		}


### PR DESCRIPTION
- In docker/DCOS you can use scaled volumes by running the following docker command

   docker run --volume-driver pxd -v secret_key=foo,secure=true,name=scaled_volume,size=10,scale=3:/data -it busybox sh

- The above command will create a volume with provided spec as well as attach it in the busybox container.
- If the same command is now run on another node, the docker volume driver in openstorage will create a new volume as a part
  of this scale set and attach it inside the container.

Problem: The secret_key provided as a part of the docker run command was not getting propagated to the create call
 for volumes done as part of the scale set. So the 2nd volume will not get created in the scale set.

Solution: Pass the secret_key got as a part of the request as VolumeSpec.
Signed-off-by: Aditya Dani <aditya@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

