### PR TITLE
PWX-10619: Fail ha-update when volume is not found

### DIFF
--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -392,7 +392,8 @@ func (vd *volAPI) volumeSet(w http.ResponseWriter, r *http.Request) {
 			VolumeId: volumeID,
 		})
 		if err != nil {
-			if !sdk.IsErrorNotFound(err) {
+			// Return error here for ha-update operation where the Action is nil
+			if !sdk.IsErrorNotFound(err) || req.Action == nil {
 				vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 				return
 			}


### PR DESCRIPTION
Signed-off-by: adikulkarni0 <adi.kulkarni@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Return error when the call to Inspect fails in volumeSet when called to handle ha-update operation
This caused an issue on the customer side where due to typo it was thought the HA update operation was done and a node failure caused a data loss.
**Which issue(s) this PR fixes** (optional)
Closes # PWX-10619

**Special notes for your reviewer**:

