### PR TITLE
PWX-19496 Default to cow_on_demand for new volumes

### DIFF
--- a/api/spec/spec_handler.go
+++ b/api/spec/spec_handler.go
@@ -182,6 +182,7 @@ func (d *specHandler) DefaultSpec() *api.VolumeSpec {
 		Format:    api.FSType_FS_TYPE_EXT4,
 		HaLevel:   1,
 		IoProfile: api.IoProfile_IO_PROFILE_AUTO,
+		Xattr:     api.Xattr_COW_ON_DEMAND,
 	}
 }
 
@@ -481,6 +482,8 @@ func (d *specHandler) UpdateSpecFromOpts(opts map[string]string, spec *api.Volum
 			} else {
 				if cowOnDemand {
 					spec.Xattr = api.Xattr_COW_ON_DEMAND
+				} else if spec.Xattr == api.Xattr_COW_ON_DEMAND {
+					spec.Xattr = api.Xattr_UNSPECIFIED
 				}
 			}
 		case api.SpecDirectIo:

--- a/api/spec/spec_handler_test.go
+++ b/api/spec/spec_handler_test.go
@@ -400,7 +400,7 @@ func TestXattr(t *testing.T) {
 	testSpecOptString(t, api.SpecCowOnDemand, "true")
 
 	spec := testSpecFromString(t, api.SpecRack, "ignore")
-	require.Equal(t, api.Xattr_UNSPECIFIED, spec.Xattr)
+	require.Equal(t, api.Xattr_COW_ON_DEMAND, spec.Xattr)
 
 	spec = testSpecFromString(t, api.SpecCowOnDemand, "false")
 	require.Equal(t, api.Xattr_UNSPECIFIED, spec.Xattr)


### PR DESCRIPTION
Signed-off-by: Harsh Desai <hadesai@purestorage.com>


**What this PR does / why we need it**:

pxctl volume create defaults to cow on demand: https://github.com/portworx/porx/blob/master/px/pxctl/spec/volume.yaml#L444

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

