### PR TITLE
Automated cherry pick of #1621: Remove LogDevices in pkg/mount

### DIFF
--- a/pkg/mount/nfs.go
+++ b/pkg/mount/nfs.go
@@ -55,7 +55,6 @@ func (m *nfsMounter) Reload(source string) error {
 	if err != nil {
 		return err
 	}
-	m.LogDevices()
 
 	newNFSmounter, ok := newNFSm.(*nfsMounter)
 	if !ok {
@@ -137,14 +136,4 @@ MountLoop:
 		)
 	}
 	return nil
-}
-
-func (m *nfsMounter) LogDevices() {
-	mnts := make(map[string]string)
-	for _, device := range m.mounts {
-		mnts = map[string]string{}
-		for _, mntPoint := range device.Mountpoint {
-			mnts[mntPoint.Root] = mntPoint.Root
-		}
-	}
 }


### PR DESCRIPTION
Cherry pick of #1621 on release-8.0.

#1621: Remove LogDevices in pkg/mount

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.