### PR TITLE
Automated cherry pick of #1841: Don't log entire request and cleanup logs

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -140,7 +140,7 @@ func (s *OsdCsiServer) ValidateVolumeCapabilities(
 	}
 
 	// Log request
-	logrus.Debugf("ValidateVolumeCapabilities of id %s "+
+	logrus.Debugf("csi.ValidateVolumeCapabilities of id %s "+
 		"capabilities %#v "+
 		id,
 		capabilities)
@@ -324,7 +324,7 @@ func (s *OsdCsiServer) CreateVolume(
 ) (*csi.CreateVolumeResponse, error) {
 
 	// Log request
-	logrus.Debugf("CreateVolume req[%#v]", *req)
+	logrus.Debugf("csi.CreateVolume request received. Volume: %s", req.GetName())
 
 	if len(req.GetName()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Name must be provided")
@@ -451,7 +451,7 @@ func (s *OsdCsiServer) DeleteVolume(
 ) (*csi.DeleteVolumeResponse, error) {
 
 	// Log request
-	logrus.Debugf("DeleteVolume req[%#v]", *req)
+	logrus.Debugf("csi.DeleteVolume request received. VolumeID: %s", req.VolumeId)
 
 	// Check arguments
 	if len(req.GetVolumeId()) == 0 {

--- a/csi/node.go
+++ b/csi/node.go
@@ -58,7 +58,7 @@ func (s *OsdCsiServer) NodePublishVolume(
 	req *csi.NodePublishVolumeRequest,
 ) (*csi.NodePublishVolumeResponse, error) {
 
-	logrus.Debugf("NodePublishVolume req[%#v]", req)
+	logrus.Debugf("csi.NodePublishVolume request received. VolumeID: %s, TargetPath: %s", req.GetVolumeId(), req.GetTargetPath())
 
 	// Check arguments
 	if len(req.GetVolumeId()) == 0 {
@@ -162,7 +162,7 @@ func (s *OsdCsiServer) NodePublishVolume(
 		return nil, err
 	}
 
-	logrus.Infof("Volume %s mounted on %s",
+	logrus.Infof("CSI Volume %s mounted on %s",
 		volumeId,
 		req.GetTargetPath())
 
@@ -175,7 +175,7 @@ func (s *OsdCsiServer) NodeUnpublishVolume(
 	req *csi.NodeUnpublishVolumeRequest,
 ) (*csi.NodeUnpublishVolumeResponse, error) {
 
-	logrus.Debugf("NodeUnPublishVolume req[%#v]", req)
+	logrus.Debugf("csi.NodeUnpublishVolume request received. VolumeID: %s, TargetPath: %s", req.GetVolumeId(), req.GetTargetPath())
 
 	// Check arguments
 	if len(req.GetVolumeId()) == 0 {
@@ -232,7 +232,7 @@ func (s *OsdCsiServer) NodeUnpublishVolume(
 			req.GetTargetPath())
 	}
 
-	logrus.Infof("Volume %s unmounted from path %s", req.GetVolumeId(), req.GetTargetPath())
+	logrus.Infof("CSI Volume %s unmounted from path %s", req.GetVolumeId(), req.GetTargetPath())
 
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }
@@ -244,7 +244,7 @@ func (s *OsdCsiServer) NodeGetCapabilities(
 	req *csi.NodeGetCapabilitiesRequest,
 ) (*csi.NodeGetCapabilitiesResponse, error) {
 
-	logrus.Debugf("NodeGetCapabilities req[%#v]", req)
+	logrus.Debugf("csi.NodeGetCapabilities request received")
 
 	return &csi.NodeGetCapabilitiesResponse{
 		Capabilities: []*csi.NodeServiceCapability{


### PR DESCRIPTION
Cherry pick of #1841 on release-9.1.

#1841: Don't log entire request and cleanup logs

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.