### PR TITLE
[CSI] Round ControllerExpand up to nearest GiB

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -426,12 +426,11 @@ func (s *OsdCsiServer) CreateVolume(
 
 	// Get Size
 	if req.GetCapacityRange() != nil && req.GetCapacityRange().GetRequiredBytes() != 0 {
-		sizeQuantity := resource.NewQuantity(req.GetCapacityRange().GetRequiredBytes(), resource.BinarySI)
-		sizeGiB, err := roundUpToGiB(*sizeQuantity)
+		size, err := roundUpToNearestGiB(req.GetCapacityRange().GetRequiredBytes())
 		if err != nil {
 			return nil, fmt.Errorf("failed to round volume size up to nearest GiB: %v", err.Error())
 		}
-		spec.Size = uint64(sizeGiB) * units.GiB
+		spec.Size = size
 
 	} else {
 		spec.Size = defaultCSIVolumeSize
@@ -559,7 +558,10 @@ func (s *OsdCsiServer) ControllerExpandVolume(
 
 	// Get Size
 	spec := &api.VolumeSpecUpdate{}
-	newSize := uint64(req.GetCapacityRange().GetRequiredBytes())
+	newSize, err := roundUpToNearestGiB(req.GetCapacityRange().GetRequiredBytes())
+	if err != nil {
+		return nil, fmt.Errorf("failed to round volume size up to nearest GiB: %v", err.Error())
+	}
 	spec.SizeOpt = &api.VolumeSpecUpdate_Size{
 		Size: newSize,
 	}
@@ -826,9 +828,15 @@ func (s *OsdCsiServer) ListSnapshots(
 	return nil, status.Error(codes.Unimplemented, "ListSnapshots is not implemented")
 }
 
-// roundUpToGiB rounds up given quantity upto chunks of GiB
-func roundUpToGiB(size resource.Quantity) (int64, error) {
-	return roundUpSizeInt64(size, units.GiB)
+// roundUpToNearestGiB rounds up given quantity upto chunks of GiB
+func roundUpToNearestGiB(sizeBytes int64) (uint64, error) {
+	sizeGiB, err := roundUpSizeInt64(*resource.NewQuantity(sizeBytes, resource.BinarySI), units.GiB)
+	if err != nil {
+		return 0, err
+	}
+	sizeGiBRounded := uint64(sizeGiB) * units.GiB
+
+	return sizeGiBRounded, nil
 }
 
 // roundUpSizeInt64 calculates how many allocation units are needed to accommodate

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -2318,14 +2318,16 @@ func TestControllerExpandVolume(t *testing.T) {
 				&api.Volume{
 					Id: myid,
 					Spec: &api.VolumeSpec{
-						Size: uint64(50),
+						Size: uint64(units.GiB),
 					},
 				},
 			}, nil).
 			Times(1),
 		s.MockDriver().
 			EXPECT().
-			Set(gomock.Any(), gomock.Any(), gomock.Any()).
+			Set(gomock.Any(), gomock.Any(), &api.VolumeSpec{
+				Size: 46 * units.GiB, // Round up from 45.5 to 46
+			}).
 			Return(nil).
 			Times(1),
 	)
@@ -2333,7 +2335,7 @@ func TestControllerExpandVolume(t *testing.T) {
 	_, err := c.ControllerExpandVolume(context.Background(), &csi.ControllerExpandVolumeRequest{
 		VolumeId: myid,
 		CapacityRange: &csi.CapacityRange{
-			RequiredBytes: int64(100),
+			RequiredBytes: int64(45.5 * units.GiB),
 		},
 		Secrets: map[string]string{authsecrets.SecretTokenKey: systemUserToken},
 	})


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
Rounds CSI Driver ControllerExpand to nearest GiB 

Matches in-tree resize
https://github.com/kubernetes/kubernetes/blob/830055379b811f69f6f4cd8622bdcf8a08307c9a/pkg/volume/portworx/portworx_util.go#L217

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

