### PR TITLE
Automated cherry pick of #1807: Add SC parameters to locator volume labels

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -353,6 +353,15 @@ func (s *OsdCsiServer) CreateVolume(
 		locator.VolumeLabels[k] = v
 	}
 
+	// Copy all SC Parameters (from req.Parameters) to locator.VolumeLabels.
+	// This explicit copy matches the equivalent behavior in the in-tree driver
+	if len(locator.VolumeLabels) == 0 {
+		locator.VolumeLabels = make(map[string]string)
+	}
+	for k, v := range req.Parameters {
+		locator.VolumeLabels[k] = v
+	}
+
 	// Add encryption secret information to VolumeLabels
 	locator.VolumeLabels = s.addEncryptionInfoToLabels(locator.VolumeLabels, req.GetSecrets())
 


### PR DESCRIPTION
Cherry pick of #1807 on release-9.0.

#1807: Add SC parameters to locator volume labels

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.