### PR TITLE
Automated cherry pick of #1917: Correlation context pkg feedback

### DIFF
--- a/csi/csi_test.go
+++ b/csi/csi_test.go
@@ -22,7 +22,6 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -425,12 +424,8 @@ func TestCSIServerStartContextInterceptor(t *testing.T) {
 	logStr := buf.String()
 
 	expectedInfoLog := "correlation-id"
-	if !strings.Contains(logStr, expectedInfoLog) {
-		t.Fatalf("failed to check for log line %s in %s ", expectedInfoLog, logStr)
-	}
+	assert.Contains(t, logStr, expectedInfoLog)
 
 	expectedInfoLog = "csi-driver"
-	if !strings.Contains(logStr, expectedInfoLog) {
-		t.Fatalf("failed to check for log line %s in %s", expectedInfoLog, logStr)
-	}
+	assert.Contains(t, logStr, expectedInfoLog)
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -23,8 +23,7 @@ import (
 )
 
 func init() {
-	correlation.RegisterComponent("auth")
-	correlation.RegisterGlobalHook()
+	correlation.RegisterComponent(correlation.ComponentAuth)
 }
 
 const (

--- a/pkg/correlation/context.go
+++ b/pkg/correlation/context.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2021 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package correlation
 
 import (
@@ -18,7 +33,7 @@ const (
 	ComponentUnknown   = Component("unknown")
 	ComponentCSIDriver = Component("csi-driver")
 	ComponentSDK       = Component("sdk-server")
-	ComponentAuth      = Component("auth")
+	ComponentAuth      = Component("openstorage/pkg/auth")
 )
 
 // RequestContext represents the context for a given a request.
@@ -35,7 +50,7 @@ type RequestContext struct {
 }
 
 // NewContext returns a new correlation context object
-func NewContext(ctx context.Context, origin Component) context.Context {
+func WithCorrelationContext(ctx context.Context, origin Component) context.Context {
 	if v := ctx.Value(ContextKey); v == nil {
 		requestContext := &RequestContext{
 			ID:     uuid.New(),

--- a/pkg/correlation/correlation_test.go
+++ b/pkg/correlation/correlation_test.go
@@ -15,7 +15,7 @@ func TestNewPackageLogger(t *testing.T) {
 	clogger.SetReportCaller(true)
 	var buf bytes.Buffer
 	clogger.SetOutput(&buf)
-	ctx := correlation.NewContext(context.Background(), "test_origin")
+	ctx := correlation.WithCorrelationContext(context.Background(), "test_origin")
 
 	clogger.WithContext(ctx).Info("test info log")
 	logStr := buf.String()
@@ -37,7 +37,7 @@ func TestNewPackageLogger(t *testing.T) {
 }
 
 func TestFunctionLogger(t *testing.T) {
-	ctx := correlation.NewContext(context.Background(), "test_origin")
+	ctx := correlation.WithCorrelationContext(context.Background(), "test_origin")
 	correlation.RegisterComponent("register_comp_test")
 
 	clogger := correlation.NewFunctionLogger(ctx)
@@ -69,7 +69,7 @@ func TestRegisterGlobalLogger(t *testing.T) {
 	logrus.SetOutput(&buf)
 	logrus.SetReportCaller(true)
 	correlation.RegisterGlobalHook()
-	ctx := correlation.NewContext(context.Background(), "test_origin")
+	ctx := correlation.WithCorrelationContext(context.Background(), "test_origin")
 
 	logrus.WithContext(ctx).Info("test info log")
 	logStr := buf.String()

--- a/pkg/correlation/hook.go
+++ b/pkg/correlation/hook.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2021 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package correlation
 
 import (

--- a/pkg/correlation/interceptor.go
+++ b/pkg/correlation/interceptor.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2021 Portworx
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package correlation
 
 import (
@@ -19,7 +34,7 @@ func (ci *ContextInterceptor) ContextUnaryInterceptor(
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
 ) (interface{}, error) {
-	ctx = NewContext(ctx, ci.Origin)
+	ctx = WithCorrelationContext(ctx, ci.Origin)
 
 	return handler(ctx, req)
 }


### PR DESCRIPTION
Cherry pick of #1917 on release-9.2.

#1917: Correlation context pkg feedback

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.