### PR TITLE
[CSI] Add SC parameters to locator volume labels

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -353,6 +353,15 @@ func (s *OsdCsiServer) CreateVolume(
 		locator.VolumeLabels[k] = v
 	}
 
+	// Copy all SC Parameters (from req.Parameters) to locator.VolumeLabels.
+	// This explicit copy matches the equivalent behavior in the in-tree driver
+	if len(locator.VolumeLabels) == 0 {
+		locator.VolumeLabels = make(map[string]string)
+	}
+	for k, v := range req.Parameters {
+		locator.VolumeLabels[k] = v
+	}
+
 	// Add encryption secret information to VolumeLabels
 	locator.VolumeLabels = s.addEncryptionInfoToLabels(locator.VolumeLabels, req.GetSecrets())
 


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <ggriffiths@purestorage.com>

**What this PR does / why we need it**:
Adds SC parameters to locator.VolumeLabels on CSI volume create.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

