### PR TITLE
Add IPv6 addr handling by adding '[]' around IPv6 connect addresses.

### DIFF
--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -419,8 +419,10 @@ func (c *ClusterManager) getCurrentState() *api.Node {
 	return nodeCopy
 }
 
+// Return ip:port string
 func getPeerAddress(ip string, port string) string {
 	if strings.Contains(ip, ":") {
+		// IPv6 addresses and '[]'
 		ip = fmt.Sprintf("[%s]", ip)
 	}
 	return fmt.Sprintf("%s:%s", ip, port)


### PR DESCRIPTION
Signed-off-by: Jose Rivera <jose@portworx.com>

Inspect IP and add square brackets around the IPv6 address to be used for the tcp:// & udp:// connect calls.
