### PR TITLE
Add timeouts to all RPCs

### DIFF
--- a/Dockerfile.osd-dev
+++ b/Dockerfile.osd-dev
@@ -1,4 +1,4 @@
-FROM quay.io/openstorage/osd-dev-base
+FROM quay.io/openstorage/osd-dev-base:1.14
 MAINTAINER gou@portworx.com
 
 EXPOSE 9005

--- a/Dockerfile.osd-dev-base
+++ b/Dockerfile.osd-dev-base
@@ -1,4 +1,4 @@
-FROM golang:1.10.4
+FROM golang:1.14
 MAINTAINER gou@portworx.com
 
 EXPOSE 9005
@@ -13,17 +13,14 @@ RUN \
 RUN \
   curl -sSL https://get.docker.com/builds/Linux/x86_64/docker-1.10.3 -o /bin/docker && \
   chmod +x /bin/docker
-# Get all required build-tools, then clean up GOPATH
+
 RUN go get -u	\
-	github.com/golang/lint/golint					\
+    golang.org/x/lint/golint \
 	github.com/kisielk/errcheck					\
 	github.com/golang/protobuf/protoc-gen-go			\
-	github.com/grpc-ecosystem/grpc-gateway/protoc-gen-grpc-gateway	\
-	github.com/grpc-ecosystem/grpc-gateway/protoc-gen-swagger	\
 	github.com/kardianos/govendor					\
 	github.com/gobuffalo/packr/...					\
 	golang.org/x/tools/cmd/cover					\
 	github.com/pierrre/gotestcover		&& \
