### PR TITLE
[cherrypick] Add support for cluster pairing over https endpoints.

### DIFF
--- a/api/client/cluster/cluster.go
+++ b/api/client/cluster/cluster.go
@@ -1,6 +1,9 @@
 package cluster
 
 import (
+	"crypto/tls"
+	"net/url"
+
 	"github.com/libopenstorage/openstorage/api/client"
 	"github.com/libopenstorage/openstorage/cluster"
 )
@@ -30,6 +33,42 @@ func NewAuthClusterClient(host, version string, authstring string, accesstoken s
 	}
 
 	return client.NewAuthClient(host, version, authstring, accesstoken, "")
+}
+
+// NewInsecureTLSAuthClusterClient returns a new REST client that will skip TLS verification for https
+// host: REST endpoint [http(s)://<ip>:<port>]
+// version: ClusterAPI version
+func NewInsecureTLSAuthClusterClient(host, version, auth string, accesstoken string) (*client.Client, error) {
+	if host == "" {
+		host = client.GetUnixServerPath(OsdSocket, cluster.APIBase)
+	}
+
+	if version == "" {
+		// Set the default version
+		version = cluster.APIVersion
+	}
+
+	var (
+		skipTLSVerify bool
+	)
+	u, err := url.Parse(host)
+	if err == nil && len(u.Scheme) != 0 {
+		if u.Scheme == "https" {
+			// We don't support cert validation yet
+			skipTLSVerify = true
+		}
+	} else {
+		host = "http://" + host
+	}
+
+	clnt, err := client.NewAuthClient(host, version, auth, accesstoken, "")
+	if err != nil {
+		return nil, err
+	}
+	if skipTLSVerify {
+		clnt.SetTLS(&tls.Config{InsecureSkipVerify: true})
+	}
+	return clnt, nil
 }
 
 // NewClusterClient returns a new REST client.

--- a/cluster/manager/pair.go
+++ b/cluster/manager/pair.go
@@ -38,8 +38,8 @@ func (c *ClusterManager) CreatePair(
 		CredentialId:       request.CredentialId,
 	}
 
-	endpoint := "http://" + remoteIp + ":" + strconv.FormatUint(uint64(request.RemoteClusterPort), 10)
-	clnt, err := clusterclient.NewAuthClusterClient(endpoint, cluster.APIVersion, request.RemoteClusterToken, "")
+	endpoint := remoteIp + ":" + strconv.FormatUint(uint64(request.RemoteClusterPort), 10)
+	clnt, err := clusterclient.NewInsecureTLSAuthClusterClient(endpoint, cluster.APIVersion, request.RemoteClusterToken, "")
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func (c *ClusterManager) RefreshPair(
 	endpoints := pair.CurrentEndpoints
 	endpoints = append(endpoints, pair.Endpoint)
 	for _, endpoint := range endpoints {
-		clnt, err := clusterclient.NewAuthClusterClient(endpoint, cluster.APIVersion, pair.Token, "")
+		clnt, err := clusterclient.NewInsecureTLSAuthClusterClient(endpoint, cluster.APIVersion, pair.Token, "")
 		if err != nil {
 			logrus.Warnf("Unable to create cluster client for %v: %v", endpoint, err)
 			continue
@@ -249,7 +249,7 @@ func (c *ClusterManager) ValidatePair(
 	endpoints := pairResp.PairInfo.CurrentEndpoints
 	endpoints = append(endpoints, pairResp.PairInfo.Endpoint)
 	for _, endpoint := range endpoints {
-		clnt, err := clusterclient.NewAuthClusterClient(
+		clnt, err := clusterclient.NewInsecureTLSAuthClusterClient(
 			endpoint,
 			cluster.APIVersion,
 			pairResp.PairInfo.Token,


### PR DESCRIPTION


**What this PR does / why we need it**:
- This ensures that two clusters can pair over an https endpoint
  with TLS config set to skip verify if the clusters are not TLS enabled.

Signed-off-by: Aditya Dani <aditya@portworx.com>

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

