### PR TITLE
Allow cloud and node information on default rbac

### DIFF
--- a/pkg/role/sdkserviceapi.go
+++ b/pkg/role/sdkserviceapi.go
@@ -97,6 +97,16 @@ var (
 					Apis: []string{"*"},
 				},
 				&api.SdkRule{
+					Services: []string{
+						"cluster",
+						"node",
+					},
+					Apis: []string{
+						"inspect*",
+						"enumerate*",
+					},
+				},
+				&api.SdkRule{
 					Services: []string{"identity"},
 					Apis:     []string{"*"},
 				},
@@ -123,6 +133,16 @@ var (
 				&api.SdkRule{
 					Services: []string{"identity"},
 					Apis:     []string{"version"},
+				},
+				&api.SdkRule{
+					Services: []string{
+						"cluster",
+						"node",
+					},
+					Apis: []string{
+						"inspect*",
+						"enumerate*",
+					},
 				},
 			},
 			mutable: true,

--- a/pkg/role/sdkserviceapi_test.go
+++ b/pkg/role/sdkserviceapi_test.go
@@ -586,6 +586,41 @@ func TestSdkRoleVerifyRules(t *testing.T) {
 			fullmethod: "/openstorage.api.OpenStorageFutureService/SomeCallInTheFuture",
 			roles:      []string{"system.view"},
 		},
+		{
+			denied:     false,
+			fullmethod: "/openstorage.api.OpenStorageCluster/InspectCurrent",
+			roles:      []string{"system.guest"},
+		},
+		{
+			denied:     false,
+			fullmethod: "/openstorage.api.OpenStorageNode/Enumerate",
+			roles:      []string{"system.guest"},
+		},
+		{
+			denied:     false,
+			fullmethod: "/openstorage.api.OpenStorageNode/Inspect",
+			roles:      []string{"system.guest"},
+		},
+		{
+			denied:     false,
+			fullmethod: "/openstorage.api.OpenStorageCluster/InspectCurrent",
+			roles:      []string{"system.user"},
+		},
+		{
+			denied:     false,
+			fullmethod: "/openstorage.api.OpenStorageNode/Enumerate",
+			roles:      []string{"system.user"},
+		},
+		{
+			denied:     false,
+			fullmethod: "/openstorage.api.OpenStorageNode/Inspect",
+			roles:      []string{"system.user"},
+		},
+		{
+			denied:     true,
+			fullmethod: "/openstorage.api.OpenStorageNode/FutureCall",
+			roles:      []string{"system.user"},
+		},
 	}
 
 	kv, err := kvdb.New(mem.Name, "role", []string{}, nil, kvdb.LogFatalErrorCB)
@@ -595,7 +630,6 @@ func TestSdkRoleVerifyRules(t *testing.T) {
 	assert.NoError(t, err)
 
 	for _, test := range tests {
-		var rules []*api.SdkRule
 		var err error
 		if len(test.roles) != 0 {
 			err = s.Verify(context.Background(), test.roles, test.fullmethod)
@@ -604,9 +638,9 @@ func TestSdkRoleVerifyRules(t *testing.T) {
 		}
 
 		if test.denied {
-			assert.NotNil(t, err, test.fullmethod, rules)
+			assert.NotNil(t, err, test.fullmethod)
 		} else {
-			assert.Nil(t, err, test.fullmethod, rules)
+			assert.Nil(t, err, test.fullmethod)
 		}
 	}
 }


### PR DESCRIPTION
Cherry-pick of #1654 