### PR TITLE
Handle Set requests from CO in auth middleware.

### DIFF
--- a/api/server/middleware_k8s.go
+++ b/api/server/middleware_k8s.go
@@ -34,13 +34,13 @@ var (
 	OverrideSchedDriverName = ""
 )
 
-// NewAuthMiddleware returns a negroni implementation of an http middleware
+// NewK8sMiddleware returns a negroni implementation of an http middleware
 // which will intercept the management APIs
-func NewAuthMiddleware() *authMiddleware {
-	return &authMiddleware{}
+func NewK8sMiddleware() *k8sMiddleware {
+	return &k8sMiddleware{}
 }
 
-type authMiddleware struct {
+type k8sMiddleware struct {
 }
 
 // newSecurityMiddleware based on auth configuration returns SecurityHandler or just
@@ -125,7 +125,7 @@ func SecurityHandler(authenticators map[string]auth.Authenticator, next http.Han
 	}
 }
 
-func (a *authMiddleware) createWithAuth(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+func (a *k8sMiddleware) createWithAuth(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	fn := "create"
 	_, authRequired := a.isTokenProcessingRequired(r)
 	if !authRequired {
@@ -184,8 +184,9 @@ func (a *authMiddleware) createWithAuth(w http.ResponseWriter, r *http.Request, 
 	next(w, r)
 }
 
-func (a *authMiddleware) setWithAuth(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+func (a *k8sMiddleware) setWithAuth(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	fn := "set"
+
 	d, authRequired := a.isTokenProcessingRequired(r)
 	if !authRequired {
 		next(w, r)
@@ -198,6 +199,41 @@ func (a *authMiddleware) setWithAuth(w http.ResponseWriter, r *http.Request, nex
 		next(w, r)
 		return
 	}
+
+	var req api.VolumeSetRequest
+
+	err = json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		volumeResponse := &api.VolumeResponse{
+			Error: err.Error(),
+		}
+		json.NewEncoder(w).Encode(volumeResponse)
+		return
+	}
+	if req.Spec != nil {
+		// A volume Set request for changing spec
+		// For requests from COs we need to reset certain fields
+		vols, err := d.Inspect([]string{volumeID})
+		if err != nil || len(vols) == 0 || vols[0] == nil {
+			next(w, r)
+			return
+		}
+		resetFields(req.Spec, vols[0].Spec)
+	}
+
+	newBody, err := json.Marshal(req)
+	if err != nil {
+		err = fmt.Errorf("failed to wrap set request: %v", err)
+		volumeResponse := &api.VolumeResponse{
+			Error: err.Error(),
+		}
+		json.NewEncoder(w).Encode(volumeResponse)
+		return
+	}
+
+	// Reset the request's Body
+	r.ContentLength = int64(len(newBody))
+	r.Body = ioutil.NopCloser(bytes.NewBuffer(newBody))
 
 	token, err := a.fetchSecretForVolume(d, volumeID)
 	if err != nil {
@@ -212,10 +248,25 @@ func (a *authMiddleware) setWithAuth(w http.ResponseWriter, r *http.Request, nex
 	}
 
 	next(w, r)
-
 }
 
-func (a *authMiddleware) deleteWithAuth(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+func resetFields(inputSpec *api.VolumeSpec, currentSpec *api.VolumeSpec) {
+	// If the request is coming from a container orchestrator like kubernetes
+	// we only allow setting the volume size in the Set request. All other fields
+	// should be reset to the original values. This needs to be done since kubernetes
+	// in-tree driver has older vendor'ed openstorage code, so any new boolean flags
+	// added to the VolumeSpec will always be set to false overwriting the exising value.
+
+	inputSpec.Cascaded = currentSpec.Cascaded
+	inputSpec.Journal = currentSpec.Journal
+	inputSpec.Sharedv4 = currentSpec.Sharedv4
+	inputSpec.QueueDepth = currentSpec.QueueDepth
+	inputSpec.ForceUnsupportedFsType = currentSpec.ForceUnsupportedFsType
+	inputSpec.Nodiscard = currentSpec.Nodiscard
+	inputSpec.StoragePolicy = currentSpec.StoragePolicy
+}
+
+func (a *k8sMiddleware) deleteWithAuth(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	fn := "delete"
 	d, authRequired := a.isTokenProcessingRequired(r)
 	if !authRequired {
@@ -252,7 +303,7 @@ func (a *authMiddleware) deleteWithAuth(w http.ResponseWriter, r *http.Request, 
 	next(w, r)
 }
 
-func (a *authMiddleware) inspectWithAuth(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+func (a *k8sMiddleware) inspectWithAuth(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	fn := "inspect"
 	d, authRequired := a.isTokenProcessingRequired(r)
 	if !authRequired {
@@ -277,7 +328,7 @@ func (a *authMiddleware) inspectWithAuth(w http.ResponseWriter, r *http.Request,
 	json.NewEncoder(w).Encode(dk)
 }
 
-func (a *authMiddleware) enumerateWithAuth(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+func (a *k8sMiddleware) enumerateWithAuth(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	fn := "enumerate"
 
 	d, authRequired := a.isTokenProcessingRequired(r)
@@ -308,7 +359,7 @@ func (a *authMiddleware) enumerateWithAuth(w http.ResponseWriter, r *http.Reques
 	next(w, r)
 }
 
-func (a *authMiddleware) isTokenProcessingRequired(r *http.Request) (volume.VolumeDriver, bool) {
+func (a *k8sMiddleware) isTokenProcessingRequired(r *http.Request) (volume.VolumeDriver, bool) {
 	// If a token has been passed, then return here
 	if len(r.Header.Get("Authorization")) > 0 {
 		return nil, false
@@ -337,7 +388,7 @@ func (a *authMiddleware) isTokenProcessingRequired(r *http.Request) (volume.Volu
 	return nil, false
 }
 
-func (a *authMiddleware) insertToken(r *http.Request, token string) {
+func (a *k8sMiddleware) insertToken(r *http.Request, token string) {
 	// Set the token in header
 	if auth.IsJwtToken(token) {
 		r.Header.Set("Authorization", "bearer "+token)
@@ -346,7 +397,7 @@ func (a *authMiddleware) insertToken(r *http.Request, token string) {
 	}
 }
 
-func (a *authMiddleware) parseID(r *http.Request) (string, error) {
+func (a *k8sMiddleware) parseID(r *http.Request) (string, error) {
 	if id, err := a.parseParam(r, "id"); err == nil {
 		return id, nil
 	}
@@ -354,7 +405,7 @@ func (a *authMiddleware) parseID(r *http.Request) (string, error) {
 	return "", fmt.Errorf("could not parse snap ID")
 }
 
-func (a *authMiddleware) parseParam(r *http.Request, param string) (string, error) {
+func (a *k8sMiddleware) parseParam(r *http.Request, param string) (string, error) {
 	vars := mux.Vars(r)
 	if id, ok := vars[param]; ok {
 		return id, nil
@@ -364,7 +415,7 @@ func (a *authMiddleware) parseParam(r *http.Request, param string) (string, erro
 
 // This functions makes it possible to secure the model of accessing the secret by allowing
 // the definition of secret access to come from the storage class, as done by CSI.
-func (a *authMiddleware) getSecretInformationInKubernetes(
+func (a *k8sMiddleware) getSecretInformationInKubernetes(
 	specLabels, locatorLabels map[string]string,
 ) (*api.TokenSecretContext, error) {
 	// Get pvc location and name
@@ -424,7 +475,7 @@ func (a *authMiddleware) getSecretInformationInKubernetes(
 	}, nil
 }
 
-func (a *authMiddleware) parseSecret(
+func (a *k8sMiddleware) parseSecret(
 	specLabels, locatorLabels map[string]string,
 ) (*api.TokenSecretContext, error) {
 
@@ -458,7 +509,7 @@ func parseSecretFromLabels(specLabels, locatorLabels map[string]string) (*api.To
 	}, nil
 }
 
-func (a *authMiddleware) log(id, fn string) *logrus.Entry {
+func (a *k8sMiddleware) log(id, fn string) *logrus.Entry {
 	return logrus.WithFields(map[string]interface{}{
 		"ID":        id,
 		"Component": "auth-middleware",
@@ -466,7 +517,7 @@ func (a *authMiddleware) log(id, fn string) *logrus.Entry {
 	})
 }
 
-func (a *authMiddleware) getBody(r *http.Request) io.ReadCloser {
+func (a *k8sMiddleware) getBody(r *http.Request) io.ReadCloser {
 	// Make a copy of the reader so that the next handler
 	// has access to the body
 	buf, _ := ioutil.ReadAll(r.Body)
@@ -485,7 +536,7 @@ func getVolumeLabel(key string, specLabels, locatorLabels map[string]string) (st
 	return v, ok
 }
 
-func (a *authMiddleware) fetchSecretForVolume(d volume.VolumeDriver, id string) (string, error) {
+func (a *k8sMiddleware) fetchSecretForVolume(d volume.VolumeDriver, id string) (string, error) {
 	vols, err := d.Inspect([]string{id})
 	if err != nil || len(vols) == 0 || vols[0] == nil {
 		return "", fmt.Errorf("Volume %s does not exist", id)

--- a/api/server/middleware_k8s_test.go
+++ b/api/server/middleware_k8s_test.go
@@ -254,7 +254,7 @@ func TestAuthMiddlewareIsTokenProcessingRequired(t *testing.T) {
 	}()
 	OverrideSchedDriverName = "fake"
 
-	a := NewAuthMiddleware()
+	a := NewK8sMiddleware()
 	assert.NotNil(t, a)
 
 	rNoToken, err := http.NewRequest("GET", "http://localhost:80", nil)

--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -1856,39 +1856,39 @@ func (vd *volAPI) SetupRoutesWithAuth(
 	// - ENUMERATE
 	// For all other routes it is expected that the REST client uses an auth token
 
-	authM := NewAuthMiddleware()
+	k8sM := NewK8sMiddleware()
 
 	// Setup middleware for Create
 	nCreate := negroni.New()
-	nCreate.Use(negroni.HandlerFunc(authM.createWithAuth))
+	nCreate.Use(negroni.HandlerFunc(k8sM.createWithAuth))
 	createRoute := vd.volumeCreateRoute()
 	nCreate.UseHandlerFunc(createRoute.fn)
 	router.Methods(createRoute.verb).Path(createRoute.path).Handler(nCreate)
 
 	// Setup middleware for Delete
 	nDelete := negroni.New()
-	nDelete.Use(negroni.HandlerFunc(authM.deleteWithAuth))
+	nDelete.Use(negroni.HandlerFunc(k8sM.deleteWithAuth))
 	deleteRoute := vd.volumeDeleteRoute()
 	nDelete.UseHandlerFunc(deleteRoute.fn)
 	router.Methods(deleteRoute.verb).Path(deleteRoute.path).Handler(nDelete)
 
 	// Setup middleware for Set
 	nSet := negroni.New()
-	nSet.Use(negroni.HandlerFunc(authM.setWithAuth))
+	nSet.Use(negroni.HandlerFunc(k8sM.setWithAuth))
 	setRoute := vd.volumeSetRoute()
 	nSet.UseHandlerFunc(setRoute.fn)
 	router.Methods(setRoute.verb).Path(setRoute.path).Handler(nSet)
 
 	// Setup middleware for Inspect
 	nInspect := negroni.New()
-	nInspect.Use(negroni.HandlerFunc(authM.inspectWithAuth))
+	nInspect.Use(negroni.HandlerFunc(k8sM.inspectWithAuth))
 	inspectRoute := vd.volumeInspectRoute()
 	nInspect.UseHandlerFunc(inspectRoute.fn)
 	router.Methods(inspectRoute.verb).Path(inspectRoute.path).Handler(nInspect)
 
 	// Setup middleware for enumerate
 	nEnumerate := negroni.New()
-	nEnumerate.Use(negroni.HandlerFunc(authM.enumerateWithAuth))
+	nEnumerate.Use(negroni.HandlerFunc(k8sM.enumerateWithAuth))
 	enumerateRoute := vd.volumeEnumerateRoute()
 	nEnumerate.UseHandlerFunc(enumerateRoute.fn)
 	router.Methods(enumerateRoute.verb).Path(enumerateRoute.path).Handler(nEnumerate)
@@ -1959,7 +1959,7 @@ func GetVolumeAPIRoutesWithAuth(
 		dummyMux: runtime.NewServeMux(),
 	}
 
-	authM := NewAuthMiddleware()
+	k8sM := NewK8sMiddleware()
 
 	// We setup auth middlewares for all the APIs that get invoked
 	// from a Container Orchestrator.
@@ -1971,35 +1971,35 @@ func GetVolumeAPIRoutesWithAuth(
 
 	// Setup middleware for Create
 	nCreate := negroni.New()
-	nCreate.Use(negroni.HandlerFunc(authM.createWithAuth))
+	nCreate.Use(negroni.HandlerFunc(k8sM.createWithAuth))
 	createRoute := vd.volumeCreateRoute()
 	nCreate.UseHandlerFunc(serverRegisterRoute(createRoute.fn, preRouteCheckFn))
 	router.Methods(createRoute.verb).Path(createRoute.path).Handler(nCreate)
 
 	// Setup middleware for Delete
 	nDelete := negroni.New()
-	nDelete.Use(negroni.HandlerFunc(authM.deleteWithAuth))
+	nDelete.Use(negroni.HandlerFunc(k8sM.deleteWithAuth))
 	deleteRoute := vd.volumeDeleteRoute()
 	nDelete.UseHandlerFunc(serverRegisterRoute(deleteRoute.fn, preRouteCheckFn))
 	router.Methods(deleteRoute.verb).Path(deleteRoute.path).Handler(nDelete)
 
 	// Setup middleware for Set
 	nSet := negroni.New()
-	nSet.Use(negroni.HandlerFunc(authM.setWithAuth))
+	nSet.Use(negroni.HandlerFunc(k8sM.setWithAuth))
 	setRoute := vd.volumeSetRoute()
 	nSet.UseHandlerFunc(serverRegisterRoute(setRoute.fn, preRouteCheckFn))
 	router.Methods(setRoute.verb).Path(setRoute.path).Handler(nSet)
 
 	// Setup middleware for Inspect
 	nInspect := negroni.New()
-	nInspect.Use(negroni.HandlerFunc(authM.inspectWithAuth))
+	nInspect.Use(negroni.HandlerFunc(k8sM.inspectWithAuth))
 	inspectRoute := vd.volumeInspectRoute()
 	nInspect.UseHandlerFunc(serverRegisterRoute(inspectRoute.fn, preRouteCheckFn))
 	router.Methods(inspectRoute.verb).Path(inspectRoute.path).Handler(nInspect)
 
 	// Setup middleware for Enumerate
 	nEnumerate := negroni.New()
-	nEnumerate.Use(negroni.HandlerFunc(authM.enumerateWithAuth))
+	nEnumerate.Use(negroni.HandlerFunc(k8sM.enumerateWithAuth))
 	enumerateRoute := vd.volumeEnumerateRoute()
 	nEnumerate.UseHandlerFunc(serverRegisterRoute(enumerateRoute.fn, preRouteCheckFn))
 	router.Methods(enumerateRoute.verb).Path(enumerateRoute.path).Handler(nEnumerate)


### PR DESCRIPTION
- Reset certain fields in the Set request.
- If the request is coming from a container orchestrator like kubernetes
  we only allow setting the volume size in the Set request. All other fields
  should be reset to the original values. This needs to be done since kubernetes
  in-tree driver has older vendor'ed openstorage code, so any new boolean flags
  added to the VolumeSpec will always be set to false overwriting the exising value.

Signed-off-by: Aditya Dani <aditya@portworx.com>


