### PR TITLE
Automated cherry pick of #1665: Expose DefaultRoles for use in other packages

### DIFF
--- a/pkg/role/sdkserviceapi.go
+++ b/pkg/role/sdkserviceapi.go
@@ -41,28 +41,30 @@ const (
 	SystemGuestRoleName = "system.guest"
 )
 
-type defaultRole struct {
-	rules   []*api.SdkRule
-	mutable bool
+// DefaultRole is a role loaded into the system on startup
+type DefaultRole struct {
+	Rules   []*api.SdkRule
+	Mutable bool
 }
 
 var (
-	// Default roles. Should be prefixed by `system.` to avoid collisions
-	defaultRoles = map[string]*defaultRole{
+	// DefaultRoles are the default roles to load on system startup
+	// Should be prefixed by `system.` to avoid collisions
+	DefaultRoles = map[string]*DefaultRole{
 		// system:admin role can run any command
-		SystemAdminRoleName: &defaultRole{
-			rules: []*api.SdkRule{
+		SystemAdminRoleName: &DefaultRole{
+			Rules: []*api.SdkRule{
 				&api.SdkRule{
 					Services: []string{"*"},
 					Apis:     []string{"*"},
 				},
 			},
-			mutable: false,
+			Mutable: false,
 		},
 
 		// system:view role can only run read-only commands
-		SystemViewRoleName: &defaultRole{
-			rules: []*api.SdkRule{
+		SystemViewRoleName: &DefaultRole{
+			Rules: []*api.SdkRule{
 				&api.SdkRule{
 					Services: []string{"*"},
 					Apis: []string{
@@ -79,11 +81,11 @@ var (
 					Apis:     []string{"*"},
 				},
 			},
-			mutable: false,
+			Mutable: false,
 		},
 		// system:user role can only access volume lifecycle commands
-		SystemUserRoleName: &defaultRole{
-			rules: []*api.SdkRule{
+		SystemUserRoleName: &DefaultRole{
+			Rules: []*api.SdkRule{
 				&api.SdkRule{
 					Services: []string{
 						"volume",
@@ -109,13 +111,13 @@ var (
 					},
 				},
 			},
-			mutable: false,
+			Mutable: false,
 		},
 
 		// system:guest role is used for any unauthenticated user.
 		// They can only use standard volume lifecycle commands.
-		SystemGuestRoleName: &defaultRole{
-			rules: []*api.SdkRule{
+		SystemGuestRoleName: &DefaultRole{
+			Rules: []*api.SdkRule{
 				&api.SdkRule{
 					Services: []string{"mountattach", "volume", "cloudbackup", "migrate"},
 					Apis:     []string{"*"},
@@ -125,7 +127,7 @@ var (
 					Apis:     []string{"version"},
 				},
 			},
-			mutable: true,
+			Mutable: true,
 		},
 	}
 )
@@ -191,7 +193,7 @@ func NewSdkRoleManager(kv kvdb.Kvdb) (*SdkRoleManager, error) {
 	}
 
 	// Load all default roles
-	for roleName, defaultRole := range defaultRoles {
+	for roleName, defaultRole := range DefaultRoles {
 		roleExists := false
 		if _, err := kv.Get(prefixWithName(roleName)); err == nil {
 			roleExists = true
@@ -199,10 +201,10 @@ func NewSdkRoleManager(kv kvdb.Kvdb) (*SdkRoleManager, error) {
 
 		// always re-initialize immutable default roles.
 		// if the role is mutable and does exist, skip kvdb put.
-		if !roleExists || !defaultRole.mutable {
+		if !roleExists || !defaultRole.Mutable {
 			role := &api.SdkRole{
 				Name:  roleName,
-				Rules: defaultRole.rules,
+				Rules: defaultRole.Rules,
 			}
 			if _, err := kv.Put(prefixWithName(roleName), role, 0); err != nil {
 				return nil, err
@@ -227,7 +229,7 @@ func (r *SdkRoleManager) Create(
 	}
 
 	// Determine if there is collision with default roles
-	if _, ok := defaultRoles[req.GetRole().GetName()]; ok {
+	if _, ok := DefaultRoles[req.GetRole().GetName()]; ok {
 		return nil, status.Errorf(
 			codes.InvalidArgument,
 			"Name %s already used by system role", req.GetRole().GetName())
@@ -310,7 +312,7 @@ func (r *SdkRoleManager) Delete(
 	}
 
 	// Determine if there is collision with default roles
-	if _, ok := defaultRoles[req.GetName()]; ok {
+	if _, ok := DefaultRoles[req.GetName()]; ok {
 		return nil, status.Errorf(
 			codes.InvalidArgument,
 			"Cannot delete system role %s", req.GetName())
@@ -338,7 +340,7 @@ func (r *SdkRoleManager) Update(
 
 	// Determine if there is collision with default roles.
 	// We can still update mutable default roles.
-	if defaultRole, ok := defaultRoles[req.GetRole().GetName()]; ok && !defaultRole.mutable {
+	if defaultRole, ok := DefaultRoles[req.GetRole().GetName()]; ok && !defaultRole.Mutable {
 		return nil, status.Errorf(
 			codes.InvalidArgument,
 			"System role %s cannot be updated", req.GetRole().GetName())

--- a/pkg/role/sdkserviceapi_test.go
+++ b/pkg/role/sdkserviceapi_test.go
@@ -197,11 +197,11 @@ func TestSdkRuleCreateCollisionSystemRole(t *testing.T) {
 	s, err := NewSdkRoleManager(kv)
 	assert.NoError(t, err)
 
-	for roleName, defaultRole := range defaultRoles {
+	for roleName, defaultRole := range DefaultRoles {
 		req := &api.SdkRoleCreateRequest{
 			Role: &api.SdkRole{
 				Name:  roleName,
-				Rules: defaultRole.rules,
+				Rules: defaultRole.Rules,
 			},
 		}
 		_, err := s.Create(context.Background(), req)
@@ -292,7 +292,7 @@ func TestSdkRuleEnumerate(t *testing.T) {
 
 	r, err := s.Enumerate(context.Background(), &api.SdkRoleEnumerateRequest{})
 	assert.NoError(t, err)
-	assert.Len(t, r.GetNames(), 2+len(defaultRoles))
+	assert.Len(t, r.GetNames(), 2+len(DefaultRoles))
 	assert.Contains(t, r.GetNames(), "one")
 	assert.Contains(t, r.GetNames(), "two")
 }
@@ -376,7 +376,7 @@ func TestSdkRuleDeleteCollisionSystemRole(t *testing.T) {
 	s, err := NewSdkRoleManager(kv)
 	assert.NoError(t, err)
 
-	for systemRole, _ := range defaultRoles {
+	for systemRole, _ := range DefaultRoles {
 		req := &api.SdkRoleDeleteRequest{
 			Name: systemRole,
 		}
@@ -451,15 +451,15 @@ func TestSdkRuleUpdateCollisionSystemRole(t *testing.T) {
 	s, err := NewSdkRoleManager(kv)
 	assert.NoError(t, err)
 
-	for roleName, defaultRole := range defaultRoles {
+	for roleName, defaultRole := range DefaultRoles {
 		req := &api.SdkRoleUpdateRequest{
 			Role: &api.SdkRole{
 				Name:  roleName,
-				Rules: defaultRole.rules,
+				Rules: defaultRole.Rules,
 			},
 		}
 		_, err := s.Update(context.Background(), req)
-		if defaultRole.mutable {
+		if defaultRole.Mutable {
 			assert.NoError(t, err)
 		} else {
 			assert.Error(t, err)


### PR DESCRIPTION
Cherry pick of #1665 on release-8.0.

#1665: Expose DefaultRoles for use in other packages

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.