### PR TITLE
Allow pkg/role verifyRule method to be accessible from external lib

### DIFF
--- a/pkg/role/sdkserviceapi.go
+++ b/pkg/role/sdkserviceapi.go
@@ -400,7 +400,7 @@ func (r *SdkRoleManager) Verify(ctx context.Context, roles []string, fullmethod 
 			continue
 		}
 
-		if err := r.verifyRules(resp.GetRole().GetRules(), fullmethod); err == nil {
+		if err := VerifyRules(resp.GetRole().GetRules(), api.SdkRootPath, fullmethod); err == nil {
 			return nil
 		}
 	}
@@ -408,10 +408,10 @@ func (r *SdkRoleManager) Verify(ctx context.Context, roles []string, fullmethod 
 	return status.Errorf(codes.PermissionDenied, "Access denied to roles: %+s", roles)
 }
 
-// verifyRules checks if the rules authorize use of the API called `fullmethod`
-func (r *SdkRoleManager) verifyRules(rules []*api.SdkRule, fullmethod string) error {
+// VerifyRules checks if the rules authorize use of the API called `fullmethod`
+func VerifyRules(rules []*api.SdkRule, rootPath, fullmethod string) error {
 
-	reqService, reqApi := grpcserver.GetMethodInformation(api.SdkRootPath, fullmethod)
+	reqService, reqApi := grpcserver.GetMethodInformation(rootPath, fullmethod)
 
 	// Look for denials first
 	for _, rule := range rules {

--- a/pkg/role/sdkserviceapi_test.go
+++ b/pkg/role/sdkserviceapi_test.go
@@ -754,7 +754,7 @@ func TestSdkRoleVerifyRules(t *testing.T) {
 		if len(test.roles) != 0 {
 			err = s.Verify(context.Background(), test.roles, test.fullmethod)
 		} else {
-			err = s.verifyRules(test.rules, test.fullmethod)
+			err = VerifyRules(test.rules, api.SdkRootPath, test.fullmethod)
 		}
 
 		if test.denied {


### PR DESCRIPTION
**What this PR does / why we need it**:
 This PR  make verifyRule method to be public so that lib  with correct `sdkRule` can use VerifyRule method to validate user

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

