### PR TITLE
[pkg/auth] Make duration parse RegEx check end and beginning of string

### DIFF
--- a/pkg/auth/duration.go
+++ b/pkg/auth/duration.go
@@ -23,22 +23,34 @@ import (
 )
 
 const (
+	// SecondDef is the abbrevation for seconds
 	SecondDef = "s"
+	// MinuteDef is the abbrevation for minutes
 	MinuteDef = "m"
-	HourDef   = "h"
-	DayDef    = "d"
-	YearDef   = "y"
+	// HourDef is the abbrevation for hours
+	HourDef = "h"
+	// DayDef is the abbrevation for days
+	DayDef = "d"
+	// YearDef is the abbrevation for years
+	YearDef = "y"
 
-	Day  = time.Hour * 24
+	// Day is the duration of hours in a day
+	Day = time.Hour * 24
+	// Year is the duration of days in a year
 	Year = Day * 365
 )
 
 var (
-	SecondRegex = regexp.MustCompile("([0-9]+)" + SecondDef)
-	MinuteRegex = regexp.MustCompile("([0-9]+)" + MinuteDef)
-	HourRegex   = regexp.MustCompile("([0-9]+)" + HourDef)
-	DayRegex    = regexp.MustCompile("([0-9]+)" + DayDef)
-	YearRegex   = regexp.MustCompile("([0-9]+)" + YearDef)
+	// SecondRegex is a regular expression for finding seconds as a duration
+	SecondRegex = regexp.MustCompile("^([0-9]+)" + SecondDef + "$")
+	// MinuteRegex is a regular expression for finding minutes as a duration
+	MinuteRegex = regexp.MustCompile("^([0-9]+)" + MinuteDef + "$")
+	// HourRegex is a regular expression for finding hours as a duration
+	HourRegex = regexp.MustCompile("^([0-9]+)" + HourDef + "$")
+	// DayRegex is a regular expression for finding days as a duration
+	DayRegex = regexp.MustCompile("^([0-9]+)" + DayDef + "$")
+	// YearRegex is a regular expression for finding years as a duration
+	YearRegex = regexp.MustCompile("^([0-9]+)" + YearDef + "$")
 )
 
 // ParseToDuration takes in a "human" type duration and changes it to

--- a/pkg/auth/duration_test.go
+++ b/pkg/auth/duration_test.go
@@ -49,6 +49,21 @@ func TestParseDuration(t *testing.T) {
 			expectedDuration: 123 * time.Second,
 		},
 		{
+			s:                "123sabcd",
+			expectedDuration: 0,
+			expectFail:       true,
+		},
+		{
+			s:                "ab123s",
+			expectedDuration: 0,
+			expectFail:       true,
+		},
+		{
+			s:                "ab123s123",
+			expectedDuration: 0,
+			expectFail:       true,
+		},
+		{
 			s:                "123",
 			expectedDuration: 0,
 			expectFail:       true,


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
This regex will still parse `1habc` as `1h`.

This adds a check in the regex for end of string.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

