### PR TITLE
[PWX-19922] Don't pass shared, sharedv4, secure parameters to Pure volume specs

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1200,6 +1200,10 @@ func (v *VolumeSpec) IsPublic(accessType Ownership_AccessType) bool {
 	return v.GetOwnership() == nil || v.GetOwnership().IsPublic(accessType)
 }
 
+func (v *VolumeSpec) IsPureVolume() bool {
+	return v.GetProxySpec() != nil && v.GetProxySpec().IsPureBackend()
+}
+
 // GetCloneCreatorOwnership returns the appropriate ownership for the
 // new snapshot and if an update is required
 func (v *VolumeSpec) GetCloneCreatorOwnership(ctx context.Context) (*Ownership, bool) {

--- a/csi/controller.go
+++ b/csi/controller.go
@@ -591,6 +591,11 @@ func resolveBlockSpec(spec *api.VolumeSpec, req *csi.CreateVolumeRequest) (*api.
 // 1. When a volume is set to RWX or a similar multi-node access mode, we default to Sharedv4
 // 2. If a user prefers shared over sharedv4, they may still use it by explicity declaring "shared": true
 func resolveSharedSpec(spec *api.VolumeSpec, req *csi.CreateVolumeRequest) (*api.VolumeSpec, error) {
+	// shared or sharedv4 parameter doesn't apply to pure backends so don't set them
+	if spec.IsPureVolume() {
+		return spec, nil
+	}
+
 	var shared bool
 	for _, cap := range req.GetVolumeCapabilities() {
 		mode := cap.GetAccessMode().GetMode()

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -2444,7 +2444,6 @@ func TestResolveSpecFromCSI(t *testing.T) {
 				Sharedv4: true,
 			},
 		},
-
 		{
 			name: "Should accept shared instead of sharedv4 if explicitly provided already",
 			req: &csi.CreateVolumeRequest{
@@ -2513,6 +2512,30 @@ func TestResolveSpecFromCSI(t *testing.T) {
 			existingSpec: &api.VolumeSpec{},
 
 			expectedError: "rpc error: code = Unimplemented desc = CSI raw block is not supported",
+		},
+		{
+			name: "Should not set shared flag to true when using pure backends RWX",
+			req: &csi.CreateVolumeRequest{
+				VolumeCapabilities: []*csi.VolumeCapability{
+					&csi.VolumeCapability{
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+						},
+					},
+				},
+			},
+			existingSpec: &api.VolumeSpec{
+				ProxySpec: &api.ProxySpec{
+					ProxyProtocol: api.ProxyProtocol_PROXY_PROTOCOL_PURE_FILE,
+				},
+			},
+
+			expectedSpec: &api.VolumeSpec{
+				Shared: false,
+				ProxySpec: &api.ProxySpec{
+					ProxyProtocol: api.ProxyProtocol_PROXY_PROTOCOL_PURE_FILE,
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**: Portworx volume spec parameters including `shared`, `sharedv4` and `secure` doesn't apply to pure volume, and shouldn't be set when parsing from storage classes

**Which issue(s) this PR fixes** (optional)
Closes # [PWX-19922](https://portworx.atlassian.net/browse/PWX-19922)

**Special notes for your reviewer**:

