### PR TITLE
Move ErrNoVolumeUpdate to volume pkg from Portworx

### DIFF
--- a/volume/volume.go
+++ b/volume/volume.go
@@ -43,6 +43,8 @@ var (
 	// ErrFsResizeFailed returned when Filesystem resize failed because of filesystem
 	// errors
 	ErrFsResizeFailed = errors.New("Filesystem Resize failed due to filesystem errors")
+	// ErrNoVolumeUpdate is returned when a volume update has no changes requested
+	ErrNoVolumeUpdate = errors.New("No change requested")
 )
 
 // Constants used by the VolumeDriver


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
This error is better to have in openstorage as many upstream dependencies can depend on it

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

