### PR TITLE
fix vet errors in release-7.0

### DIFF
--- a/csi/node_test.go
+++ b/csi/node_test.go
@@ -46,7 +46,7 @@ func TestNodePublishVolumeBadArguments(t *testing.T) {
 	}{
 		{
 			expectedErrorContains: "Volume id",
-			req: &csi.NodePublishVolumeRequest{},
+			req:                   &csi.NodePublishVolumeRequest{},
 		},
 		{
 			expectedErrorContains: "Target path",

--- a/csi/v0.3/node_test.go
+++ b/csi/v0.3/node_test.go
@@ -104,7 +104,7 @@ func TestNodePublishVolumeBadArguments(t *testing.T) {
 	}{
 		{
 			expectedErrorContains: "Volume id",
-			req: &csi.NodePublishVolumeRequest{},
+			req:                   &csi.NodePublishVolumeRequest{},
 		},
 		{
 			expectedErrorContains: "Target path",

--- a/pkg/sanity/backup_restore.go
+++ b/pkg/sanity/backup_restore.go
@@ -110,6 +110,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			numVolumesAfter = len(volumes)
+			Expect(numVolumesAfter).To(Equal(1))
 		})
 
 		It("Should create Volume successfully for backup", func() {
@@ -217,6 +218,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			numVolumesAfter = len(volumes)
+			Expect(numVolumesAfter).To(Equal(1))
 		})
 
 		It("Should create enumerate backup volumes", func() {
@@ -342,6 +344,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			numVolumesAfter = len(volumes)
+			Expect(numVolumesAfter).To(Equal(1))
 		})
 
 		It("Should restore backup", func() {
@@ -480,6 +483,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			numVolumesAfter = len(volumes)
+			Expect(numVolumesAfter).To(Equal(1))
 		})
 
 		It("Should create a backup schedule ", func() {
@@ -557,6 +561,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			numVolumesAfter = len(volumes)
+			Expect(numVolumesAfter).To(Equal(1))
 		})
 
 		It("Should delete a backup schedule ", func() {
@@ -648,6 +653,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			numVolumesAfter = len(volumes)
+			Expect(numVolumesAfter).To(Equal(1))
 		})
 
 		It("Should enumerate a backup schedule ", func() {
@@ -736,6 +742,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			numVolumesAfter = len(volumes)
+			Expect(numVolumesAfter).To(Equal(1))
 		})
 
 		It("Should create Volume successfully for backup", func() {

--- a/pkg/sanity/snapshot.go
+++ b/pkg/sanity/snapshot.go
@@ -75,6 +75,7 @@ var _ = Describe("Volume [Snapshot Tests]", func() {
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			numVolumesAfter = len(volumes)
+			Expect(numVolumesAfter).To(Equal(1))
 		})
 
 		It("Should create Volume successfully for snapshot", func() {
@@ -159,6 +160,7 @@ var _ = Describe("Volume [Snapshot Tests]", func() {
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			numVolumesAfter = len(volumes)
+			Expect(numVolumesAfter).To(Equal(1))
 		})
 
 		It("Should enumerate Volume snapshots", func() {
@@ -256,6 +258,7 @@ var _ = Describe("Volume [Snapshot Tests]", func() {
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			numVolumesAfter = len(volumes)
+			Expect(numVolumesAfter).To(Equal(1))
 		})
 
 		It("Should restore Volume successfully for snapshot", func() {

--- a/pkg/sanity/volume.go
+++ b/pkg/sanity/volume.go
@@ -73,6 +73,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 				volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 				Expect(err).ToNot(HaveOccurred())
 				numVolumesAfter = len(volumes)
+				Expect(numVolumesAfter).To(Equal(1))
 			}
 		})
 
@@ -193,6 +194,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 				volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 				Expect(err).ToNot(HaveOccurred())
 				numVolumesAfter = len(volumes)
+				Expect(numVolumesAfter).To(Equal(1))
 			}
 		})
 
@@ -264,6 +266,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, make(map[string]string))
 			numVolumesBefore = len(volumes)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(numVolumesBefore).To(Equal(0))
 		})
 
 		AfterEach(func() {
@@ -401,6 +404,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			numVolumesAfter = len(volumes)
+			Expect(numVolumesAfter).To(Equal(1))
 		})
 
 		It("Should attach and detach successfully", func() {
@@ -484,6 +488,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			numVolumesAfter = len(volumes)
+			Expect(numVolumesAfter).To(Equal(1))
 		})
 
 		It("Should mount and unmount successfully", func() {
@@ -560,6 +565,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			numVolumesAfter = len(volumes)
+			Expect(numVolumesAfter).To(Equal(1))
 		})
 
 		It("Should update successfully with the new volume size.", func() {
@@ -711,6 +717,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			numVolumesAfter = len(volumes)
+			Expect(numVolumesAfter).To(Equal(1))
 		})
 
 		It("Should retrieve volume stats successfully", func() {
@@ -778,6 +785,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			numVolumesAfter = len(volumes)
+			Expect(numVolumesAfter).To(Equal(1))
 		})
 
 		It("Should get ActiveRequests successfully", func() {
@@ -843,6 +851,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			numVolumesAfter = len(volumes)
+			Expect(numVolumesAfter).To(Equal(1))
 		})
 
 		It("Should get volume used size successfully", func() {
@@ -914,6 +923,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
 			Expect(err).ToNot(HaveOccurred())
 			numVolumesAfter = len(volumes)
+			Expect(numVolumesAfter).To(Equal(1))
 		})
 
 		It("Should quiesce unquiesce volume successfully", func() {


### PR DESCRIPTION
Cherry pick of #1241 on release-7.0.

#1241: Change build matrix to use go 1.11 and 1.12

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.