### PR TITLE
Make unit tests compatible with podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ REGISTRY = openstorage
 IMAGE_MOCKSDKSERVER := $(REGISTRY)/mock-sdk-server:$(MOCKSDKSERVERTAG)
 
 ifndef TAGS
-TAGS := daemon
+$(error TAGS not defined)
+TAGS := daemon mounttest
 endif
 
 ifndef PKGS
@@ -290,7 +291,6 @@ docker-build: docker-build-osd-dev
 docker-test: docker-build-osd-dev
 	docker run \
 		--privileged \
-		-v /var/run/docker.sock:/var/run/docker.sock \
 		-v /mnt:/mnt \
 		-e AWS_REGION \
 		-e AWS_ZONE \

--- a/pkg/chattr/chattr_test.go
+++ b/pkg/chattr/chattr_test.go
@@ -1,3 +1,5 @@
+// +build mounttest
+
 package chattr
 
 import (

--- a/pkg/mount/deleted_mount_test.go
+++ b/pkg/mount/deleted_mount_test.go
@@ -1,3 +1,5 @@
+//+build mounttest
+
 package mount
 
 import (

--- a/pkg/mount/device_test.go
+++ b/pkg/mount/device_test.go
@@ -1,3 +1,5 @@
+// +build mounttest
+
 package mount
 
 import (

--- a/pkg/mount/mount_test.go
+++ b/pkg/mount/mount_test.go
@@ -1,3 +1,5 @@
+// +build mounttest
+
 package mount
 
 import (

--- a/volume/drivers/nfs/nfs_test.go
+++ b/volume/drivers/nfs/nfs_test.go
@@ -1,3 +1,5 @@
+// +build mounttest
+
 package nfs
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
Docker is starting to be replaced by podman, rc, and others. This
change makes it possible to run the unit tests using podman on
the development system. There seems to be an issue with mouting
inside podman and using chattr. By default the unit tests will
not be changed.

A developer using podman or another container runtime can use:

    make TAGS=daemon docker-test


