### PR TITLE
Automated cherry pick of #1884: Fix Volume Snapshot restore size

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -716,7 +716,7 @@ func (s *OsdCsiServer) CreateSnapshot(
 
 	return &csi.CreateSnapshotResponse{
 		Snapshot: &csi.Snapshot{
-			SizeBytes:      int64(v.GetSpec().GetSize()),
+			SizeBytes:      int64(snapInfo.GetSpec().GetSize()),
 			SnapshotId:     snapshotID,
 			SourceVolumeId: req.GetSourceVolumeId(),
 			CreationTime:   snapInfo.GetCtime(),


### PR DESCRIPTION
Cherry pick of #1884 on release-9.0.

#1884: Fix Volume Snapshot restore size

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.