### PR TITLE
Correct unit types displayed accordingly in units.String()

### DIFF
--- a/pkg/units/units.go
+++ b/pkg/units/units.go
@@ -80,19 +80,19 @@ var unitPattern = regexp.MustCompile(
 var BadUnit = errors.New("Bad unit")
 
 func String(b uint64) string {
-	if b > PiB {
+	if b >= PiB {
 		return fmt.Sprintf("%.2f PiB", float64(b)/float64(PiB))
 	}
-	if b > TiB {
+	if b >= TiB {
 		return fmt.Sprintf("%.2f TiB", float64(b)/float64(TiB))
 	}
-	if b > GiB {
-		return fmt.Sprintf("%.1f TiB", float64(b)/float64(GiB))
+	if b >= GiB {
+		return fmt.Sprintf("%.1f GiB", float64(b)/float64(GiB))
 	}
-	if b > MiB {
+	if b >= MiB {
 		return fmt.Sprintf("%v MiB", b/MiB)
 	}
-	if b > KiB {
+	if b >= KiB {
 		return fmt.Sprintf("%v KiB", b/KiB)
 	}
 	return fmt.Sprintf("%v bytes", b)
@@ -102,13 +102,13 @@ func Parse(bUnit string) (int64, error) {
 	ustring := strings.TrimSpace(bUnit)
 	unitPattern.Longest()
 	if !unitPattern.MatchString(ustring) {
-		return -1, fmt.Errorf("Unit parse error: %s", bUnit)
+		return -1, fmt.Errorf("unit parse error: %s", bUnit)
 	}
 	matches := unitPattern.FindStringSubmatch(ustring)
 
 	if len(matches) == 0 || len(matches) > 4 {
 		return -1, fmt.Errorf(
-			"Unit parse error: invalid count of fields (%v)",
+			"unit parse error: invalid count of fields (%v)",
 			len(matches))
 	}
 	if len(matches) == 1 {
@@ -119,7 +119,7 @@ func Parse(bUnit string) (int64, error) {
 		shift = 1
 	}
 	if len(matches) == 2 {
-		return -1, fmt.Errorf("Unit parse error: invalid fields %v",
+		return -1, fmt.Errorf("unit parse error: invalid fields %v",
 			matches)
 	}
 	if ustring != matches[0] {

--- a/pkg/units/units_test.go
+++ b/pkg/units/units_test.go
@@ -20,10 +20,10 @@ func testParse(t *testing.T, suffix string, b int64, bi int64) {
 	require.NoError(t, err, "Parse")
 	require.Equal(t, int64(10*bi), n, "Parse")
 
-	n, err = Parse("1  0" + suffix)
+	_, err = Parse("1  0" + suffix)
 	require.Error(t, err, "Parse")
 
-	n, err = Parse("10" + suffix + "z")
+	_, err = Parse("10" + suffix + "z")
 	require.Error(t, err, "Parse")
 
 	if len(suffix) == 0 {
@@ -56,4 +56,17 @@ func TestParse(t *testing.T) {
 	testParse(t, "g", 1000*1000*1000, 1024*1024*1024)
 	testParse(t, "t", 1000*1000*1000*1000, 1024*1024*1024*1024)
 	testParse(t, "p", 1000*1000*1000*1000*1000, 1024*1024*1024*1024*1024)
+}
+
+func testString(t *testing.T, quantity uint64, expected string) {
+	s := String(quantity)
+	require.Equal(t, s, expected)
+}
+func TestString(t *testing.T) {
+	testString(t, 1, "1 bytes")
+	testString(t, uint64(KiB), "1 KiB")
+	testString(t, uint64(MiB), "1 MiB")
+	testString(t, uint64(GiB), "1.0 GiB")
+	testString(t, uint64(TiB), "1.00 TiB")
+	testString(t, uint64(PiB), "1.00 PiB")
 }


### PR DESCRIPTION
Signed-off-by: Jordi Gil <jgil@redhat.com>

<!--
  Make sure to have done the following:
  [X] Signed off your work as per the DCO.
  [X] Add unit-tests
-->

**What this PR does / why we need it**:
Changes the comparison for `func String(b uint64) error` to have the range match equals or greater the unit types, so that:
* `1*units.PiB` expects `1.00 PiB` actual is `1024.00 TiB`
* `1*units.TiB` expects `1.00 TiB` actual is `1024.00 GiB`
* `1*units.GiB` expects `1.0 GiB` actual is `1024.0 MiB`
* `1*units.MiB` expects `1 MiB` actual is `1024 KiB`
* `1*units.KiB` expects `1 KiB` actual is `1024 bytes`

Also fixes the wrong unit type for `GiB`:
* `2*units.GiB` expects `2.0 GiB` actual is `2.0 TiB`
