### PR TITLE
Handle Set requests from CO in auth middleware.

### DIFF
--- a/api/server/middleware_k8s_test.go
+++ b/api/server/middleware_k8s_test.go
@@ -254,7 +254,7 @@ func TestAuthMiddlewareIsTokenProcessingRequired(t *testing.T) {
 	}()
 	OverrideSchedDriverName = "fake"
 
-	a := NewAuthMiddleware()
+	a := NewK8sMiddleware()
 	assert.NotNil(t, a)
 
 	rNoToken, err := http.NewRequest("GET", "http://localhost:80", nil)

--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -1861,39 +1861,39 @@ func (vd *volAPI) SetupRoutesWithAuth(
 	// - ENUMERATE
 	// For all other routes it is expected that the REST client uses an auth token
 
-	authM := NewAuthMiddleware()
+	k8sM := NewK8sMiddleware()
 
 	// Setup middleware for Create
 	nCreate := negroni.New()
-	nCreate.Use(negroni.HandlerFunc(authM.createWithAuth))
+	nCreate.Use(negroni.HandlerFunc(k8sM.createWithAuth))
 	createRoute := vd.volumeCreateRoute()
 	nCreate.UseHandlerFunc(createRoute.fn)
 	router.Methods(createRoute.verb).Path(createRoute.path).Handler(nCreate)
 
 	// Setup middleware for Delete
 	nDelete := negroni.New()
-	nDelete.Use(negroni.HandlerFunc(authM.deleteWithAuth))
+	nDelete.Use(negroni.HandlerFunc(k8sM.deleteWithAuth))
 	deleteRoute := vd.volumeDeleteRoute()
 	nDelete.UseHandlerFunc(deleteRoute.fn)
 	router.Methods(deleteRoute.verb).Path(deleteRoute.path).Handler(nDelete)
 
 	// Setup middleware for Set
 	nSet := negroni.New()
-	nSet.Use(negroni.HandlerFunc(authM.setWithAuth))
+	nSet.Use(negroni.HandlerFunc(k8sM.setWithAuth))
 	setRoute := vd.volumeSetRoute()
 	nSet.UseHandlerFunc(setRoute.fn)
 	router.Methods(setRoute.verb).Path(setRoute.path).Handler(nSet)
 
 	// Setup middleware for Inspect
 	nInspect := negroni.New()
-	nInspect.Use(negroni.HandlerFunc(authM.inspectWithAuth))
+	nInspect.Use(negroni.HandlerFunc(k8sM.inspectWithAuth))
 	inspectRoute := vd.volumeInspectRoute()
 	nInspect.UseHandlerFunc(inspectRoute.fn)
 	router.Methods(inspectRoute.verb).Path(inspectRoute.path).Handler(nInspect)
 
 	// Setup middleware for enumerate
 	nEnumerate := negroni.New()
-	nEnumerate.Use(negroni.HandlerFunc(authM.enumerateWithAuth))
+	nEnumerate.Use(negroni.HandlerFunc(k8sM.enumerateWithAuth))
 	enumerateRoute := vd.volumeEnumerateRoute()
 	nEnumerate.UseHandlerFunc(enumerateRoute.fn)
 	router.Methods(enumerateRoute.verb).Path(enumerateRoute.path).Handler(nEnumerate)
@@ -1964,7 +1964,7 @@ func GetVolumeAPIRoutesWithAuth(
 		dummyMux: runtime.NewServeMux(),
 	}
 
-	authM := NewAuthMiddleware()
+	k8sM := NewK8sMiddleware()
 
 	// We setup auth middlewares for all the APIs that get invoked
 	// from a Container Orchestrator.
@@ -1976,35 +1976,35 @@ func GetVolumeAPIRoutesWithAuth(
 
 	// Setup middleware for Create
 	nCreate := negroni.New()
-	nCreate.Use(negroni.HandlerFunc(authM.createWithAuth))
+	nCreate.Use(negroni.HandlerFunc(k8sM.createWithAuth))
 	createRoute := vd.volumeCreateRoute()
 	nCreate.UseHandlerFunc(serverRegisterRoute(createRoute.fn, preRouteCheckFn))
 	router.Methods(createRoute.verb).Path(createRoute.path).Handler(nCreate)
 
 	// Setup middleware for Delete
 	nDelete := negroni.New()
-	nDelete.Use(negroni.HandlerFunc(authM.deleteWithAuth))
+	nDelete.Use(negroni.HandlerFunc(k8sM.deleteWithAuth))
 	deleteRoute := vd.volumeDeleteRoute()
 	nDelete.UseHandlerFunc(serverRegisterRoute(deleteRoute.fn, preRouteCheckFn))
 	router.Methods(deleteRoute.verb).Path(deleteRoute.path).Handler(nDelete)
 
 	// Setup middleware for Set
 	nSet := negroni.New()
-	nSet.Use(negroni.HandlerFunc(authM.setWithAuth))
+	nSet.Use(negroni.HandlerFunc(k8sM.setWithAuth))
 	setRoute := vd.volumeSetRoute()
 	nSet.UseHandlerFunc(serverRegisterRoute(setRoute.fn, preRouteCheckFn))
 	router.Methods(setRoute.verb).Path(setRoute.path).Handler(nSet)
 
 	// Setup middleware for Inspect
 	nInspect := negroni.New()
-	nInspect.Use(negroni.HandlerFunc(authM.inspectWithAuth))
+	nInspect.Use(negroni.HandlerFunc(k8sM.inspectWithAuth))
 	inspectRoute := vd.volumeInspectRoute()
 	nInspect.UseHandlerFunc(serverRegisterRoute(inspectRoute.fn, preRouteCheckFn))
 	router.Methods(inspectRoute.verb).Path(inspectRoute.path).Handler(nInspect)
 
 	// Setup middleware for Enumerate
 	nEnumerate := negroni.New()
-	nEnumerate.Use(negroni.HandlerFunc(authM.enumerateWithAuth))
+	nEnumerate.Use(negroni.HandlerFunc(k8sM.enumerateWithAuth))
 	enumerateRoute := vd.volumeEnumerateRoute()
 	nEnumerate.UseHandlerFunc(serverRegisterRoute(enumerateRoute.fn, preRouteCheckFn))
 	router.Methods(enumerateRoute.verb).Path(enumerateRoute.path).Handler(nEnumerate)


### PR DESCRIPTION
**What this PR does / why we need it**:
- Reset certain fields in the Set request.
- If the request is coming from a container orchestrator like kubernetes
  we only allow setting the volume size in the Set request. All other fields
  should be reset to the original values. This needs to be done since kubernetes
  in-tree driver has older vendor'ed openstorage code, so any new boolean flags
  added to the VolumeSpec will always be set to false overwriting the exising value.

Signed-off-by: Aditya Dani <aditya@portworx.com>


**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

