### PR TITLE
pb-1857: Reverting the defaultTimeout base context in NewOIDC api.

### DIFF
--- a/pkg/auth/oidc.go
+++ b/pkg/auth/oidc.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	oidc "github.com/coreos/go-oidc"
-	"github.com/libopenstorage/openstorage/pkg/grpcutil"
 )
 
 // OIDCAuthConfig configures an OIDC connection
@@ -56,8 +55,9 @@ type OIDCAuthenticator struct {
 
 // NewOIDC returns a new OIDC authenticator
 func NewOIDC(config *OIDCAuthConfig) (*OIDCAuthenticator, error) {
-	ctx, cancel := grpcutil.WithDefaultTimeout(context.Background())
-	defer cancel()
+	// Reverting the defaultTimeout base context as some of the coreos oidc api
+	// takes this context for subsequent call and end up using expired context.
+	ctx := context.Background()
 
 	p, err := oidc.NewProvider(ctx, config.Issuer)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
```
pb-1857: Reverting the defaultTimeout base context in NewOIDC api.

      Reverting the defaultTimeout base context as some of the coreos oidc
      api takes this context for subsequent call and end up using expired
      context.

    Signed-off-by: sivakumar subramani <ssubramani@purestorage.com>
 ```
**Which issue(s) this PR fixes** (optional)
Closes # PB-1857

**Special notes for your reviewer**:

