### PR TITLE
use pointer to node in cluster api struct

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -266,7 +266,7 @@ type Cluster struct {
 	NodeId string
 
 	// array of all the nodes in the cluster.
-	Nodes []Node
+	Nodes []*Node
 
 	// Management url for the cluster
 	ManagementURL string

--- a/api/server/cluster_test.go
+++ b/api/server/cluster_test.go
@@ -33,16 +33,16 @@ func TestClusterEnumerateSuccess(t *testing.T) {
 			Id:            "cluster-dummy-id",
 			Status:        api.Status_STATUS_OK,
 			ManagementURL: "mgmturl:1234/mgmt-endpoint",
-			Nodes: []api.Node{
-				api.Node{
+			Nodes: []*api.Node{
+				{
 					Hostname: "node1-hostname",
 					Id:       "1",
 				},
-				api.Node{
+				{
 					Hostname: "node2-hostname",
 					Id:       "2",
 				},
-				api.Node{
+				{
 					Hostname: "node3-hostname",
 					Id:       "3",
 				},

--- a/api/server/sdk/node_test.go
+++ b/api/server/sdk/node_test.go
@@ -316,7 +316,7 @@ func TestSdkNodeInspectCurrent(t *testing.T) {
 	nodeid := "nodeid"
 
 	// Create response
-	node := &api.Node{
+	node := api.Node{
 		Id:                nodeid,
 		SchedulerNodeName: "nodename",
 		Cpu:               1.414,
@@ -345,7 +345,7 @@ func TestSdkNodeInspectCurrent(t *testing.T) {
 		Id:     "someid",
 		NodeId: nodeid,
 		Status: api.Status_STATUS_NOT_IN_QUORUM,
-		Nodes:  []*api.Node{node},
+		Nodes:  []*api.Node{&node},
 	}
 
 	s.MockCluster().EXPECT().Enumerate().Return(cluster, nil).Times(1)

--- a/api/server/sdk/node_test.go
+++ b/api/server/sdk/node_test.go
@@ -62,8 +62,8 @@ func TestSdkNodeEnumerate(t *testing.T) {
 		Id:     "someid",
 		NodeId: "somenodeid",
 		Status: api.Status_STATUS_NOT_IN_QUORUM,
-		Nodes: []api.Node{
-			api.Node{
+		Nodes: []*api.Node{
+			{
 				Id:       "nodeid",
 				Cpu:      1.414,
 				MemTotal: 112,
@@ -139,8 +139,8 @@ func TestSdkNodeEnumerateWithFilters(t *testing.T) {
 		Id:     "someid",
 		NodeId: "somenodeid",
 		Status: api.Status_STATUS_NOT_IN_QUORUM,
-		Nodes: []api.Node{
-			api.Node{
+		Nodes: []*api.Node{
+			{
 				Id:                "nodeid",
 				SchedulerNodeName: "schedulernodename",
 				Cpu:               1.414,
@@ -316,7 +316,7 @@ func TestSdkNodeInspectCurrent(t *testing.T) {
 	nodeid := "nodeid"
 
 	// Create response
-	node := api.Node{
+	node := &api.Node{
 		Id:                nodeid,
 		SchedulerNodeName: "nodename",
 		Cpu:               1.414,
@@ -345,7 +345,7 @@ func TestSdkNodeInspectCurrent(t *testing.T) {
 		Id:     "someid",
 		NodeId: nodeid,
 		Status: api.Status_STATUS_NOT_IN_QUORUM,
-		Nodes:  []api.Node{node},
+		Nodes:  []*api.Node{node},
 	}
 
 	s.MockCluster().EXPECT().Enumerate().Return(cluster, nil).Times(1)

--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -1229,7 +1229,7 @@ func (c *ClusterManager) initListeners(
 	c.nodeCacheLock.Lock()
 	defer c.nodeCacheLock.Unlock()
 	for _, node := range c.nodes(kvClusterInfo) {
-		c.nodeCache[node.Id] = node
+		c.nodeCache[node.Id] = *node
 	}
 	return kvp.ModifiedIndex, kvClusterInfo, nil
 }
@@ -1501,8 +1501,8 @@ func (c *ClusterManager) PeerStatus(listenerName string) (map[string]api.Status,
 	return statusMap, nil
 }
 
-func (c *ClusterManager) nodes(clusterDB *cluster.ClusterInfo) []api.Node {
-	nodes := []api.Node{}
+func (c *ClusterManager) nodes(clusterDB *cluster.ClusterInfo) []*api.Node {
+	nodes := make([]*api.Node, 0)
 	for _, n := range clusterDB.NodeEntries {
 		node := api.Node{}
 		if n.Id == c.selfNode.Id {
@@ -1516,29 +1516,29 @@ func (c *ClusterManager) nodes(clusterDB *cluster.ClusterInfo) []api.Node {
 			node.Hostname = n.Hostname
 			node.NodeLabels = n.NodeLabels
 		}
-		nodes = append(nodes, node)
+		nodes = append(nodes, &node)
 	}
 	return nodes
 }
 
-func (c *ClusterManager) enumerateFromClusterDB() []api.Node {
+func (c *ClusterManager) enumerateFromClusterDB() []*api.Node {
 	clusterDB, _, err := readClusterInfo()
 	if err != nil {
 		logrus.Errorf("enumerateNodesFromClusterDB failed with error: %v", err)
-		return make([]api.Node, 0)
+		return make([]*api.Node, 0)
 	}
 	return c.nodes(&clusterDB)
 }
 
-func (c *ClusterManager) enumerateFromCache() []api.Node {
+func (c *ClusterManager) enumerateFromCache() []*api.Node {
 	var clusterDB cluster.ClusterInfo
 	c.nodeCacheLock.Lock()
 	defer c.nodeCacheLock.Unlock()
-	nodes := make([]api.Node, len(c.nodeCache))
+	nodes := make([]*api.Node, len(c.nodeCache))
 	i := 0
 	for _, n := range c.nodeCache {
 		n, _ := c.getNodeEntry(n.Id, &clusterDB)
-		nodes[i] = *n.Copy()
+		nodes[i] = n.Copy()
 		i++
 	}
 	return nodes


### PR DESCRIPTION
Apparently, golang cannot use pass by reference. Instead of hacking each usage, updating the api struct itself

https://dave.cheney.net/2017/04/29/there-is-no-pass-by-reference-in-go

Signed-off-by: Harsh Desai <harsh@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

