### PR TITLE
swap incorrect env variable names

### DIFF
--- a/volume/drivers/pwx/connection.go
+++ b/volume/drivers/pwx/connection.go
@@ -74,8 +74,8 @@ func NewConnectionParamsBuilderDefaultConfig() *ConnectionParamsBuilderConfig {
 		CaCertSecretKeyEnv:          "PX_CA_CERT_SECRET_KEY",
 		TokenIssuerEnv:              "PX_JWT_ISSUER",
 		StaticEndpointEnv:           "PX_ENDPOINT",
-		StaticSDKPortEnv:            "PX_API_PORT",
-		StaticRestPortEnv:           "PX_SDK_PORT",
+		StaticSDKPortEnv:            "PX_SDK_PORT",
+		StaticRestPortEnv:           "PX_API_PORT",
 		AuthEnabled:                 false,
 		AuthTokenGenerator:          func() (string, error) { return "", fmt.Errorf("auth token generator func is not set") },
 	}

--- a/volume/drivers/pwx/connection_test.go
+++ b/volume/drivers/pwx/connection_test.go
@@ -24,8 +24,8 @@ const (
 	pxRestPort           = "px-api"
 	pxSdkPort            = "px-sdk"
 	pxEndpointEnv        = "PX_ENDPOINT"
-	StaticSDKPortEnv     = "PX_API_PORT"
-	StaticRestPortEnv    = "PX_SDK_PORT"
+	StaticSDKPortEnv     = "PX_SDK_PORT"
+	StaticRestPortEnv    = "PX_API_PORT"
 )
 
 func getSvc() *v1.Service {


### PR DESCRIPTION
Env variables for SDK and API port where mixed up.

Signed-off-by: Neelesh Thakur <neelesh.thakur@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Fixes an issue found by code inspection.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

