### PR TITLE
Check for nil when accessing secret instance

### DIFF
--- a/api/server/middleware_auth.go
+++ b/api/server/middleware_auth.go
@@ -429,7 +429,8 @@ func (a *authMiddleware) parseSecret(
 ) (*api.TokenSecretContext, error) {
 
 	// Check if it is Kubernetes
-	if lsecrets.Instance().String() == lsecrets.TypeK8s {
+	if lsecrets.Instance() != nil &&
+		lsecrets.Instance().String() == lsecrets.TypeK8s {
 		return a.getSecretInformationInKubernetes(specLabels, locatorLabels)
 	}
 

--- a/pkg/auth/secrets/secrets.go
+++ b/pkg/auth/secrets/secrets.go
@@ -87,6 +87,11 @@ func GetToken(tokenSecretContext *api.TokenSecretContext) (string, error) {
 func requestToContext(request *api.TokenSecretContext) map[string]string {
 	context := make(map[string]string)
 
+	// Check if instance is nil
+	if lsecrets.Instance() == nil {
+		return context
+	}
+
 	// Add namespace for providers that support it.
 	switch lsecrets.Instance().String() {
 	case lsecrets.TypeK8s:


### PR DESCRIPTION
**What this PR does / why we need it**:
Need to check for nil when accessing the secrets instance


