### PR TITLE
Automated cherry pick of #1789: Create mountpath if it does not exist

### DIFF
--- a/csi/node_test.go
+++ b/csi/node_test.go
@@ -173,10 +173,6 @@ func TestNodePublishVolumeInvalidTargetLocation(t *testing.T) {
 		targetPath            string
 	}{
 		{
-			expectedErrorContains: "does not exist",
-			targetPath:            "////a/sdf//fd/asdf/as/f/asdfasf/fds",
-		},
-		{
 			expectedErrorContains: "not a directory",
 			targetPath:            "/etc/hosts",
 		},


### PR DESCRIPTION
Cherry pick of #1789 on release-9.0.

#1789: Create mountpath if it does not exist

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.