### PR TITLE
Automated cherry pick of #1854: Raw Block support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ cmd/osd-sanity/osd-sanity
 api/client/sdk/python/build
 api/client/sdk/js/node_modules
 api/client/sdk/js/package-lock.json
+.vscode/

--- a/csi/controller.go
+++ b/csi/controller.go
@@ -328,6 +328,35 @@ func cleanupVolumeLabels(labels map[string]string) map[string]string {
 	return labels
 }
 
+func validateCreateVolumeCapabilities(caps []*csi.VolumeCapability) error {
+	if len(caps) == 0 {
+		return status.Error(codes.InvalidArgument, "Volume capabilities must be provided")
+	}
+
+	var shared bool
+	var block bool
+	for _, cap := range caps {
+		mode := cap.GetAccessMode().GetMode()
+		if mode == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER ||
+			mode == csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER ||
+			mode == csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY {
+			shared = true
+		}
+
+		if cap.GetBlock() != nil {
+			block = true
+		}
+
+		if block && shared {
+			return status.Errorf(
+				codes.InvalidArgument,
+				"Shared raw block volumes are not supported")
+		}
+	}
+
+	return nil
+}
+
 // CreateVolume is a CSI API which creates a volume on OSD
 // This function supports snapshots if the parent volume id is supplied
 // in the parameters.
@@ -342,8 +371,8 @@ func (s *OsdCsiServer) CreateVolume(
 	if len(req.GetName()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Name must be provided")
 	}
-	if req.GetVolumeCapabilities() == nil || len(req.GetVolumeCapabilities()) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "Volume capabilities must be provided")
+	if err := validateCreateVolumeCapabilities(req.GetVolumeCapabilities()); err != nil {
+		return nil, err
 	}
 
 	// Get parameters
@@ -565,20 +594,7 @@ func isFilesystemSpecSet(params map[string]string) bool {
 	return fsSet
 }
 
