### PR TITLE
Fix missing updates in cluster listener enumerate

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -169,7 +169,7 @@ type ClusterListenerGenericOps interface {
 	UpdateCluster(self *api.Node, clusterInfo *ClusterInfo) error
 
 	// Enumerate updates listener specific data in Enumerate.
-	Enumerate(cluster api.Cluster) error
+	Enumerate(cluster *api.Cluster) error
 }
 
 // ClusterListenerStatusOps defines APIs that a listener needs to implement
@@ -407,7 +407,7 @@ func (nc *NullClusterListener) CleanupInit(
 	return nil
 }
 
-func (nc *NullClusterListener) Enumerate(cluster api.Cluster) error {
+func (nc *NullClusterListener) Enumerate(_ *api.Cluster) error {
 	return nil
 }
 

--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -1563,7 +1563,7 @@ func (c *ClusterManager) Enumerate() (api.Cluster, error) {
 
 	// Allow listeners to add/modify data
 	for e := c.listeners.Front(); e != nil; e = e.Next() {
-		if err := e.Value.(cluster.ClusterListener).Enumerate(clusterState); err != nil {
+		if err := e.Value.(cluster.ClusterListener).Enumerate(&clusterState); err != nil {
 			logrus.Warnf("listener %s enumerate failed: %v",
 				e.Value.(cluster.ClusterListener).String(), err)
 			continue


### PR DESCRIPTION
The Enumerate interface API in cluster listener is not taking in a pointer. This results in all downstream updates to be lost

Simplified golang playground demonstrating the issue

https://play.golang.org/p/nTATQKfd_kD

Signed-off-by: Harsh Desai <harsh@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

