### PR TITLE
Remove golang base image to avoid rate limited docker pull

### DIFF
--- a/Dockerfile.osd
+++ b/Dockerfile.osd
@@ -1,4 +1,4 @@
-FROM golang:1.9.2
+FROM gcr.io/distroless/base-debian10
 MAINTAINER gou@portworx.com
 
 EXPOSE 9005 9100 9110

--- a/hack/docker-integration-test.sh
+++ b/hack/docker-integration-test.sh
@@ -82,7 +82,7 @@ assert_attached false
 
 # Run app with our  volume
 app_name="APP_TEST_$volume_name"
-sudo docker run -d --name $app_name --volume-driver fake -v size=12345,token=$token,name=${volume_name}:/app nginx:latest
+sudo docker run -d --name $app_name --volume-driver fake -v size=12345,token=$token,name=${volume_name}:/app k8s.gcr.io/nginx-slim:0.8
 assert_success
 assert_attached true
 
@@ -93,7 +93,7 @@ assert_attached false
 
 # Run app based on volume ID
 sudo docker rm $app_name
-sudo docker run -d --name $app_name --volume-driver fake -v size=12345,token=$token,name=${volume_id}:/app nginx:latest
+sudo docker run -d --name $app_name --volume-driver fake -v size=12345,token=$token,name=${volume_id}:/app k8s.gcr.io/nginx-slim:0.8
 assert_success
 assert_attached true
 


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
Logging into docker via Travis is not straightforward when working with forks. Instead of dealing with that, we can move a problematic base image to use a gcr.io base image instead.

This will lower the amount of rate limiting we hit

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

