### PR TITLE
[cherry-pick]  Fix missing updates in cluster listener enumerate (#1660)

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -249,7 +249,7 @@ type Cluster struct {
 	NodeId string
 
 	// array of all the nodes in the cluster.
-	Nodes []Node
+	Nodes []*Node
 
 	// Logging url for the cluster.
 	LoggingURL string

--- a/api/server/cluster_test.go
+++ b/api/server/cluster_test.go
@@ -33,16 +33,16 @@ func TestClusterEnumerateSuccess(t *testing.T) {
 			Id:            "cluster-dummy-id",
 			Status:        api.Status_STATUS_OK,
 			ManagementURL: "mgmturl:1234/mgmt-endpoint",
-			Nodes: []api.Node{
-				api.Node{
+			Nodes: []*api.Node{
+				{
 					Hostname: "node1-hostname",
 					Id:       "1",
 				},
-				api.Node{
+				{
 					Hostname: "node2-hostname",
 					Id:       "2",
 				},
-				api.Node{
+				{
 					Hostname: "node3-hostname",
 					Id:       "3",
 				},

--- a/api/server/sdk/node_test.go
+++ b/api/server/sdk/node_test.go
@@ -62,8 +62,8 @@ func TestSdkNodeEnumerate(t *testing.T) {
 		Id:     "someid",
 		NodeId: "somenodeid",
 		Status: api.Status_STATUS_NOT_IN_QUORUM,
-		Nodes: []api.Node{
-			api.Node{
+		Nodes: []*api.Node{
+			{
 				Id:       "nodeid",
 				Cpu:      1.414,
 				MemTotal: 112,
@@ -139,8 +139,8 @@ func TestSdkNodeEnumerateWithFilters(t *testing.T) {
 		Id:     "someid",
 		NodeId: "somenodeid",
 		Status: api.Status_STATUS_NOT_IN_QUORUM,
-		Nodes: []api.Node{
-			api.Node{
+		Nodes: []*api.Node{
+			{
 				Id:                "nodeid",
 				SchedulerNodeName: "schedulernodename",
 				Cpu:               1.414,
@@ -314,7 +314,7 @@ func TestSdkNodeInspectCurrent(t *testing.T) {
 	nodeid := "nodeid"
 
 	// Create response
-	node := api.Node{
+	node := &api.Node{
 		Id:                nodeid,
 		SchedulerNodeName: "nodename",
 		Cpu:               1.414,
@@ -343,7 +343,7 @@ func TestSdkNodeInspectCurrent(t *testing.T) {
 		Id:     "someid",
 		NodeId: nodeid,
 		Status: api.Status_STATUS_NOT_IN_QUORUM,
-		Nodes:  []api.Node{node},
+		Nodes:  []*api.Node{node},
 	}
 
 	s.MockCluster().EXPECT().Enumerate().Return(cluster, nil).Times(1)

--- a/api/server/sdk/node_test.go
+++ b/api/server/sdk/node_test.go
@@ -314,7 +314,7 @@ func TestSdkNodeInspectCurrent(t *testing.T) {
 	nodeid := "nodeid"
 
 	// Create response
-	node := &api.Node{
+	node := api.Node{
 		Id:                nodeid,
 		SchedulerNodeName: "nodename",
 		Cpu:               1.414,
@@ -343,7 +343,7 @@ func TestSdkNodeInspectCurrent(t *testing.T) {
 		Id:     "someid",
 		NodeId: nodeid,
 		Status: api.Status_STATUS_NOT_IN_QUORUM,
-		Nodes:  []*api.Node{node},
+		Nodes:  []*api.Node{&node},
 	}
 
 	s.MockCluster().EXPECT().Enumerate().Return(cluster, nil).Times(1)

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -167,7 +167,7 @@ type ClusterListenerGenericOps interface {
 	UpdateCluster(self *api.Node, clusterInfo *ClusterInfo) error
 
 	// Enumerate updates listener specific data in Enumerate.
-	Enumerate(cluster api.Cluster) error
+	Enumerate(cluster *api.Cluster) error
 }
 
 // ClusterListenerStatusOps defines APIs that a listener needs to implement
@@ -404,7 +404,7 @@ func (nc *NullClusterListener) CleanupInit(
 	return nil
 }
 
-func (nc *NullClusterListener) Enumerate(cluster api.Cluster) error {
+func (nc *NullClusterListener) Enumerate(_ *api.Cluster) error {
 	return nil
 }
 

--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -1532,7 +1532,7 @@ func (c *ClusterManager) Enumerate() (api.Cluster, error) {
 
 	// Allow listeners to add/modify data
 	for e := c.listeners.Front(); e != nil; e = e.Next() {
-		if err := e.Value.(cluster.ClusterListener).Enumerate(clusterState); err != nil {
+		if err := e.Value.(cluster.ClusterListener).Enumerate(&clusterState); err != nil {
 			logrus.Warnf("listener %s enumerate failed: %v",
 				e.Value.(cluster.ClusterListener).String(), err)
 			continue

--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -1204,7 +1204,7 @@ func (c *ClusterManager) initListeners(
 	c.nodeCacheLock.Lock()
 	defer c.nodeCacheLock.Unlock()
 	for _, node := range c.nodes(kvClusterInfo) {
-		c.nodeCache[node.Id] = node
+		c.nodeCache[node.Id] = *node
 	}
 	return kvp.ModifiedIndex, kvClusterInfo, nil
 }
@@ -1470,8 +1470,8 @@ func (c *ClusterManager) PeerStatus(listenerName string) (map[string]api.Status,
 	return statusMap, nil
 }
 
-func (c *ClusterManager) nodes(clusterDB *cluster.ClusterInfo) []api.Node {
-	nodes := []api.Node{}
+func (c *ClusterManager) nodes(clusterDB *cluster.ClusterInfo) []*api.Node {
+	nodes := make([]*api.Node, 0)
 	for _, n := range clusterDB.NodeEntries {
 		node := api.Node{}
 		if n.Id == c.selfNode.Id {
@@ -1485,29 +1485,29 @@ func (c *ClusterManager) nodes(clusterDB *cluster.ClusterInfo) []api.Node {
 			node.Hostname = n.Hostname
 			node.NodeLabels = n.NodeLabels
 		}
-		nodes = append(nodes, node)
+		nodes = append(nodes, &node)
 	}
 	return nodes
 }
 
-func (c *ClusterManager) enumerateFromClusterDB() []api.Node {
+func (c *ClusterManager) enumerateFromClusterDB() []*api.Node {
 	clusterDB, _, err := readClusterInfo()
 	if err != nil {
 		logrus.Errorf("enumerateNodesFromClusterDB failed with error: %v", err)
-		return make([]api.Node, 0)
+		return make([]*api.Node, 0)
 	}
 	return c.nodes(&clusterDB)
 }
 
-func (c *ClusterManager) enumerateFromCache() []api.Node {
+func (c *ClusterManager) enumerateFromCache() []*api.Node {
 	var clusterDB cluster.ClusterInfo
 	c.nodeCacheLock.Lock()
 	defer c.nodeCacheLock.Unlock()
-	nodes := make([]api.Node, len(c.nodeCache))
+	nodes := make([]*api.Node, len(c.nodeCache))
 	i := 0
 	for _, n := range c.nodeCache {
 		n, _ := c.getNodeEntry(n.Id, &clusterDB)
-		nodes[i] = *n.Copy()
+		nodes[i] = n.Copy()
 		i++
 	}
 	return nodes


### PR DESCRIPTION
* Fix missing updates in cluster listener enumerate

The Enumerate interface API in cluster listener is not taking in a pointer. This results in all downstream updates to be lost

Signed-off-by: Harsh Desai <harsh@portworx.com>

* fix compile

Signed-off-by: Harsh Desai <harsh@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

