### PR TITLE
Automated cherry pick of #1906: Change CSI driver logs from Debugf to Infof

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -126,7 +126,7 @@ func (s *OsdCsiServer) ControllerGetVolume(
 	ctx context.Context,
 	req *csi.ControllerGetVolumeRequest,
 ) (*csi.ControllerGetVolumeResponse, error) {
-	logrus.Debugf("ControllerGetVolume request received. VolumeID: %s", req.GetVolumeId())
+	logrus.Infof("ControllerGetVolume request received. VolumeID: %s", req.GetVolumeId())
 
 	vol, err := s.driverGetVolume(req.GetVolumeId())
 	if err != nil {
@@ -161,7 +161,7 @@ func (s *OsdCsiServer) ValidateVolumeCapabilities(
 	}
 
 	// Log request
-	logrus.Debugf("csi.ValidateVolumeCapabilities of id %s "+
+	logrus.Infof("csi.ValidateVolumeCapabilities of id %s "+
 		"capabilities %#v "+
 		id,
 		capabilities)
@@ -376,7 +376,7 @@ func (s *OsdCsiServer) CreateVolume(
 ) (*csi.CreateVolumeResponse, error) {
 
 	// Log request
-	logrus.Debugf("csi.CreateVolume request received. Volume: %s", req.GetName())
+	logrus.Infof("csi.CreateVolume request received. Volume: %s", req.GetName())
 
 	if len(req.GetName()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Name must be provided")
@@ -510,7 +510,7 @@ func (s *OsdCsiServer) DeleteVolume(
 ) (*csi.DeleteVolumeResponse, error) {
 
 	// Log request
-	logrus.Debugf("csi.DeleteVolume request received. VolumeID: %s", req.VolumeId)
+	logrus.Infof("csi.DeleteVolume request received. VolumeID: %s", req.VolumeId)
 
 	// Check arguments
 	if len(req.GetVolumeId()) == 0 {
@@ -842,7 +842,7 @@ func (s *OsdCsiServer) listSingleSnapshot(
 ) (*csi.ListSnapshotsResponse, error) {
 	snapshotId := req.GetSnapshotId()
 
-	logrus.Debugf("ListSnapshots for a single snapshot %s received", req.GetSnapshotId())
+	logrus.Infof("ListSnapshots for a single snapshot %s received", req.GetSnapshotId())
 
 	// Get grpc connection
 	conn, err := s.getConn()
@@ -905,7 +905,7 @@ func (s *OsdCsiServer) listMultipleSnapshots(
 	startingToken := req.GetStartingToken()
 	maxEntries := req.GetMaxEntries()
 
-	logrus.Debugf("ListSnapshots for multiple snapshots received. sourceVolumeId: %s, startingToken: %s, maxEntries: %v",
+	logrus.Infof("ListSnapshots for multiple snapshots received. sourceVolumeId: %s, startingToken: %s, maxEntries: %v",
 		sourceVolumeId,
 		startingToken,
 		maxEntries,

--- a/csi/node.go
+++ b/csi/node.go
@@ -70,7 +70,7 @@ func (s *OsdCsiServer) NodePublishVolume(
 	volumeId := req.GetVolumeId()
 	targetPath := req.GetTargetPath()
 
-	logrus.Debugf("csi.NodePublishVolume request received. VolumeID: %s, TargetPath: %s", volumeId, targetPath)
+	logrus.Infof("csi.NodePublishVolume request received. VolumeID: %s, TargetPath: %s", volumeId, targetPath)
 
 	// Check arguments
 	if len(volumeId) == 0 {
@@ -211,7 +211,7 @@ func (s *OsdCsiServer) NodeUnpublishVolume(
 	volumeId := req.GetVolumeId()
 	targetPath := req.GetTargetPath()
 
-	logrus.Debugf("csi.NodeUnpublishVolume request received. VolumeID: %s, TargetPath: %s", volumeId, targetPath)
+	logrus.Infof("csi.NodeUnpublishVolume request received. VolumeID: %s, TargetPath: %s", volumeId, targetPath)
 
 	// Check arguments
 	if len(volumeId) == 0 {
@@ -280,7 +280,7 @@ func (s *OsdCsiServer) NodeGetCapabilities(
 	req *csi.NodeGetCapabilitiesRequest,
 ) (*csi.NodeGetCapabilitiesResponse, error) {
 
-	logrus.Debugf("csi.NodeGetCapabilities request received")
+	logrus.Infof("csi.NodeGetCapabilities request received")
 
 	caps := []csi.NodeServiceCapability_RPC_Type{
 		// Getting volume stats for volume health monitoring
@@ -336,7 +336,7 @@ func getVolumeCondition(vol *api.Volume) *csi.VolumeCondition {
 // and only exposed via the CSI unix domain socket. If a secrets field is added
 // in csi.NodeGetVolumeStatsRequest, we can update this to hit the SDK and use auth.
 func (s *OsdCsiServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
-	logrus.Debugf("NodeGetVolumeStats request received. VolumeID: %s, VolumePath: %s", req.GetVolumeId(), req.GetVolumePath())
+	logrus.Infof("NodeGetVolumeStats request received. VolumeID: %s, VolumePath: %s", req.GetVolumeId(), req.GetVolumePath())
 
 	// Check arguments
 	id := req.GetVolumeId()


### PR DESCRIPTION
Cherry pick of #1906 on release-9.1.

#1906: Change CSI driver logs from Debugf to Infof

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.