-// resolveBlockSpec makes the following assumptions:
-// 1. This CSI driver does not yet support raw block
-// 2. CSI Drivers that do not support raw block should not allow raw block requests
-func resolveBlockSpec(spec *api.VolumeSpec, req *csi.CreateVolumeRequest) (*api.VolumeSpec, error) {
-	for _, cap := range req.GetVolumeCapabilities() {
-		if block := cap.GetBlock(); block != nil {
-			return nil, status.Errorf(codes.Unimplemented, "CSI raw block is not supported")
-		}
-	}
-
-	return spec, nil
-}
-
-// resolveFSTypeSpec makes the following assumptions:
+// resolveSharedSpec makes the following assumptions:
 // 1. When a volume is set to RWX or a similar multi-node access mode, we default to Sharedv4
 // 2. If a user prefers shared over sharedv4, they may still use it by explicity declaring "shared": true
 func resolveSharedSpec(spec *api.VolumeSpec, req *csi.CreateVolumeRequest) (*api.VolumeSpec, error) {
@@ -613,8 +629,12 @@ func resolveSharedSpec(spec *api.VolumeSpec, req *csi.CreateVolumeRequest) (*api
 // 2. The default value for spec.Format is determined upstream by SpecFromOpts(req.GetParameters())
 func resolveFSTypeSpec(spec *api.VolumeSpec, req *csi.CreateVolumeRequest) (*api.VolumeSpec, error) {
 	var csiFsType string
-
 	for _, cap := range req.GetVolumeCapabilities() {
+		if cap.GetBlock() != nil {
+			spec.Format = api.FSType_FS_TYPE_NONE
+			return spec, nil
+		}
+
 		// Get FsType according to CSI spec
 		if mount := cap.GetMount(); mount != nil {
 			csiFsType = mount.FsType
@@ -638,14 +658,8 @@ func resolveFSTypeSpec(spec *api.VolumeSpec, req *csi.CreateVolumeRequest) (*api
 // resolveSpecFromCSI alters the api.VolumeSpec based on any CSI parameters passed in.
 // Various volume spec fields have CSI equivalents. This function resolves each one.
 func resolveSpecFromCSI(spec *api.VolumeSpec, req *csi.CreateVolumeRequest) (*api.VolumeSpec, error) {
-	// Handles whether or not we support CSI raw block
-	spec, err := resolveBlockSpec(spec, req)
-	if err != nil {
-		return nil, err
-	}
-
 	// Handles shared vs. sharedv4 resolution. We default to Sharedv4
-	spec, err = resolveSharedSpec(spec, req)
+	spec, err := resolveSharedSpec(spec, req)
 	if err != nil {
 		return nil, err
 	}

--- a/csi/node.go
+++ b/csi/node.go
@@ -21,10 +21,9 @@ import (
 	"os"
 	"strings"
 
+	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/portworx/kvdb"
-
-	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -67,29 +66,33 @@ func (s *OsdCsiServer) NodePublishVolume(
 	ctx context.Context,
 	req *csi.NodePublishVolumeRequest,
 ) (*csi.NodePublishVolumeResponse, error) {
+	volumeId := req.GetVolumeId()
+	targetPath := req.GetTargetPath()
 
-	logrus.Debugf("csi.NodePublishVolume request received. VolumeID: %s, TargetPath: %s", req.GetVolumeId(), req.GetTargetPath())
+	logrus.Debugf("csi.NodePublishVolume request received. VolumeID: %s, TargetPath: %s", volumeId, targetPath)
 
 	// Check arguments
-	if len(req.GetVolumeId()) == 0 {
+	if len(volumeId) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume id must be provided")
 	}
-	if len(req.GetTargetPath()) == 0 {
+	if len(targetPath) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Target path must be provided")
 	}
-	if req.GetVolumeCapability() == nil || req.GetVolumeCapability().GetAccessMode() == nil {
+	if req.GetVolumeCapability() == nil || req.GetVolumeCapability().GetAccessMode() == nil ||
+		req.GetVolumeCapability().GetAccessMode().Mode == csi.VolumeCapability_AccessMode_UNKNOWN {
 		return nil, status.Error(codes.InvalidArgument, "Volume access mode must be provided")
-	}
-	if req.GetVolumeCapability().GetBlock() != nil {
-		return nil, status.Errorf(codes.Unimplemented, "CSI raw block is not supported")
 	}
 
 	// Ensure target location is created correctly
-	if err := ensureMountPathCreated(req.GetTargetPath()); err != nil {
+	isBlockAccessType := false
+	if req.GetVolumeCapability().GetBlock() != nil {
+		isBlockAccessType = true
+	}
+	if err := ensureMountPathCreated(targetPath, isBlockAccessType); err != nil {
 		return nil, status.Errorf(
 			codes.Aborted,
 			"Failed to use target location %s: %s",
-			req.GetTargetPath(),
+			targetPath,
 			err.Error())
 	}
 
@@ -132,14 +135,7 @@ func (s *OsdCsiServer) NodePublishVolume(
 		}
 	}
 
-	// prepare for mount/attaching
-	mounts := api.NewOpenStorageMountAttachClient(conn)
-	opts := &api.SdkVolumeAttachOptions{
-		SecretName: spec.GetPassphrase(),
-	}
-
 	// can use either spec.Ephemeral or VolumeContext label
-	volumeId := req.GetVolumeId()
 	if req.GetVolumeContext()["csi.storage.k8s.io/ephemeral"] == "true" || spec.Ephemeral {
 		if !s.allowInlineVolumes {
 			return nil, status.Error(codes.InvalidArgument, "CSI ephemeral inline volumes are disabled on this cluster")
@@ -152,7 +148,7 @@ func (s *OsdCsiServer) NodePublishVolume(
 		spec.Ephemeral = true
 		volumes := api.NewOpenStorageVolumeClient(conn)
 		resp, err := volumes.Create(ctx, &api.SdkVolumeCreateRequest{
-			Name:   req.GetVolumeId(),
+			Name:   volumeId,
 			Spec:   spec,
 			Labels: locator.GetVolumeLabels(),
 		})
@@ -162,7 +158,14 @@ func (s *OsdCsiServer) NodePublishVolume(
 		volumeId = resp.VolumeId
 	}
 
+	// prepare for mount/attaching
+	opts := &api.SdkVolumeAttachOptions{
+		SecretName: spec.GetPassphrase(),
+	}
+	mounts := api.NewOpenStorageMountAttachClient(conn)
 	if driverType == api.DriverType_DRIVER_TYPE_BLOCK {
+		// attach is assumed to be idempotent
+		// attach is assumed to return the same DevicePath on each call
 		if _, err = mounts.Attach(ctx, &api.SdkVolumeAttachRequest{
 			VolumeId:      volumeId,
 			Options:       opts,
@@ -176,10 +179,10 @@ func (s *OsdCsiServer) NodePublishVolume(
 		}
 	}
 
-	// Mount volume onto the path
+	// for volumes with mount access type just mount volume onto the path
 	if _, err := mounts.Mount(ctx, &api.SdkVolumeMountRequest{
 		VolumeId:      volumeId,
-		MountPath:     req.GetTargetPath(),
+		MountPath:     targetPath,
 		Options:       opts,
 		DriverOptions: driverOpts,
 	}); err != nil {
@@ -202,14 +205,16 @@ func (s *OsdCsiServer) NodeUnpublishVolume(
 	ctx context.Context,
 	req *csi.NodeUnpublishVolumeRequest,
 ) (*csi.NodeUnpublishVolumeResponse, error) {
+	volumeId := req.GetVolumeId()
+	targetPath := req.GetTargetPath()
 
-	logrus.Debugf("csi.NodeUnpublishVolume request received. VolumeID: %s, TargetPath: %s", req.GetVolumeId(), req.GetTargetPath())
+	logrus.Debugf("csi.NodeUnpublishVolume request received. VolumeID: %s, TargetPath: %s", volumeId, targetPath)
 
 	// Check arguments
-	if len(req.GetVolumeId()) == 0 {
+	if len(volumeId) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Volume id must be provided")
 	}
-	if len(req.GetTargetPath()) == 0 {
+	if len(targetPath) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Target path must be provided")
 	}
 
@@ -229,16 +234,16 @@ func (s *OsdCsiServer) NodeUnpublishVolume(
 		}
 	}
 
-	// Mount volume onto the path
 	if err = s.driver.Unmount(req.GetVolumeId(), req.GetTargetPath(), nil); err != nil {
-		logrus.Infof("Unable to unmount volume %s onto %s: %s",
+		logrus.Infof("unable to unmount volume %s onto %s: %s",
 			req.GetVolumeId(),
 			req.GetTargetPath(),
-			err.Error())
+			err.Error(),
+		)
 	}
 
 	if s.driver.Type() == api.DriverType_DRIVER_TYPE_BLOCK {
-		if err = s.driver.Detach(req.GetVolumeId(), nil); err != nil {
+		if err = s.driver.Detach(volumeId, nil); err != nil {
 			return nil, status.Errorf(
 				codes.Internal,
 				"Unable to detach volume: %s",
@@ -249,18 +254,18 @@ func (s *OsdCsiServer) NodeUnpublishVolume(
 	// Attempt to remove volume path
 	// Kubernetes handles this after NodeUnpublishVolume finishes, but this allows for cross-CO compatibility
 	if err := os.Remove(req.GetTargetPath()); err != nil && !os.IsNotExist(err) {
-		logrus.Warnf("Failed to delete mount path %s: %s", req.GetTargetPath(), err.Error())
+		logrus.Warnf("Failed to delete mount path %s: %s", targetPath, err.Error())
 	}
 
 	// Return error to Kubelet if mount path still exists to force a retry
-	if _, err := os.Stat(req.GetTargetPath()); !os.IsNotExist(err) {
+	if _, err := os.Stat(targetPath); !os.IsNotExist(err) {
 		return nil, status.Errorf(
 			codes.Internal,
 			"Mount path still exists: %s",
-			req.GetTargetPath())
+			targetPath)
 	}
 
-	logrus.Infof("CSI Volume %s unmounted from path %s", req.GetVolumeId(), req.GetTargetPath())
+	logrus.Infof("CSI Volume %s unmounted from path %s", volumeId, targetPath)
 
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }
@@ -394,21 +399,38 @@ func (s *OsdCsiServer) cleanupEphemeral(ctx context.Context, conn *grpc.ClientCo
 	}
 }
 
-func ensureMountPathCreated(targetPath string) error {
+func ensureMountPathCreated(targetPath string, isBlock bool) error {
+	// Check if targetpath exists
 	fileInfo, err := os.Lstat(targetPath)
 	if err != nil && os.IsNotExist(err) {
-		err = os.MkdirAll(targetPath, 0750)
-		if err != nil {
-			return fmt.Errorf(
-				"Failed to create target path %s: %s",
-				targetPath,
-				err.Error())
+		// Create if does not exist
+		// 1. Block - create targetPath file
+		// 2. Mount - create targetpath directory
+		if isBlock {
+			if err = makeFile(targetPath); err != nil {
+				return err
+			}
+		} else {
+			if err = makeDir(targetPath); err != nil {
+				return err
+			}
 		}
+
+		return nil
 	} else if err != nil {
 		return fmt.Errorf(
-			"Unknown error while verifying target location %s: %s",
+			"unknown error while verifying target location %s: %s",
 			targetPath,
 			err.Error())
+	}
+
+	// Check for directory or file.
+	// 1. Block - should be file
+	// 2. Mount - should be directory
+	if isBlock {
+		if fileInfo.IsDir() {
+			return fmt.Errorf("Target location %s is not a file", targetPath)
+		}
 	} else {
 		if !fileInfo.IsDir() {
 			return fmt.Errorf("Target location %s is not a directory", targetPath)
@@ -426,6 +448,35 @@ func validateEphemeralVolumeAttributes(volumeAttributes map[string]string) error
 					"Volume attributes %v are not allowed for ephemeral volumes", ephemeralDenyList)
 			}
 		}
+	}
+
+	return nil
+}
+
+func makeFile(pathname string) error {
+	f, err := os.OpenFile(pathname, os.O_CREATE, os.FileMode(0644))
+	defer func() {
+		err := f.Close()
+		if err != nil {
+			logrus.Warnf("failed to close file: %s", err.Error())
+		}
+	}()
+	if err != nil {
+		if !os.IsExist(err) {
+			return fmt.Errorf("failed to create block file: %s", err.Error())
+		}
+	}
+
+	return nil
+}
+
+func makeDir(targetPath string) error {
+	err := os.MkdirAll(targetPath, 0750)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to create target path %s: %s",
+			targetPath,
+			err.Error())
 	}
 
 	return nil

--- a/csi/node_test.go
+++ b/csi/node_test.go
@@ -113,7 +113,12 @@ func TestNodePublishVolumeVolumeNotFound(t *testing.T) {
 		VolumeId:   name,
 		TargetPath: "/",
 		VolumeCapability: &csi.VolumeCapability{
-			AccessMode: &csi.VolumeCapability_AccessMode{},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{},
+			},
 		},
 		Secrets: map[string]string{authsecrets.SecretTokenKey: systemUserToken},
 	}
@@ -147,7 +152,12 @@ func TestNodePublishVolumeBadAttribute(t *testing.T) {
 		VolumeId:   name,
 		TargetPath: "mypath",
 		VolumeCapability: &csi.VolumeCapability{
-			AccessMode: &csi.VolumeCapability_AccessMode{},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{},
+			},
 		},
 
 		// This will cause an error
@@ -190,7 +200,9 @@ func TestNodePublishVolumeInvalidTargetLocation(t *testing.T) {
 	req := &csi.NodePublishVolumeRequest{
 		VolumeId: name,
 		VolumeCapability: &csi.VolumeCapability{
-			AccessMode: &csi.VolumeCapability_AccessMode{},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
 			AccessType: &csi.VolumeCapability_Mount{
 				Mount: &csi.VolumeCapability_MountVolume{},
 			},
@@ -255,7 +267,12 @@ func TestNodePublishVolumeFailedToAttach(t *testing.T) {
 		VolumeId:   name,
 		TargetPath: "/mnt",
 		VolumeCapability: &csi.VolumeCapability{
-			AccessMode: &csi.VolumeCapability_AccessMode{},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{},
+			},
 		},
 		Secrets: map[string]string{authsecrets.SecretTokenKey: systemUserToken},
 	}
@@ -313,7 +330,12 @@ func TestNodePublishVolumeFailedMount(t *testing.T) {
 		VolumeId:   name,
 		TargetPath: targetPath,
 		VolumeCapability: &csi.VolumeCapability{
-			AccessMode: &csi.VolumeCapability_AccessMode{},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{},
+			},
 		},
 		Secrets: map[string]string{authsecrets.SecretTokenKey: systemUserToken},
 	}
@@ -327,9 +349,6 @@ func TestNodePublishVolumeFailedMount(t *testing.T) {
 }
 
 func TestNodePublishVolumeBlock(t *testing.T) {
-	// Skipping for now - issues with symlink
-	t.Skip()
-
 	// Create server and client connection
 	s := newTestServer(t)
 	defer s.Stop()
@@ -361,9 +380,11 @@ func TestNodePublishVolumeBlock(t *testing.T) {
 			Times(1),
 		s.MockDriver().
 			EXPECT().
-			Inspect([]string{name}).
+			Enumerate(&api.VolumeLocator{
+				VolumeIds: []string{name},
+			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id: name,
 					Locator: &api.VolumeLocator{
 						Name: name,
@@ -376,13 +397,30 @@ func TestNodePublishVolumeBlock(t *testing.T) {
 			Times(1),
 		s.MockDriver().
 			EXPECT().
-			Type().
-			Return(api.DriverType_DRIVER_TYPE_BLOCK).
+			Attach(name, gomock.Any()).
+			Return("", nil).
 			Times(1),
 		s.MockDriver().
 			EXPECT().
-			Attach(name, gomock.Any()).
-			Return(devicePath, nil).
+			Enumerate(&api.VolumeLocator{
+				VolumeIds: []string{name},
+			}, nil).
+			Return([]*api.Volume{
+				{
+					Id: name,
+					Locator: &api.VolumeLocator{
+						Name: name,
+					},
+					Spec: &api.VolumeSpec{
+						Size: size,
+					},
+				},
+			}, nil).
+			Times(1),
+		s.MockDriver().
+			EXPECT().
+			Mount(name, targetPath, nil).
+			Return(nil).
 			Times(1),
 	)
 
@@ -390,7 +428,9 @@ func TestNodePublishVolumeBlock(t *testing.T) {
 		VolumeId:   name,
 		TargetPath: targetPath,
 		VolumeCapability: &csi.VolumeCapability{
-			AccessMode: &csi.VolumeCapability_AccessMode{},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
 			AccessType: &csi.VolumeCapability_Block{
 				Block: &csi.VolumeCapability_BlockVolume{},
 			},
@@ -402,10 +442,9 @@ func TestNodePublishVolumeBlock(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, r)
 
-	// Check that the symlink was created
-	fileInfo, err := os.Lstat(targetPath)
+	// Check that the targetpath exists
+	_, err = os.Lstat(targetPath)
 	assert.NoError(t, err)
-	assert.Equal(t, fileInfo.Mode()&os.ModeSymlink, os.ModeSymlink)
 }
 
 func TestNodePublishVolumeMount(t *testing.T) {
@@ -454,7 +493,12 @@ func TestNodePublishVolumeMount(t *testing.T) {
 		VolumeId:   name,
 		TargetPath: targetPath,
 		VolumeCapability: &csi.VolumeCapability{
-			AccessMode: &csi.VolumeCapability_AccessMode{},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{},
+			},
 		},
 		Secrets: map[string]string{authsecrets.SecretTokenKey: systemUserToken},
 	}
@@ -512,8 +556,9 @@ func TestNodePublishPureVolumeMountOptions(t *testing.T) {
 		VolumeId:   name,
 		TargetPath: targetPath,
 		VolumeCapability: &csi.VolumeCapability{
-			AccessMode: &csi.VolumeCapability_AccessMode{},
-			AccessType: &csi.VolumeCapability_Mount{
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			}, AccessType: &csi.VolumeCapability_Mount{
 				Mount: &csi.VolumeCapability_MountVolume{
 					MountFlags: mountFlags,
 				},
@@ -590,7 +635,9 @@ func TestNodePublishVolumeEphemeralEnabled(t *testing.T) {
 		VolumeId:   name,
 		TargetPath: targetPath,
 		VolumeCapability: &csi.VolumeCapability{
-			AccessMode: &csi.VolumeCapability_AccessMode{},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
 		},
 		VolumeContext: map[string]string{
 			"csi.storage.k8s.io/ephemeral": "true",
@@ -628,7 +675,9 @@ func TestNodePublishVolumeEphemeralDisabled(t *testing.T) {
 		VolumeId:   name,
 		TargetPath: targetPath,
 		VolumeCapability: &csi.VolumeCapability{
-			AccessMode: &csi.VolumeCapability_AccessMode{},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			},
 		},
 		VolumeContext: map[string]string{
 			"csi.storage.k8s.io/ephemeral": "true",
@@ -666,8 +715,9 @@ func TestNodePublishVolumeEphemeralDenyList(t *testing.T) {
 		VolumeId:   name,
 		TargetPath: targetPath,
 		VolumeCapability: &csi.VolumeCapability{
-			AccessMode: &csi.VolumeCapability_AccessMode{},
-		},
+			AccessMode: &csi.VolumeCapability_AccessMode{
+				Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+			}},
 		VolumeContext: map[string]string{
 			"csi.storage.k8s.io/ephemeral": "true",
 			api.SpecPriority:               "high",

--- a/hack/csi-sanity-test.sh
+++ b/hack/csi-sanity-test.sh
@@ -15,6 +15,7 @@ assert_success() {
 
 # Install osd binary
 make install
+assert_success
 
 # Start OSD
 sudo -E $GOPATH/bin/osd \

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -92,6 +92,8 @@ const (
 	CustomMount
 	// BindMount indicates a bind mount point
 	BindMount
+	// RawMount indicates a raw mount point
+	RawMount
 )
 
 const (
@@ -535,7 +537,7 @@ func (m *Mounter) Mount(
 			}
 		}
 
-		return err
+		return fmt.Errorf("%s", err)
 	}
 
 	info.Mountpoint = append(info.Mountpoint, &PathInfo{Path: path})
@@ -814,6 +816,8 @@ func New(
 		return NewBindMounter(identifiers, mountImpl, allowedDirs, trashLocation)
 	case CustomMount:
 		return NewCustomMounter(identifiers, mountImpl, customMounter, allowedDirs)
+	case RawMount:
+		return NewRawBindMounter(identifiers, mountImpl, allowedDirs, trashLocation)
 	}
 	return nil, ErrUnsupported
 }

--- a/pkg/mount/mount_test.go
+++ b/pkg/mount/mount_test.go
@@ -6,6 +6,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -13,28 +14,36 @@ const (
 	source        = "/mnt/ost/mount_test_src"
 	dest          = "/mnt/ost/mount_test_dest"
 	trashLocation = "/tmp/.trash"
+	rawSource     = "/mnt/rawtests/test_src_raw"
+	rawDest       = "/mnt/rawtests/test_dest_raw"
 )
 
 var m Manager
 
 func TestNFSMounter(t *testing.T) {
 	setupNFS(t)
-	allTests(t)
+	allTests(t, source, dest)
 }
 
 func TestBindMounter(t *testing.T) {
 	setupBindMounter(t)
-	allTests(t)
+	allTests(t, source, dest)
 }
-func allTests(t *testing.T) {
-	load(t)
-	mountTest(t)
-	inspect(t)
-	reload(t)
-	hasMounts(t)
-	refcounts(t)
-	exists(t)
-	shutdown(t)
+
+func TestRawMounter(t *testing.T) {
+	setupRawMounter(t)
+	allTests(t, rawSource, rawDest)
+}
+
+func allTests(t *testing.T, source, dest string) {
+	load(t, source, dest)
+	mountTest(t, source, dest)
+	inspect(t, source, dest)
+	reload(t, source, dest)
+	hasMounts(t, source, dest)
+	refcounts(t, source, dest)
+	exists(t, source, dest)
+	shutdown(t, source, dest)
 }
 
 func setupNFS(t *testing.T) {
@@ -57,24 +66,34 @@ func setupBindMounter(t *testing.T) {
 	cleandir(dest)
 }
 
+func setupRawMounter(t *testing.T) {
+	var err error
+	m, err = New(RawMount, nil, []string{""}, nil, []string{}, trashLocation)
+	if err != nil {
+		t.Fatalf("Failed to setup test %v", err)
+	}
+	cleandir(rawSource)
+	cleandir(rawDest)
+}
+
 func cleandir(dir string) {
 	syscall.Unmount(dir, 0)
 	os.RemoveAll(dir)
 	os.MkdirAll(dir, 0755)
 }
 
-func load(t *testing.T) {
+func load(t *testing.T, source, dest string) {
 	require.NoError(t, m.Load([]string{""}), "Failed in load")
 }
 
-func mountTest(t *testing.T) {
+func mountTest(t *testing.T, source, dest string) {
 	err := m.Mount(0, source, dest, "", syscall.MS_BIND, "", 0, nil)
 	require.NoError(t, err, "Failed in mount")
 	err = m.Unmount(source, dest, 0, 0, nil)
 	require.NoError(t, err, "Failed in unmount")
 }
 
-func inspect(t *testing.T) {
+func inspect(t *testing.T, source, dest string) {
 	p := m.Inspect(source)
 	require.Equal(t, 0, len(p), "Expect 0 mounts actual %v mounts", len(p))
 
@@ -89,7 +108,7 @@ func inspect(t *testing.T) {
 	require.NoError(t, err, "Failed in unmount")
 }
 
-func reload(t *testing.T) {
+func reload(t *testing.T, source, dest string) {
 	p := m.Inspect(source)
 	require.Equal(t, 0, len(p), "Expect 0 mounts actual %v mounts", len(p))
 
@@ -105,7 +124,7 @@ func reload(t *testing.T) {
 	require.Equal(t, 0, len(p), "Expect 0 mounts actual %v mounts", len(p))
 }
 
-func hasMounts(t *testing.T) {
+func hasMounts(t *testing.T, source, dest string) {
 	count := m.HasMounts(source)
 	require.Equal(t, 0, count, "Expect 0 mounts actual %v mounts", count)
 
@@ -139,7 +158,7 @@ func hasMounts(t *testing.T) {
 	require.Equal(t, mounts, 0, "Expect 0 mounts actual %v mounts", mounts)
 }
 
-func refcounts(t *testing.T) {
+func refcounts(t *testing.T, source, dest string) {
 	require.Equal(t, m.HasMounts(source) == 0, true, "Don't expect mounts in the beginning")
 	for i := 0; i < 10; i++ {
 		err := m.Mount(0, source, dest, "", syscall.MS_BIND, "", 0, nil)
@@ -155,7 +174,7 @@ func refcounts(t *testing.T) {
 	require.Error(t, err, "Unmount should fail")
 }
 
-func exists(t *testing.T) {
+func exists(t *testing.T, source, dest string) {
 	err := m.Mount(0, source, dest, "", syscall.MS_BIND, "", 0, nil)
 	require.NoError(t, err, "Failed in mount")
 	exists, _ := m.Exists(source, "foo")
@@ -166,7 +185,24 @@ func exists(t *testing.T) {
 	require.NoError(t, err, "Failed in unmount")
 }
 
-func shutdown(t *testing.T) {
+func shutdown(t *testing.T, source, dest string) {
 	os.RemoveAll(dest)
 	os.RemoveAll(source)
+}
+
+func makeFile(pathname string) error {
+	f, err := os.OpenFile(pathname, os.O_CREATE, os.FileMode(0644))
+	defer func() {
+		err := f.Close()
+		if err != nil {
+			logrus.Warnf("failed to close file: %s", err.Error())
+		}
+	}()
+	if err != nil {
+		if !os.IsExist(err) {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/mount/raw_mount.go
+++ b/pkg/mount/raw_mount.go
@@ -1,0 +1,168 @@
+// +build linux
+
+package mount
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/docker/docker/pkg/mount"
+	"github.com/libopenstorage/openstorage/pkg/keylock"
+)
+
+var (
+	skippedLocations = []string{"/proc", "/null"}
+)
+
+// rawMounter loads mounts for raw volumes that are bind mounted in the mount table
+type rawMounter struct {
+	Mounter
+}
+
+// NewRawBindMounter returns a new rawBindMounter
+func NewRawBindMounter(
+	rootSubstrings []string,
+	mountImpl MountImpl,
+	allowedDirs []string,
+	trashLocation string,
+) (*rawMounter, error) {
+	rm := &rawMounter{
+		Mounter: Mounter{
+			mountImpl:     mountImpl,
+			mounts:        make(DeviceMap),
+			paths:         make(PathMap),
+			allowedDirs:   allowedDirs,
+			kl:            keylock.New(),
+			trashLocation: trashLocation,
+		},
+	}
+	if err := rm.Load(rootSubstrings); err != nil {
+		return nil, err
+	}
+	return rm, nil
+}
+
+func (rm *rawMounter) Reload(rootSubstring string) error {
+	newRBM, err := NewRawBindMounter(
+		[]string{rootSubstring},
+		rm.mountImpl,
+		rm.allowedDirs,
+		rm.trashLocation,
+	)
+	if err != nil {
+		return err
+	}
+	return rm.reload(rootSubstring, newRBM.mounts[rootSubstring])
+}
+
+func shouldSkipMountPoint(mountPoint string) bool {
+	for _, skip := range skippedLocations {
+		if strings.HasPrefix(mountPoint, skip) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// this mount filtering implementation is done based on logic implemented in findmnt + libmount
+func (rm *rawMounter) Load(rawVolumeDevicesPaths []string) error {
+	mountPoints, err := GetMounts()
+	if err != nil {
+		return err
+	}
+
+	// try to find all bind mounts of raw volumes
+	if len(rawVolumeDevicesPaths) == 0 || rawVolumeDevicesPaths[0] == "" {
+		mountPointsByMajMin := make(map[string]*[]mount.Info)
+		mountPointsByTarget := make(map[string]*mount.Info)
+
+		for _, mp := range mountPoints {
+			// skip proc mount points
+			if shouldSkipMountPoint(mp.Mountpoint) || mp.Root == "/null" {
+				continue
+			}
+			majMin := fmt.Sprintf("%v:%v", mp.Major, mp.Minor)
+
+			mountPointsForNumber, exists := mountPointsByMajMin[majMin]
+			if !exists {
+				mountPointsForNumber = &[]mount.Info{}
+				mountPointsByMajMin[majMin] = mountPointsForNumber
+			}
+
+			*mountPointsForNumber = append(*mountPointsForNumber, *mp)
+
+			mountPointsByTarget[mp.Mountpoint] = mp
+		}
+
+		devicesMP, exists := mountPointsByTarget["/dev"]
+		if !exists {
+			return fmt.Errorf("cannot find /dev mount point while loading mount points")
+		}
+
+		devMajMin := fmt.Sprintf("%v:%v", devicesMP.Major, devicesMP.Minor)
+
+		mountPointsForNumber := mountPointsByMajMin[devMajMin]
+
+		mps := *mountPointsForNumber
+		filteredMPs := []mount.Info{}
+		for i := range mps {
+			if mps[i].Mountpoint != "/dev" {
+				filteredMPs = append(filteredMPs, mps[i])
+			}
+		}
+
+		for _, mp := range filteredMPs {
+			devicePath := "/dev" + mp.Root
+
+			// source for raw volumes is equal to rawVolumeDevicePath
+			mount, ok := rm.mounts[devicePath]
+			if !ok {
+				mount = &Info{
+					Device: devicePath,
+					Fs:     "",
+					Minor:  mp.Minor,
+					Mountpoint: []*PathInfo{&PathInfo{
+						Root: normalizeMountPath(devicePath),
+						Path: normalizeMountPath(mp.Mountpoint),
+					}},
+				}
+				rm.mounts[devicePath] = mount
+			}
+		}
+	}
+
+	// find raw volume bind mounts
+	for _, rawVolumeDevicePath := range rawVolumeDevicesPaths {
+		var mountPointForRoot *mount.Info
+		for _, mp := range mountPoints {
+			if strings.HasSuffix(rawVolumeDevicePath, mp.Root) {
+				mountPointForRoot = mp
+				break
+			}
+		}
+
+		if mountPointForRoot == nil {
+			continue
+		}
+
+		devicePath := "/dev" + mountPointForRoot.Root
+
+		// source for raw volumes is equal to rawVolumeDevicePath
+		mount, ok := rm.mounts[devicePath]
+		if !ok {
+			mount = &Info{
+				Device: devicePath,
+				Fs:     "",
+				Minor:  mountPointForRoot.Minor,
+				Mountpoint: []*PathInfo{&PathInfo{
+					Root: normalizeMountPath(devicePath),
+					Path: normalizeMountPath(mountPointForRoot.Mountpoint),
+				}},
+			}
+			rm.mounts[devicePath] = mount
+		}
+	}
+
+	return nil
+}

--- a/volume/drivers/fake/fake.go
+++ b/volume/drivers/fake/fake.go
@@ -226,9 +226,6 @@ func (d *driver) Unmount(volumeID string, mountpath string, options map[string]s
 	if err != nil {
 		return err
 	}
-	if len(v.AttachPath) == 0 {
-		return fmt.Errorf("Device %v not mounted", volumeID)
-	}
 
 	v.AttachPath = nil
 	return d.UpdateVol(v)


### PR DESCRIPTION
Cherry pick of #1854 on release-9.1.

#1854: Raw Block support

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.