### PR TITLE
Auth-middleware delete is not idempotent

### DIFF
--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -122,6 +122,11 @@ func clusterInst() (cluster.Cluster, error) {
 	return inst, nil
 }
 
+// ClearInst is used to clear the singleton instance. Use in Tests only
+func ClearInst() {
+	inst = nil
+}
+
 type checkFunc func(*cluster.ClusterInfo) error
 
 func ifaceToIp(iface *net.Interface) (string, error) {


### PR DESCRIPTION
* Also fixed an error in auth middleware Enumerate function where
  it returns the incorrect object in an error.

Signed-off-by: Luis Pabón <lpabon@purestorage.com>

**What this PR does / why we need it**:
Auth middleware has the following errors:

- Deletions of volumes that do not exist where returning error. If a volume does not exist, return success according to idempotency rules
- the client.Inspect() call was receiving the incorrect object from the auth middleware. The auth middleware encountered an error condition it returned the error object instead of an empty list as expected by the client.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

- Unit tests were updated to completely reset the KV stores used by the `fake` driver and the `cluster` objects.