-		\
 	rm -fr /go/src/* /go/pkg/*		&& \
 	mkdir -p /go/src/github.com/libopenstorage/openstorage

--- a/Makefile
+++ b/Makefile
@@ -314,6 +314,7 @@ docker-test: docker-build-osd-dev
 		-e "PKGS=$(PKGS)" \
 		-e "BUILDFLAGS=$(BUILDFLAGS)" \
 		-e "TESTFLAGS=$(TESTFLAGS)" \
+		-e "GO111MODULE=auto" \
 		openstorage/osd-dev \
 			make test
 

--- a/api/client/request.go
+++ b/api/client/request.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 	"time"
 
 	"github.com/libopenstorage/openstorage/pkg/auth"
+	"github.com/libopenstorage/openstorage/pkg/grpcutil"
 )
 
 const (
@@ -41,6 +43,7 @@ type Request struct {
 	timeout     time.Duration
 	authstring  string
 	accesstoken string
+	ctx         context.Context
 }
 
 // Response is a representation of HTTP response received from the server.
@@ -59,6 +62,19 @@ type Status struct {
 
 // NewRequest instance
 func NewRequest(client *http.Client, base *url.URL, verb string, version string, authstring, userAgent string) *Request {
+	return NewRequestWithContext(nil, client, base, verb, version, authstring, userAgent)
+}
+
+// NewRequestWithContext takes in context which may describe a timeout
+func NewRequestWithContext(
+	ctx context.Context,
+	client *http.Client,
+	base *url.URL,
+	verb string,
+	version string,
+	authstring,
+	userAgent string,
+) *Request {
 	r := &Request{
 		client:     client,
 		verb:       verb,
@@ -66,6 +82,7 @@ func NewRequest(client *http.Client, base *url.URL, verb string, version string,
 		path:       base.Path,
 		version:    version,
 		authstring: authstring,
+		ctx:        ctx,
 	}
 	r.SetHeader("User-Agent", userAgent)
 	return r
@@ -245,12 +262,19 @@ func (r *Request) Do() *Response {
 		return &Response{err: r.err}
 	}
 
+	// Get a context timeout if non provided
+	if r.ctx == nil {
+		ctx, cancel := grpcutil.WithDefaultTimeout(context.Background())
+		r.ctx = ctx
+		defer cancel()
+	}
+
 	url = r.URL().String()
 	start := time.Now()
 	attemptNum := 0
 	for {
 		// Re-create Request for every call to make sure body isn't empty.
-		req, err = http.NewRequest(r.verb, url, bytes.NewBuffer(r.body))
+		req, err = http.NewRequestWithContext(r.ctx, r.verb, url, bytes.NewBuffer(r.body))
 		if err != nil {
 			return &Response{err: err}
 		}

--- a/api/server/backup.go
+++ b/api/server/backup.go
@@ -23,7 +23,8 @@ func (vd *volAPI) cloudBackupCreate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
@@ -71,7 +72,8 @@ func (vd *volAPI) cloudBackupGroupCreate(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
@@ -188,7 +190,8 @@ func (vd *volAPI) cloudBackupEnumerate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
@@ -249,7 +252,8 @@ func (vd *volAPI) cloudBackupStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
@@ -356,7 +360,8 @@ func (vd *volAPI) cloudBackupStateChange(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
@@ -392,7 +397,8 @@ func (vd *volAPI) cloudBackupSchedCreate(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
@@ -434,7 +440,8 @@ func (vd *volAPI) cloudBackupSchedUpdate(w http.ResponseWriter, r *http.Request)
 	}
 
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return

--- a/api/server/migrate.go
+++ b/api/server/migrate.go
@@ -19,7 +19,8 @@ func (vd *volAPI) cloudMigrateStart(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
@@ -84,7 +85,8 @@ func (vd *volAPI) cloudMigrateCancel(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
@@ -123,7 +125,8 @@ func (vd *volAPI) cloudMigrateStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return

--- a/api/server/sdk/sdk_test.go
+++ b/api/server/sdk/sdk_test.go
@@ -234,7 +234,7 @@ func newTestServerAuth(t *testing.T) *testServer {
 func (s *testServer) setPorts() {
 	source := rand.NewSource(time.Now().UnixNano())
 	r := rand.New(source)
-	port := r.Intn(20000) + 10000
+	port := r.Intn(1000) + 30000
 
 	s.port = fmt.Sprintf("%d", port)
 	s.gwport = fmt.Sprintf("%d", port+1)

--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -23,6 +23,7 @@ import (
 	clustermanager "github.com/libopenstorage/openstorage/cluster/manager"
 	"github.com/libopenstorage/openstorage/pkg/auth"
 	"github.com/libopenstorage/openstorage/pkg/grpcserver"
+	"github.com/libopenstorage/openstorage/pkg/grpcutil"
 	"github.com/libopenstorage/openstorage/pkg/options"
 	"github.com/libopenstorage/openstorage/volume"
 	volumedrivers "github.com/libopenstorage/openstorage/volume/drivers"
@@ -83,12 +84,22 @@ func (vd *volAPI) getConn() (*grpc.ClientConn, error) {
 	return vd.conn, nil
 }
 
-func (vd *volAPI) annotateContext(r *http.Request) (context.Context, error) {
+// caller must still call defer cancel() on error
+func (vd *volAPI) annotateContext(r *http.Request) (context.Context, context.CancelFunc, error) {
+
+	// Get the context if any passed over the request Headers
+	ctx := r.Context()
+
+	// Set the timeout if non set. context.WithTimeout will set the soonest of the
+	// two, either the amount requested in the second argument, or the timeout
+	// already set in the context 'ctx'.
+	ctx, cancel := grpcutil.WithDefaultTimeout(ctx)
+
 	// This creates a context and populates the authentication token
 	// using the same function as the SDK REST Gateway
-	ctx, err := runtime.AnnotateContext(context.Background(), vd.dummyMux, r)
+	ctx, err := runtime.AnnotateContext(ctx, vd.dummyMux, r)
 	if err != nil {
-		return ctx, err
+		return ctx, cancel, err
 	}
 	// If a header exists in the request fetch the requested driver name if provided
 	// and pass it in the grpc context as a metadata key value
@@ -97,10 +108,10 @@ func (vd *volAPI) annotateContext(r *http.Request) (context.Context, error) {
 		// Check if the request is coming from a container orchestrator
 		clientName := strings.Split(userAgent, "/")
 		if len(clientName) > 0 {
-			return grpcserver.AddMetadataToContext(ctx, sdk.ContextDriverKey, clientName[0]), nil
+			ctx = grpcserver.AddMetadataToContext(ctx, sdk.ContextDriverKey, clientName[0])
 		}
 	}
-	return ctx, nil
+	return ctx, cancel, nil
 }
 
 func (vd *volAPI) getVolDriver(r *http.Request) (volume.VolumeDriver, error) {
@@ -198,7 +209,8 @@ func (vd *volAPI) create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
@@ -303,7 +315,8 @@ func (vd *volAPI) volumeSet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
@@ -644,7 +657,8 @@ func (vd *volAPI) inspect(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
@@ -729,7 +743,8 @@ func (vd *volAPI) delete(w http.ResponseWriter, r *http.Request) {
 	volumeResponse := &api.VolumeResponse{}
 
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
@@ -800,7 +815,8 @@ func (vd *volAPI) enumerate(w http.ResponseWriter, r *http.Request) {
 	method := "enumerate"
 
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
@@ -924,7 +940,8 @@ func (vd *volAPI) snap(w http.ResponseWriter, r *http.Request) {
 	vd.logRequest(method, string(snapReq.Id)).Infoln("")
 
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
@@ -1005,7 +1022,8 @@ func (vd *volAPI) restore(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
@@ -1100,7 +1118,8 @@ func (vd *volAPI) snapEnumerate(w http.ResponseWriter, r *http.Request) {
 		request.Labels = labels
 	}
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
@@ -1220,7 +1239,8 @@ func (vd *volAPI) stats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return
@@ -1299,7 +1319,8 @@ func (vd *volAPI) usedsize(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Get context with auth token
-	ctx, err := vd.annotateContext(r)
+	ctx, cancel, err := vd.annotateContext(r)
+	defer cancel()
 	if err != nil {
 		vd.sendError(vd.name, method, w, err.Error(), http.StatusBadRequest)
 		return

--- a/csi/controller.go
+++ b/csi/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/portworx/kvdb"
 
 	"github.com/libopenstorage/openstorage/api"
+	"github.com/libopenstorage/openstorage/pkg/grpcutil"
 	"github.com/libopenstorage/openstorage/pkg/util"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
@@ -168,6 +169,8 @@ func (s *OsdCsiServer) ValidateVolumeCapabilities(
 
 	// Get secret if any was passed
 	ctx = s.setupContextWithToken(ctx, req.GetSecrets())
+	ctx, cancel := grpcutil.WithDefaultTimeout(ctx)
+	defer cancel()
 
 	// Check ID is valid with the specified volume capabilities
 	volumes := api.NewOpenStorageVolumeClient(conn)
@@ -409,6 +412,8 @@ func (s *OsdCsiServer) CreateVolume(
 
 	// Get secret if any was passed
 	ctx = s.setupContextWithToken(ctx, req.GetSecrets())
+	ctx, cancel := grpcutil.WithDefaultTimeout(ctx)
+	defer cancel()
 
 	// Check ID is valid with the specified volume capabilities
 	volumes := api.NewOpenStorageVolumeClient(conn)
@@ -481,6 +486,8 @@ func (s *OsdCsiServer) DeleteVolume(
 
 	// Get secret if any was passed
 	ctx = s.setupContextWithToken(ctx, req.GetSecrets())
+	ctx, cancel := grpcutil.WithDefaultTimeout(ctx)
+	defer cancel()
 
 	// Check ID is valid with the specified volume capabilities
 	volumes := api.NewOpenStorageVolumeClient(conn)
@@ -529,6 +536,8 @@ func (s *OsdCsiServer) ControllerExpandVolume(
 
 	// Get secret if any was passed
 	ctx = s.setupContextWithToken(ctx, req.GetSecrets())
+	ctx, cancel := grpcutil.WithDefaultTimeout(ctx)
+	defer cancel()
 
 	// If the new size is greater than the current size, a volume update
 	// should be issued. Otherwise, no operation should occur.
@@ -679,6 +688,8 @@ func (s *OsdCsiServer) CreateSnapshot(
 
 	// Get secret if any was passed
 	ctx = s.setupContextWithToken(ctx, req.GetSecrets())
+	ctx, cancel := grpcutil.WithDefaultTimeout(ctx)
+	defer cancel()
 
 	// Check ID is valid with the specified volume capabilities
 	volumes := api.NewOpenStorageVolumeClient(conn)
@@ -758,6 +769,8 @@ func (s *OsdCsiServer) DeleteSnapshot(
 
 	// Get secret if any was passed
 	ctx = s.setupContextWithToken(ctx, req.GetSecrets())
+	ctx, cancel := grpcutil.WithDefaultTimeout(ctx)
+	defer cancel()
 
 	// Check ID is valid with the specified volume capabilities
 	volumes := api.NewOpenStorageVolumeClient(conn)

--- a/csi/node.go
+++ b/csi/node.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/libopenstorage/openstorage/api"
+	"github.com/libopenstorage/openstorage/pkg/grpcutil"
 	"github.com/portworx/kvdb"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
@@ -103,6 +104,8 @@ func (s *OsdCsiServer) NodePublishVolume(
 
 	// Get secret if any was passed
 	ctx = s.setupContextWithToken(ctx, req.GetSecrets())
+	ctx, cancel := grpcutil.WithDefaultTimeout(ctx)
+	defer cancel()
 
 	// Check if block device
 	driverType := s.driver.Type()

--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	oidc "github.com/coreos/go-oidc"
+	"github.com/libopenstorage/openstorage/pkg/grpcutil"
 )
 
 // OIDCAuthConfig configures an OIDC connection
@@ -55,7 +56,10 @@ type OIDCAuthenticator struct {
 
 // NewOIDC returns a new OIDC authenticator
 func NewOIDC(config *OIDCAuthConfig) (*OIDCAuthenticator, error) {
-	p, err := oidc.NewProvider(context.Background(), config.Issuer)
+	ctx, cancel := grpcutil.WithDefaultTimeout(context.Background())
+	defer cancel()
+
+	p, err := oidc.NewProvider(ctx, config.Issuer)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to communicate with OIDC provider %s: %v",
 			config.Issuer,

--- a/pkg/defaultcontext/default.go
+++ b/pkg/defaultcontext/default.go
@@ -1,0 +1,91 @@
+/*
+Package defaultcontext manage the default context and timeouts
+Copyright 2021 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package defaultcontext
+
+import (
+	"sync"
+	"time"
+
+	grpcgw "github.com/grpc-ecosystem/grpc-gateway/runtime"
+)
+
+var (
+	inst     *defaultContextManager
+	instLock sync.Mutex
+
+	defaultDuration = 5 * time.Minute
+
+	// Inst returns the singleton to the default context manager
+	Inst = func() *defaultContextManager {
+		return defaultContextManagerGetInst()
+	}
+)
+
+func defaultContextManagerGetInst() *defaultContextManager {
+	instLock.Lock()
+	defer instLock.Unlock()
+
+	if inst == nil {
+		inst = newDefaultContextManager()
+	}
+
+	return inst
+}
+
+type defaultContextManager struct {
+	lock    sync.RWMutex
+	timeout time.Duration
+}
+
+func newDefaultContextManager() *defaultContextManager {
+	d := &defaultContextManager{
+		timeout: defaultDuration,
+	}
+	d.apply()
+
+	return d
+}
+
+// SetDefaultTimeout sets the default timeout duration used by contexts without a timeout
+func (d *defaultContextManager) SetDefaultTimeout(t time.Duration) error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	d.timeout = t
+	d.apply()
+
+	return nil
+}
+
+// GetDefaultTimeout returns the default timeout duration used by contexts without a timeout.
+//
+// It is recommended to use grpcutils.WithDefaultTimeout(ctx) which calls this function,
+// instead of calling this function directly.
+func (d *defaultContextManager) GetDefaultTimeout() time.Duration {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+
+	return d.timeout
+}
+
+// Add here any external default timeouts that need to be set
+func (d *defaultContextManager) apply() {
+
+	// Set SDK Gateway default context
+	grpcgw.DefaultContextTimeout = d.timeout
+
+}

--- a/pkg/defaultcontext/default_test.go
+++ b/pkg/defaultcontext/default_test.go
@@ -1,0 +1,38 @@
+/*
+Package defaultcontext manage the default context and timeouts
+Copyright 2021 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package defaultcontext
+
+import (
+	"testing"
+	"time"
+
+	grpcgw "github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDefaultContextManager(t *testing.T) {
+	d := Inst()
+	assert.NotNil(t, d)
+	assert.Equal(t, d.GetDefaultTimeout(), defaultDuration)
+	assert.Equal(t, grpcgw.DefaultContextTimeout, defaultDuration)
+
+	timeout := 100 * time.Hour
+	err := d.SetDefaultTimeout(timeout)
+	assert.NoError(t, err)
+	assert.Equal(t, d.GetDefaultTimeout(), timeout)
+	assert.Equal(t, grpcgw.DefaultContextTimeout, timeout)
+}

--- a/pkg/grpcutil/context.go
+++ b/pkg/grpcutil/context.go
@@ -1,0 +1,27 @@
+/*
+Package grpcutil is a package for gRPC utilities
+Copyright 2021 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package grpcutil
+
+import (
+	"context"
+
+	"github.com/libopenstorage/openstorage/pkg/defaultcontext"
+)
+
+func WithDefaultTimeout(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(ctx, defaultcontext.Inst().GetDefaultTimeout())
+}

--- a/pkg/grpcutil/context_test.go
+++ b/pkg/grpcutil/context_test.go
@@ -1,0 +1,44 @@
+/*
+Package grpcutil is a package for gRPC utilities
+Copyright 2021 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package grpcutil
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/libopenstorage/openstorage/pkg/defaultcontext"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWithDefaultTimeout(t *testing.T) {
+	timeout := defaultcontext.Inst().GetDefaultTimeout()
+
+	ctx, _ := WithDefaultTimeout(context.Background())
+	deadline, ok := ctx.Deadline()
+	assert.True(t, ok)
+	time.Sleep(10 * time.Millisecond)
+	assert.True(t, deadline.Before(time.Now().Add(timeout)))
+
+	timeout = time.Hour
+	defaultcontext.Inst().SetDefaultTimeout(time.Hour)
+	ctx, _ = WithDefaultTimeout(context.Background())
+	deadline, ok = ctx.Deadline()
+	assert.True(t, ok)
+	time.Sleep(10 * time.Millisecond)
+	assert.True(t, deadline.Before(time.Now().Add(timeout)))
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Need timeouts on all RPC calls



**Special notes for your reviewer**:
* This fix also cleans up the gRPC client connect to use
`grpc.WithBlock()` and `grpc.DialWithContext()` since the APIs we used
to use where experimental.
* Needed to bump the docker-test golang version from 1.10 to something more than 1.13 since we require `http.NewRequestWithContext()`. FYI, when I used 1.15 or 1.16 golang versions, the unit test SDK server did not allow connections. OSD built with 1.15 did allow. Something to investigate later.