### PR TITLE
Fix error missing optional arg list

### DIFF
--- a/api/server/sdk/server_interceptors.go
+++ b/api/server/sdk/server_interceptors.go
@@ -68,7 +68,7 @@ func (s *sdkGrpcServer) auth(ctx context.Context) (context.Context, error) {
 			"method": "Authentication",
 			"code":   c.String(),
 		}).Warningf(format, a)
-		return status.Errorf(c, format, a)
+		return status.Errorf(c, format, a...)
 	}
 
 	// guest call attempted, add system.guest user


### PR DESCRIPTION
**What this PR does / why we need it**:
Error was being returned as:

```
Failed to get volumes: signature is invalid%!(EXTRA []interface {}=[])
```
