### PR TITLE
[CSI] Add feature flag for enabling inline volumes

### DIFF
--- a/csi/node.go
+++ b/csi/node.go
@@ -32,6 +32,15 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+var (
+	ephemeralDenyList = []string{
+		api.SpecPriorityAlias,
+		api.SpecPriority,
+		api.SpecSticky,
+		api.SpecScale,
+	}
+)
+
 func (s *OsdCsiServer) NodeGetInfo(
 	ctx context.Context,
 	req *csi.NodeGetInfoRequest,
@@ -132,6 +141,14 @@ func (s *OsdCsiServer) NodePublishVolume(
 	// can use either spec.Ephemeral or VolumeContext label
 	volumeId := req.GetVolumeId()
 	if req.GetVolumeContext()["csi.storage.k8s.io/ephemeral"] == "true" || spec.Ephemeral {
+		if !s.allowInlineVolumes {
+			return nil, status.Error(codes.InvalidArgument, "CSI ephemeral inline volumes are disabled on this cluster")
+		}
+
+		if err := validateEphemeralVolumeAttributes(req.GetVolumeContext()); err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+
 		spec.Ephemeral = true
 		volumes := api.NewOpenStorageVolumeClient(conn)
 		resp, err := volumes.Create(ctx, &api.SdkVolumeCreateRequest{
@@ -395,6 +412,19 @@ func ensureMountPathCreated(targetPath string) error {
 	} else {
 		if !fileInfo.IsDir() {
 			return fmt.Errorf("Target location %s is not a directory", targetPath)
+		}
+	}
+
+	return nil
+}
+
+func validateEphemeralVolumeAttributes(volumeAttributes map[string]string) error {
+	for attr := range volumeAttributes {
+		for _, deny := range ephemeralDenyList {
+			if attr == deny {
+				return fmt.Errorf("invalid ephemeral volume attribute provided. "+
+					"Volume attributes %v are not allowed for ephemeral volumes", ephemeralDenyList)
+			}
 		}
 	}
 

--- a/csi/node_test.go
+++ b/csi/node_test.go
@@ -527,6 +527,159 @@ func TestNodePublishPureVolumeMountOptions(t *testing.T) {
 	assert.NotNil(t, r)
 }
 
+func TestNodePublishVolumeEphemeralEnabled(t *testing.T) {
+	// Create server and client connection
+	s := newTestServerWithConfig(t, &OsdCsiServerConfig{
+		DriverName:          mockDriverName,
+		EnableInlineVolumes: true,
+	})
+	defer s.Stop()
+
+	// Make a call
+	c := csi.NewNodeClient(s.Conn())
+
+	name := "csi-12345"
+	size := uint64(10)
+	targetPath := "/mnt"
+	gomock.InOrder(
+		s.MockDriver().
+			EXPECT().
+			Type().
+			Return(api.DriverType_DRIVER_TYPE_NONE).
+			Times(1),
+		s.MockDriver().
+			EXPECT().
+			Inspect([]string{name}).
+			Return(nil, fmt.Errorf("not found")).
+			Times(1),
+		s.MockDriver().
+			EXPECT().
+			Enumerate(&api.VolumeLocator{Name: name}, nil).
+			Return(nil, fmt.Errorf("not found")).
+			Times(1),
+		s.MockDriver().
+			EXPECT().
+			Create(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(name, nil).
+			Times(1),
+		s.MockDriver().
+			EXPECT().
+			Enumerate(&api.VolumeLocator{
+				VolumeIds: []string{name},
+			}, nil).
+			Return([]*api.Volume{
+				&api.Volume{
+					Id: name,
+					Locator: &api.VolumeLocator{
+						Name: name,
+					},
+					Spec: &api.VolumeSpec{
+						Size: size,
+					},
+				},
+			}, nil).
+			Times(1),
+		s.MockDriver().
+			EXPECT().
+			Mount(name, targetPath, nil).
+			Return(nil).
+			Times(1),
+	)
+
+	req := &csi.NodePublishVolumeRequest{
+		VolumeId:   name,
+		TargetPath: targetPath,
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{},
+		},
+		VolumeContext: map[string]string{
+			"csi.storage.k8s.io/ephemeral": "true",
+		},
+		Secrets: map[string]string{authsecrets.SecretTokenKey: systemUserToken},
+	}
+
+	r, err := c.NodePublishVolume(context.Background(), req)
+	assert.Nil(t, err)
+	assert.NotNil(t, r)
+}
+
+func TestNodePublishVolumeEphemeralDisabled(t *testing.T) {
+	// Create server and client connection
+	s := newTestServerWithConfig(t, &OsdCsiServerConfig{
+		DriverName:          mockDriverName,
+		EnableInlineVolumes: false,
+	})
+	defer s.Stop()
+
+	// Make a call
+	c := csi.NewNodeClient(s.Conn())
+
+	name := "csi-12345"
+	targetPath := "/mnt"
+	gomock.InOrder(
+		s.MockDriver().
+			EXPECT().
+			Type().
+			Return(api.DriverType_DRIVER_TYPE_NONE).
+			Times(1),
+	)
+
+	req := &csi.NodePublishVolumeRequest{
+		VolumeId:   name,
+		TargetPath: targetPath,
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{},
+		},
+		VolumeContext: map[string]string{
+			"csi.storage.k8s.io/ephemeral": "true",
+		},
+		Secrets: map[string]string{authsecrets.SecretTokenKey: systemUserToken},
+	}
+
+	_, err := c.NodePublishVolume(context.Background(), req)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "CSI ephemeral inline volumes are disabled on this cluster")
+}
+
+func TestNodePublishVolumeEphemeralDenyList(t *testing.T) {
+	// Create server and client connection
+	s := newTestServerWithConfig(t, &OsdCsiServerConfig{
+		DriverName:          mockDriverName,
+		EnableInlineVolumes: true,
+	})
+	defer s.Stop()
+
+	// Make a call
+	c := csi.NewNodeClient(s.Conn())
+
+	name := "csi-12345"
+	targetPath := "/mnt"
+	gomock.InOrder(
+		s.MockDriver().
+			EXPECT().
+			Type().
+			Return(api.DriverType_DRIVER_TYPE_NONE).
+			Times(1),
+	)
+
+	req := &csi.NodePublishVolumeRequest{
+		VolumeId:   name,
+		TargetPath: targetPath,
+		VolumeCapability: &csi.VolumeCapability{
+			AccessMode: &csi.VolumeCapability_AccessMode{},
+		},
+		VolumeContext: map[string]string{
+			"csi.storage.k8s.io/ephemeral": "true",
+			api.SpecPriority:               "high",
+		},
+		Secrets: map[string]string{authsecrets.SecretTokenKey: systemUserToken},
+	}
+
+	_, err := c.NodePublishVolume(context.Background(), req)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid ephemeral volume attribute provided")
+}
+
 func TestNodeUnpublishVolumeVolumeNotFound(t *testing.T) {
 	// Create server and client connection
 	s := newTestServer(t)


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
* Adds feature flag for enabling inline volume support.
* Inline volume has a security flag in that it allows for creation of volumes without respect to any quotas or k8s RBAC. Customers will need to opt-in to this feature as a result.
* Generic ephemeral volumes should be used instead:
https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

