### PR TITLE
Automated cherry pick of #1930: Add correlation context to Attach/Detach/MountedAt

### DIFF
--- a/api/client/volume/client.go
+++ b/api/client/volume/client.go
@@ -349,7 +349,7 @@ func (v *volumeClient) SnapEnumerate(ids []string,
 // Attach map device to the host.
 // On success the devicePath specifies location where the device is exported
 // Errors ErrEnoEnt, ErrVolAttached may be returned.
-func (v *volumeClient) Attach(volumeID string, attachOptions map[string]string) (string, error) {
+func (v *volumeClient) Attach(ctx context.Context, volumeID string, attachOptions map[string]string) (string, error) {
 	response, err := v.doVolumeSetGetResponse(
 		volumeID,
 		&api.VolumeSetRequest{
@@ -374,7 +374,7 @@ func (v *volumeClient) Attach(volumeID string, attachOptions map[string]string) 
 
 // Detach device from the host.
 // Errors ErrEnoEnt, ErrVolDetached may be returned.
-func (v *volumeClient) Detach(volumeID string, options map[string]string) error {
+func (v *volumeClient) Detach(ctx context.Context, volumeID string, options map[string]string) error {
 	return v.doVolumeSet(
 		volumeID,
 		&api.VolumeSetRequest{
@@ -386,7 +386,7 @@ func (v *volumeClient) Detach(volumeID string, options map[string]string) error 
 	)
 }
 
-func (v *volumeClient) MountedAt(mountPath string) string {
+func (v *volumeClient) MountedAt(ctx context.Context, mountPath string) string {
 	return ""
 }
 

--- a/api/flexvolume/flexvolume.go
+++ b/api/flexvolume/flexvolume.go
@@ -55,7 +55,7 @@ func (c *flexVolumeClient) Attach(jsonOptions map[string]string) error {
 	if !ok {
 		return ErrInvalidSpecVolumeID
 	}
-	if _, err := driver.Attach(mountDevice, nil); err != nil {
+	if _, err := driver.Attach(context.TODO(), mountDevice, nil); err != nil {
 		return err
 	}
 	return nil
@@ -71,7 +71,7 @@ func (c *flexVolumeClient) Detach(mountDevice string, options map[string]string)
 	if err != nil {
 		return err
 	}
-	if err := driver.Detach(mountDevice, options); err != nil {
+	if err := driver.Detach(context.TODO(), mountDevice, options); err != nil {
 		return err
 	}
 	return nil

--- a/api/server/docker.go
+++ b/api/server/docker.go
@@ -688,7 +688,7 @@ func (d *driver) mount(w http.ResponseWriter, r *http.Request) {
 	// detached. If not return an error.
 	mountpoint := d.mountpath(name)
 	if vol.Spec.Scale > 1 {
-		id := v.MountedAt(mountpoint)
+		id := v.MountedAt(ctx, mountpoint)
 		if len(id) != 0 {
 			err = v.Unmount(correlation.TODO(), id, mountpoint, nil)
 			if err != nil {
@@ -700,7 +700,7 @@ func (d *driver) mount(w http.ResponseWriter, r *http.Request) {
 			}
 
 			if v.Type() == api.DriverType_DRIVER_TYPE_BLOCK {
-				err = v.Detach(id, nil)
+				err = v.Detach(ctx, id, nil)
 				if err != nil {
 					d.logRequest(method, "").Warnf("Error detaching scaled volume: %v", err)
 
@@ -840,6 +840,7 @@ func (d *driver) get(w http.ResponseWriter, r *http.Request) {
 
 func (d *driver) unmount(w http.ResponseWriter, r *http.Request) {
 	method := "unmount"
+	ctx := r.Context()
 
 	v, err := volumedrivers.Get(d.name)
 	if err != nil {
@@ -866,7 +867,7 @@ func (d *driver) unmount(w http.ResponseWriter, r *http.Request) {
 	mountpoint := d.mountpath(name)
 	id := vol.Id
 	if vol.Spec.Scale > 1 {
-		id = v.MountedAt(mountpoint)
+		id = v.MountedAt(ctx, mountpoint)
 		if len(id) == 0 {
 			err := fmt.Errorf("Failed to find volume mapping for %v",
 				mountpoint)
@@ -891,7 +892,7 @@ func (d *driver) unmount(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if v.Type() == api.DriverType_DRIVER_TYPE_BLOCK {
-		_ = v.Detach(id, nil)
+		_ = v.Detach(context.TODO(), id, nil)
 	}
 	d.emptyResponse(w)
 }

--- a/api/server/middleware_auth.go
+++ b/api/server/middleware_auth.go
@@ -170,6 +170,8 @@ func (a *authMiddleware) createWithAuth(w http.ResponseWriter, r *http.Request, 
 
 func (a *authMiddleware) setWithAuth(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 	fn := "set"
+
+	ctx := correlation.WithCorrelationContext(r.Context(), "auth-middleware")
 	d, authRequired := a.isTokenProcessingRequired(r)
 	if !authRequired {
 		next(w, r)
@@ -210,9 +212,9 @@ func (a *authMiddleware) setWithAuth(w http.ResponseWriter, r *http.Request, nex
 		if req.Action.Attach != api.VolumeActionParam_VOLUME_ACTION_PARAM_NONE {
 			isOpDone = true
 			if req.Action.Attach == api.VolumeActionParam_VOLUME_ACTION_PARAM_ON {
-				_, err = d.Attach(volumeID, req.Options)
+				_, err = d.Attach(ctx, volumeID, req.Options)
 			} else {
-				err = d.Detach(volumeID, req.Options)
+				err = d.Detach(ctx, volumeID, req.Options)
 			}
 			if err != nil {
 				break
@@ -226,9 +228,9 @@ func (a *authMiddleware) setWithAuth(w http.ResponseWriter, r *http.Request, nex
 					err = fmt.Errorf("Invalid mount path")
 					break
 				}
-				err = d.Mount(correlation.TODO(), volumeID, req.Action.MountPath, req.Options)
+				err = d.Mount(ctx, volumeID, req.Action.MountPath, req.Options)
 			} else {
-				err = d.Unmount(correlation.TODO(), volumeID, req.Action.MountPath, req.Options)
+				err = d.Unmount(ctx, volumeID, req.Action.MountPath, req.Options)
 			}
 			if err != nil {
 				break

--- a/api/server/sdk/volume_node_ops.go
+++ b/api/server/sdk/volume_node_ops.go
@@ -65,7 +65,7 @@ func (s *VolumeServer) Attach(
 		}
 	}
 
-	devPath, err := s.driver(ctx).Attach(req.GetVolumeId(), options)
+	devPath, err := s.driver(ctx).Attach(ctx, req.GetVolumeId(), options)
 	if err == volume.ErrVolAttachedOnRemoteNode {
 		return nil, status.Error(codes.AlreadyExists, err.Error())
 	} else if err != nil {
@@ -109,7 +109,7 @@ func (s *VolumeServer) Detach(
 		options[mountattachoptions.OptionsRedirectDetach] = fmt.Sprint(req.GetOptions().GetRedirect())
 	}
 
-	err = s.driver(ctx).Detach(req.GetVolumeId(), options)
+	err = s.driver(ctx).Detach(context.TODO(), req.GetVolumeId(), options)
 	if err != nil && !IsErrorNotFound(err) {
 		return nil, status.Errorf(
 			codes.Internal,

--- a/api/server/sdk/volume_node_ops_test.go
+++ b/api/server/sdk/volume_node_ops_test.go
@@ -67,7 +67,7 @@ func TestSdkVolumeAttachSuccess(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Attach(id, options).
+			Attach(gomock.Any(), id, options).
 			Return(devpath, nil),
 	)
 
@@ -116,7 +116,7 @@ func TestSdkVolumeAttachFailed(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Attach(id, options).
+			Attach(gomock.Any(), id, options).
 			Return("", fmt.Errorf("Failed to Attach device")),
 	)
 
@@ -191,7 +191,7 @@ func TestSdkVolumeDetachSuccess(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Detach(id, options).
+			Detach(gomock.Any(), id, options).
 			Return(nil),
 	)
 
@@ -238,7 +238,7 @@ func TestSdkVolumeDetachFailed(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Detach(id, options).
+			Detach(gomock.Any(), id, options).
 			Return(fmt.Errorf("Failed to Detach")),
 	)
 

--- a/api/server/volume_test.go
+++ b/api/server/volume_test.go
@@ -1014,7 +1014,7 @@ func TestVolumeAttachSuccess(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
-	_, err = driverclient.Attach(id, map[string]string{})
+	_, err = driverclient.Attach(context.TODO(), id, map[string]string{})
 	assert.Nil(t, err)
 
 	// Assert volume information is correct
@@ -1064,7 +1064,7 @@ func TestVolumeAttachFailed(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
-	_, err = driverclient.Attach("doesnotexist", map[string]string{})
+	_, err = driverclient.Attach(context.TODO(), "doesnotexist", map[string]string{})
 	assert.NotNil(t, err)
 
 	// Assert volume information is correct
@@ -1115,11 +1115,11 @@ func TestVolumeDetachSuccess(t *testing.T) {
 	assert.NotEmpty(t, id)
 
 	// Attach
-	_, err = driverclient.Attach(id, map[string]string{})
+	_, err = driverclient.Attach(context.TODO(), id, map[string]string{})
 	assert.Nil(t, err)
 
 	// Detach
-	res := driverclient.Detach(id, map[string]string{})
+	res := driverclient.Detach(context.TODO(), id, map[string]string{})
 	assert.Nil(t, res)
 
 	volumes := api.NewOpenStorageVolumeClient(testVolDriver.Conn())
@@ -1168,11 +1168,11 @@ func TestVolumeDetachFailed(t *testing.T) {
 	assert.NotEmpty(t, id)
 
 	// Attach
-	_, err = driverclient.Attach(id, map[string]string{})
+	_, err = driverclient.Attach(context.TODO(), id, map[string]string{})
 	assert.Nil(t, err)
 
 	// Detach
-	res := driverclient.Detach("doesnotexist", map[string]string{})
+	res := driverclient.Detach(context.TODO(), "doesnotexist", map[string]string{})
 	// Detach must not fail on non-existing volume
 	assert.Nil(t, res)
 

--- a/cli/volumes.go
+++ b/cli/volumes.go
@@ -174,7 +174,7 @@ func (v *volDriver) volumeAttach(cliContext *cli.Context) {
 	v.volumeOptions(cliContext)
 	volumeID := cliContext.Args()[0]
 
-	devicePath, err := v.volDriver.Attach(string(volumeID), nil)
+	devicePath, err := v.volDriver.Attach(context.TODO(), (volumeID), nil)
 	if err != nil {
 		cmdError(cliContext, fn, err)
 		return
@@ -191,7 +191,7 @@ func (v *volDriver) volumeDetach(cliContext *cli.Context) {
 	}
 	volumeID := cliContext.Args()[0]
 	v.volumeOptions(cliContext)
-	err := v.volDriver.Detach(string(volumeID), nil)
+	err := v.volDriver.Detach(context.TODO(), string(volumeID), nil)
 	if err != nil {
 		cmdError(cliContext, fn, err)
 		return

--- a/csi/controller.go
+++ b/csi/controller.go
@@ -175,7 +175,7 @@ func (s *OsdCsiServer) ValidateVolumeCapabilities(
 	}
 
 	// Get secret if any was passed
-	ctx = s.setupContextWithToken(ctx, req.GetSecrets())
+	ctx = s.setupContext(ctx, req.GetSecrets())
 	ctx, cancel := grpcutil.WithDefaultTimeout(ctx)
 	defer cancel()
 
@@ -451,7 +451,7 @@ func (s *OsdCsiServer) CreateVolume(
 	}
 
 	// Get secret if any was passed
-	ctx = s.setupContextWithToken(ctx, req.GetSecrets())
+	ctx = s.setupContext(ctx, req.GetSecrets())
 	ctx, cancel := grpcutil.WithDefaultTimeout(ctx)
 	defer cancel()
 
@@ -524,7 +524,7 @@ func (s *OsdCsiServer) DeleteVolume(
 	}
 
 	// Get secret if any was passed
-	ctx = s.setupContextWithToken(ctx, req.GetSecrets())
+	ctx = s.setupContext(ctx, req.GetSecrets())
 	ctx, cancel := grpcutil.WithDefaultTimeout(ctx)
 	defer cancel()
 
@@ -577,7 +577,7 @@ func (s *OsdCsiServer) ControllerExpandVolume(
 	}
 
 	// Get secret if any was passed
-	ctx = s.setupContextWithToken(ctx, req.GetSecrets())
+	ctx = s.setupContext(ctx, req.GetSecrets())
 	ctx, cancel := grpcutil.WithDefaultTimeout(ctx)
 	defer cancel()
 
@@ -719,7 +719,7 @@ func (s *OsdCsiServer) CreateSnapshot(
 	}
 
 	// Get secret if any was passed
-	ctx = s.setupContextWithToken(ctx, req.GetSecrets())
+	ctx = s.setupContext(ctx, req.GetSecrets())
 	ctx, cancel := grpcutil.WithDefaultTimeout(ctx)
 	defer cancel()
 
@@ -800,7 +800,7 @@ func (s *OsdCsiServer) DeleteSnapshot(
 	}
 
 	// Get secret if any was passed
-	ctx = s.setupContextWithToken(ctx, req.GetSecrets())
+	ctx = s.setupContext(ctx, req.GetSecrets())
 	ctx, cancel := grpcutil.WithDefaultTimeout(ctx)
 	defer cancel()
 
@@ -852,7 +852,7 @@ func (s *OsdCsiServer) listSingleSnapshot(
 	}
 
 	// Get secret if any was passed
-	ctx = s.setupContextWithToken(ctx, req.GetSecrets())
+	ctx = s.setupContext(ctx, req.GetSecrets())
 	ctx, cancel := grpcutil.WithDefaultTimeout(ctx)
 	defer cancel()
 	volumes := api.NewOpenStorageVolumeClient(conn)
@@ -919,7 +919,7 @@ func (s *OsdCsiServer) listMultipleSnapshots(
 	}
 
 	// Get secret if any was passed
-	ctx = s.setupContextWithToken(ctx, req.GetSecrets())
+	ctx = s.setupContext(ctx, req.GetSecrets())
 	ctx, cancel := grpcutil.WithDefaultTimeout(ctx)
 	defer cancel()
 	volumes := api.NewOpenStorageVolumeClient(conn)

--- a/csi/node.go
+++ b/csi/node.go
@@ -105,7 +105,7 @@ func (s *OsdCsiServer) NodePublishVolume(
 	}
 
 	// Get secret if any was passed
-	ctx = s.setupContextWithToken(ctx, req.GetSecrets())
+	ctx = s.setupContext(ctx, req.GetSecrets())
 	ctx, cancel := grpcutil.WithDefaultTimeout(ctx)
 	defer cancel()
 

--- a/csi/node.go
+++ b/csi/node.go
@@ -245,7 +245,7 @@ func (s *OsdCsiServer) NodeUnpublishVolume(
 	}
 
 	if s.driver.Type() == api.DriverType_DRIVER_TYPE_BLOCK {
-		if err = s.driver.Detach(volumeId, nil); err != nil {
+		if err = s.driver.Detach(ctx, volumeId, nil); err != nil {
 			return nil, status.Errorf(
 				codes.Internal,
 				"Unable to detach volume: %s",

--- a/csi/node_test.go
+++ b/csi/node_test.go
@@ -258,7 +258,7 @@ func TestNodePublishVolumeFailedToAttach(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Attach(name, gomock.Any()).
+			Attach(gomock.Any(), name, gomock.Any()).
 			Return("", fmt.Errorf("Unable to attach volume")).
 			Times(1),
 	)
@@ -397,7 +397,7 @@ func TestNodePublishVolumeBlock(t *testing.T) {
 			Times(1),
 		s.MockDriver().
 			EXPECT().
-			Attach(name, gomock.Any()).
+			Attach(gomock.Any(), name, gomock.Any()).
 			Return("", nil).
 			Times(1),
 		s.MockDriver().
@@ -804,7 +804,7 @@ func TestNodeUnpublishVolumeFailedToUnmount(t *testing.T) {
 			Times(1),
 		s.MockDriver().
 			EXPECT().
-			Detach(name, gomock.Any()).
+			Detach(gomock.Any(), name, gomock.Any()).
 			Return(nil).
 			Times(1),
 	)
@@ -861,7 +861,7 @@ func TestNodeUnpublishVolumeFailedDetach(t *testing.T) {
 			Times(1),
 		s.MockDriver().
 			EXPECT().
-			Detach(name, gomock.Any()).
+			Detach(gomock.Any(), name, gomock.Any()).
 			Return(fmt.Errorf("DETACH ERROR")).
 			Times(1),
 	)
@@ -923,7 +923,7 @@ func TestNodeUnpublishVolumeUnmount(t *testing.T) {
 			Times(1),
 		s.MockDriver().
 			EXPECT().
-			Detach(name, gomock.Any()).
+			Detach(gomock.Any(), name, gomock.Any()).
 			Return(nil).
 			Times(1),
 	)

--- a/csi/v0.3/node.go
+++ b/csi/v0.3/node.go
@@ -120,7 +120,7 @@ func (s *OsdCsiServer) NodePublishVolume(
 	// If this is for a block driver, first attach the volume
 	var devicePath string
 	if s.driver.Type() == api.DriverType_DRIVER_TYPE_BLOCK {
-		if devicePath, err = s.driver.Attach(req.GetVolumeId(), opts); err != nil {
+		if devicePath, err = s.driver.Attach(ctx, req.GetVolumeId(), opts); err != nil {
 			return nil, status.Errorf(
 				codes.Internal,
 				"Unable to attach volume: %s",
@@ -132,7 +132,7 @@ func (s *OsdCsiServer) NodePublishVolume(
 		// As block create a sym link to the attached location
 		err = os.Symlink(devicePath, req.GetTargetPath())
 		if err != nil {
-			detachErr := s.driver.Detach(v.GetId(), opts)
+			detachErr := s.driver.Detach(ctx, v.GetId(), opts)
 			if detachErr != nil {
 				logrus.Errorf("Unable to detach volume %s: %s",
 					v.GetId(),
@@ -158,7 +158,7 @@ func (s *OsdCsiServer) NodePublishVolume(
 		// Mount volume onto the path
 		if err := s.driver.Mount(ctx, req.GetVolumeId(), req.GetTargetPath(), nil); err != nil {
 			// Detach on error
-			detachErr := s.driver.Detach(v.GetId(), opts)
+			detachErr := s.driver.Detach(ctx, v.GetId(), opts)
 			if detachErr != nil {
 				logrus.Errorf("Unable to detach volume %s: %s",
 					v.GetId(),
@@ -244,7 +244,7 @@ func (s *OsdCsiServer) NodeUnpublishVolume(
 	}
 
 	if s.driver.Type() == api.DriverType_DRIVER_TYPE_BLOCK {
-		if err = s.driver.Detach(req.GetVolumeId(), nil); err != nil {
+		if err = s.driver.Detach(ctx, req.GetVolumeId(), nil); err != nil {
 			return nil, status.Errorf(
 				codes.Internal,
 				"Unable to detach volume: %s",

--- a/csi/v0.3/node_test.go
+++ b/csi/v0.3/node_test.go
@@ -260,7 +260,7 @@ func TestNodePublishVolumeInvalidTargetLocation(t *testing.T) {
 		Times(2 * len(testargs))
 	s.MockDriver().
 		EXPECT().
-		Attach(name, map[string]string{}).
+		Attach(gomock.Any(), name, map[string]string{}).
 		Return(devicePath, nil).
 		Times(len(testargs))
 	s.MockDriver().
@@ -327,7 +327,7 @@ func TestNodePublishVolumeFailedToAttach(t *testing.T) {
 			Times(2),
 		s.MockDriver().
 			EXPECT().
-			Attach(name, gomock.Any()).
+			Attach(gomock.Any(), name, gomock.Any()).
 			Return("", fmt.Errorf("TEST")).
 			Times(1),
 	)
@@ -383,7 +383,7 @@ func TestNodePublishVolumeFailedMount(t *testing.T) {
 			Times(2),
 		s.MockDriver().
 			EXPECT().
-			Attach(name, gomock.Any()).
+			Attach(gomock.Any(), name, gomock.Any()).
 			Return("", nil).
 			Times(1),
 		s.MockDriver().
@@ -393,7 +393,7 @@ func TestNodePublishVolumeFailedMount(t *testing.T) {
 			Times(1),
 		s.MockDriver().
 			EXPECT().
-			Detach(name, gomock.Any()).
+			Detach(gomock.Any(), name, gomock.Any()).
 			Return(nil).
 			Times(1),
 	)
@@ -450,7 +450,7 @@ func TestNodePublishVolumeBlock(t *testing.T) {
 			Times(2),
 		s.MockDriver().
 			EXPECT().
-			Attach(name, gomock.Any()).
+			Attach(gomock.Any(), name, gomock.Any()).
 			Return(devicePath, nil).
 			Times(1),
 	)
@@ -517,7 +517,7 @@ func TestNodePublishVolumeMount(t *testing.T) {
 			Times(2),
 		s.MockDriver().
 			EXPECT().
-			Attach(name, gomock.Any()).
+			Attach(gomock.Any(), name, gomock.Any()).
 			Return("", nil).
 			Times(1),
 		s.MockDriver().
@@ -706,7 +706,7 @@ func TestNodeUnpublishVolumeFailedDetach(t *testing.T) {
 			Times(1),
 		s.MockDriver().
 			EXPECT().
-			Detach(name, gomock.Any()).
+			Detach(gomock.Any(), name, gomock.Any()).
 			Return(fmt.Errorf("DETACH ERROR")).
 			Times(1),
 	)
@@ -764,7 +764,7 @@ func TestNodeUnpublishVolumeUnmount(t *testing.T) {
 			Times(1),
 		s.MockDriver().
 			EXPECT().
-			Detach(name, gomock.Any()).
+			Detach(gomock.Any(), name, gomock.Any()).
 			Return(nil).
 			Times(1),
 	)

--- a/graph/drivers/layer0/layer0.go
+++ b/graph/drivers/layer0/layer0.go
@@ -190,7 +190,7 @@ func (l *Layer0) create(id, parent string) (string, *Layer0Vol, error) {
 
 	// If this is a block driver, first attach the volume.
 	if l.volDriver.Type() == api.DriverType_DRIVER_TYPE_BLOCK {
-		_, err := l.volDriver.Attach(vols[index].Id, nil)
+		_, err := l.volDriver.Attach(context.TODO(), vols[index].Id, nil)
 		if err != nil {
 			logrus.Errorf("Failed to attach volume %v", vols[index].Id)
 			delete(l.volumes, id)
@@ -259,7 +259,7 @@ func (l *Layer0) Remove(id string) error {
 
 			err = l.volDriver.Unmount(context.TODO(), v.volumeID, v.path, opts)
 			if l.volDriver.Type() == api.DriverType_DRIVER_TYPE_BLOCK {
-				_ = l.volDriver.Detach(v.volumeID, nil)
+				_ = l.volDriver.Detach(context.TODO(), v.volumeID, nil)
 			}
 			err = os.RemoveAll(v.path)
 			delete(l.volumes, v.id)

--- a/pkg/correlation/correlation_test.go
+++ b/pkg/correlation/correlation_test.go
@@ -3,6 +3,7 @@ package correlation_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -95,6 +96,7 @@ func TestWithCorrelationContext(t *testing.T) {
 
 	id := cc.ID
 	assert.NotEmpty(t, id)
+	fmt.Println(id)
 
 	ctx = correlation.WithCorrelationContext(ctx, "test")
 	cc, ok = ctx.Value(correlation.ContextKey).(*correlation.RequestContext)
@@ -102,5 +104,6 @@ func TestWithCorrelationContext(t *testing.T) {
 		t.Error("correlation context not found")
 	}
 	newID := cc.ID
+	fmt.Println(newID)
 	assert.Equal(t, id, newID)
 }

--- a/pkg/correlation/hook.go
+++ b/pkg/correlation/hook.go
@@ -71,9 +71,15 @@ func (lh *LogHook) Fire(entry *logrus.Entry) error {
 
 	// If a context has been found, we will populate the correlation info
 	if ctx != nil {
-		correlationContext, ok := ctx.Value(ContextKey).(*RequestContext)
+		ctxKeyValue := ctx.Value(ContextKey)
+		if ctxKeyValue == nil {
+			// Return without error as we not always add the correlation context
+			return nil
+		}
+
+		correlationContext, ok := ctxKeyValue.(*RequestContext)
 		if !ok {
-			return fmt.Errorf("failed to get context for correlation logging hook")
+			return fmt.Errorf("failed to get request context for correlation logging hook")
 		}
 
 		entry.Data[LogFieldID] = correlationContext.ID
@@ -158,6 +164,8 @@ func registerFileAsComponent(file string, component Component) {
 // i.e. /go/src/github.com/libopenstorage/openstorage/pkg/correlation
 // will return openstorage/pkg/correlation
 func getLocalPackage(dir string) string {
+	fmt.Println("GETTING LCOAL PKG", dir)
+
 	parts := strings.Split(dir, "/")
 	var githubIndex int
 	for i, d := range parts {

--- a/pkg/correlation/hook.go
+++ b/pkg/correlation/hook.go
@@ -101,8 +101,11 @@ func (lh *LogHook) Fire(entry *logrus.Entry) error {
 			entry.Data[LogFieldComponent] = getLocalPackage(dir)
 		}
 
-		// Clear caller metadata. We don't want to log the entire file/function
-		entry.Caller.File = ""
+	}
+
+	if entry.HasCaller() {
+		// always clear caller metadata. We don't want to log the entire file/function
+		entry.Caller.File = filepath.Base(entry.Caller.File)
 		entry.Caller.Function = ""
 	}
 
@@ -164,8 +167,6 @@ func registerFileAsComponent(file string, component Component) {
 // i.e. /go/src/github.com/libopenstorage/openstorage/pkg/correlation
 // will return openstorage/pkg/correlation
 func getLocalPackage(dir string) string {
-	fmt.Println("GETTING LCOAL PKG", dir)
-
 	parts := strings.Split(dir, "/")
 	var githubIndex int
 	for i, d := range parts {

--- a/pkg/correlation/interceptor.go
+++ b/pkg/correlation/interceptor.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 )
 
 // ContextInterceptor represents a correlation interceptor
@@ -34,6 +35,16 @@ func (ci *ContextInterceptor) ContextUnaryInterceptor(
 	info *grpc.UnaryServerInfo,
 	handler grpc.UnaryHandler,
 ) (interface{}, error) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if ok {
+		// Get request context from gRPC metadata
+		rc := RequestContextFromContextMetadata(md)
+
+		// Only add to context if an ID exists
+		if len(rc.ID) > 0 {
+			ctx = context.WithValue(ctx, ContextKey, rc)
+		}
+	}
 	ctx = WithCorrelationContext(ctx, ci.Origin)
 
 	return handler(ctx, req)

--- a/pkg/sanity/backup_restore.go
+++ b/pkg/sanity/backup_restore.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sanity
 
 import (
+	"context"
 	"time"
 
 	"github.com/libopenstorage/openstorage/api"
@@ -101,7 +102,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 		AfterEach(func() {
 			var err error
 
-			err = volumedriver.Detach(volumeID, nil)
+			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = volumedriver.Delete(volumeID)
@@ -153,7 +154,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 				}
 
 				// Attaching the volume first
-				str, err := volumedriver.Attach(volumeID, nil)
+				str, err := volumedriver.Attach(context.TODO(), volumeID, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(str).NotTo(BeNil())
 
@@ -209,7 +210,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 		AfterEach(func() {
 			var err error
 
-			err = volumedriver.Detach(volumeID, nil)
+			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = volumedriver.Delete(volumeID)
@@ -259,7 +260,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 				}
 
 				// Attaching the volume first
-				str, err := volumedriver.Attach(volumeID, nil)
+				str, err := volumedriver.Attach(context.TODO(), volumeID, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(str).NotTo(BeNil())
 
@@ -332,7 +333,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 		AfterEach(func() {
 			var err error
 
-			err = volumedriver.Detach(volumeID, nil)
+			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = volumedriver.Delete(volumeID)
@@ -387,7 +388,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 				}
 
 				// Attaching the volume first
-				str, err := volumedriver.Attach(volumeID, nil)
+				str, err := volumedriver.Attach(context.TODO(), volumeID, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(str).NotTo(BeNil())
 
@@ -474,7 +475,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 		AfterEach(func() {
 			var err error
 
-			err = volumedriver.Detach(volumeID, nil)
+			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = volumedriver.Delete(volumeID)
@@ -552,7 +553,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 		AfterEach(func() {
 			var err error
 
-			err = volumedriver.Detach(volumeID, nil)
+			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = volumedriver.Delete(volumeID)
@@ -644,7 +645,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 		AfterEach(func() {
 			var err error
 
-			err = volumedriver.Detach(volumeID, nil)
+			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = volumedriver.Delete(volumeID)
@@ -733,7 +734,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 		AfterEach(func() {
 			var err error
 
-			err = volumedriver.Detach(volumeID, nil)
+			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = volumedriver.Delete(volumeID)
@@ -785,7 +786,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 				}
 
 				// Attaching the volume first
-				str, err := volumedriver.Attach(volumeID, nil)
+				str, err := volumedriver.Attach(context.TODO(), volumeID, nil)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(str).NotTo(BeNil())
 

--- a/pkg/sanity/volume.go
+++ b/pkg/sanity/volume.go
@@ -439,7 +439,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 
 			By("Attaching the volume to a node")
 
-			str, err := volumedriver.Attach(volumeID, nil)
+			str, err := volumedriver.Attach(context.TODO(), volumeID, nil)
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(str).NotTo(BeNil())
@@ -453,7 +453,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			Expect(volumes[0].GetAttachedState()).To(BeEquivalentTo(api.AttachState_ATTACH_STATE_EXTERNAL))
 
 			By("Detaching the volume successfully")
-			err = volumedriver.Detach(volumeID, nil)
+			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 		})
@@ -479,7 +479,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 		AfterEach(func() {
 			var err error
 
-			err = volumedriver.Detach(volumeID, nil)
+			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = volumedriver.Delete(volumeID)
@@ -523,7 +523,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 
 			By("Attaching a volume before mounting")
 
-			str, err := volumedriver.Attach(volumeID, nil)
+			str, err := volumedriver.Attach(context.TODO(), volumeID, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(str).NotTo(BeEmpty())
 
@@ -599,7 +599,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 
 			By("First attaching and mounting the volume to a node")
 
-			str, err := volumedriver.Attach(volumeID, nil)
+			str, err := volumedriver.Attach(context.TODO(), volumeID, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(str).NotTo(BeNil())
 
@@ -631,7 +631,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			err = volumedriver.Unmount(context.TODO(), volumeID, "/mnt", nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = volumedriver.Detach(volumeID, nil)
+			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -913,7 +913,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			err = volumedriver.Unmount(context.TODO(), volumeID, "/mnt", nil)
 			Expect(err).NotTo(HaveOccurred())
 
-			err = volumedriver.Detach(volumeID, nil)
+			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			err = volumedriver.Delete(volumeID)
@@ -959,7 +959,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			Expect(err).To(HaveOccurred())
 
 			By("Now Attaching and mounting the volume")
-			str, err := volumedriver.Attach(volumeID, nil)
+			str, err := volumedriver.Attach(context.TODO(), volumeID, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(str).NotTo(BeNil())
 

--- a/volume/drivers/buse/buse.go
+++ b/volume/drivers/buse/buse.go
@@ -268,7 +268,7 @@ func (d *driver) Delete(volumeID string) error {
 	return nil
 }
 
-func (d *driver) MountedAt(mountpath string) string {
+func (d *driver) MountedAt(ctx context.Context, mountpath string) string {
 	return ""
 }
 
@@ -360,12 +360,12 @@ func (d *driver) Set(volumeID string, locator *api.VolumeLocator, spec *api.Volu
 	return d.UpdateVol(v)
 }
 
-func (d *driver) Attach(volumeID string, attachOptions map[string]string) (string, error) {
+func (d *driver) Attach(ctx context.Context, volumeID string, attachOptions map[string]string) (string, error) {
 	// Nothing to do on attach.
 	return path.Join(BuseMountPath, volumeID), nil
 }
 
-func (d *driver) Detach(volumeID string, options map[string]string) error {
+func (d *driver) Detach(ctx context.Context, volumeID string, options map[string]string) error {
 	// Nothing to do on detach.
 	return nil
 }

--- a/volume/drivers/fake/fake.go
+++ b/volume/drivers/fake/fake.go
@@ -207,7 +207,7 @@ func (d *driver) Delete(volumeID string) error {
 	return nil
 }
 
-func (d *driver) MountedAt(mountpath string) string {
+func (d *driver) MountedAt(ctx context.Context, mountpath string) string {
 	return ""
 }
 
@@ -267,11 +267,11 @@ func (d *driver) SnapshotGroup(groupID string, labels map[string]string, volumeI
 	return nil, volume.ErrNotSupported
 }
 
-func (d *driver) Attach(volumeID string, attachOptions map[string]string) (string, error) {
+func (d *driver) Attach(ctx context.Context, volumeID string, attachOptions map[string]string) (string, error) {
 	return "/dev/fake/" + volumeID, nil
 }
 
-func (d *driver) Detach(volumeID string, options map[string]string) error {
+func (d *driver) Detach(ctx context.Context, volumeID string, options map[string]string) error {
 	return nil
 }
 

--- a/volume/drivers/fuse/volume_driver.go
+++ b/volume/drivers/fuse/volume_driver.go
@@ -112,7 +112,7 @@ func (v *volumeDriver) Delete(volumeID string) error {
 	return v.DeleteVol(volumeID)
 }
 
-func (v *volumeDriver) MountedAt(mountpath string) string {
+func (v *volumeDriver) MountedAt(ctx context.Context, mountpath string) string {
 	return ""
 }
 

--- a/volume/drivers/mock/driver.mock.go
+++ b/volume/drivers/mock/driver.mock.go
@@ -36,18 +36,18 @@ func (m *MockVolumeDriver) EXPECT() *MockVolumeDriverMockRecorder {
 }
 
 // Attach mocks base method.
-func (m *MockVolumeDriver) Attach(arg0 string, arg1 map[string]string) (string, error) {
+func (m *MockVolumeDriver) Attach(arg0 context.Context, arg1 string, arg2 map[string]string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Attach", arg0, arg1)
+	ret := m.ctrl.Call(m, "Attach", arg0, arg1, arg2)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Attach indicates an expected call of Attach.
-func (mr *MockVolumeDriverMockRecorder) Attach(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockVolumeDriverMockRecorder) Attach(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Attach", reflect.TypeOf((*MockVolumeDriver)(nil).Attach), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Attach", reflect.TypeOf((*MockVolumeDriver)(nil).Attach), arg0, arg1, arg2)
 }
 
 // CapacityUsage mocks base method.
@@ -475,17 +475,17 @@ func (mr *MockVolumeDriverMockRecorder) Delete(arg0 interface{}) *gomock.Call {
 }
 
 // Detach mocks base method.
-func (m *MockVolumeDriver) Detach(arg0 string, arg1 map[string]string) error {
+func (m *MockVolumeDriver) Detach(arg0 context.Context, arg1 string, arg2 map[string]string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Detach", arg0, arg1)
+	ret := m.ctrl.Call(m, "Detach", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Detach indicates an expected call of Detach.
-func (mr *MockVolumeDriverMockRecorder) Detach(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockVolumeDriverMockRecorder) Detach(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Detach", reflect.TypeOf((*MockVolumeDriver)(nil).Detach), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Detach", reflect.TypeOf((*MockVolumeDriver)(nil).Detach), arg0, arg1, arg2)
 }
 
 // Enumerate mocks base method.
@@ -652,17 +652,17 @@ func (mr *MockVolumeDriverMockRecorder) Mount(arg0, arg1, arg2, arg3 interface{}
 }
 
 // MountedAt mocks base method.
-func (m *MockVolumeDriver) MountedAt(arg0 string) string {
+func (m *MockVolumeDriver) MountedAt(arg0 context.Context, arg1 string) string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MountedAt", arg0)
+	ret := m.ctrl.Call(m, "MountedAt", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	return ret0
 }
 
 // MountedAt indicates an expected call of MountedAt.
-func (mr *MockVolumeDriverMockRecorder) MountedAt(arg0 interface{}) *gomock.Call {
+func (mr *MockVolumeDriverMockRecorder) MountedAt(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MountedAt", reflect.TypeOf((*MockVolumeDriver)(nil).MountedAt), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MountedAt", reflect.TypeOf((*MockVolumeDriver)(nil).MountedAt), arg0, arg1)
 }
 
 // Name mocks base method.

--- a/volume/drivers/nfs/nfs.go
+++ b/volume/drivers/nfs/nfs.go
@@ -487,7 +487,7 @@ func (d *driver) Delete(volumeID string) (e error) {
 	return nil
 }
 
-func (d *driver) MountedAt(mountpath string) string {
+func (d *driver) MountedAt(ctx context.Context, mountpath string) string {
 	return ""
 }
 
@@ -693,7 +693,7 @@ func (d *driver) SnapshotGroup(groupID string, labels map[string]string, volumeI
 	return nil, volume.ErrNotSupported
 }
 
-func (d *driver) Attach(volumeID string, attachOptions map[string]string) (string, error) {
+func (d *driver) Attach(ctx context.Context, volumeID string, attachOptions map[string]string) (string, error) {
 
 	nfsPath, err := d.getNFSPathById(volumeID)
 	if err != nil {
@@ -732,7 +732,7 @@ func (d *driver) Attach(volumeID string, attachOptions map[string]string) (strin
 	return dev.Path(), nil
 }
 
-func (d *driver) Detach(volumeID string, options map[string]string) error {
+func (d *driver) Detach(ctx context.Context, volumeID string, options map[string]string) error {
 
 	// Get volume info
 	v, err := util.VolumeFromName(d, volumeID)

--- a/volume/drivers/test/driver.go
+++ b/volume/drivers/test/driver.go
@@ -204,13 +204,13 @@ func attach(t *testing.T, ctx *Context) {
 	fmt.Println("attach")
 	err := waitReady(t, ctx)
 	require.NoError(t, err, "Volume status is not up")
-	p, err := ctx.Attach(ctx.volID, ctx.AttachOptions)
+	p, err := ctx.Attach(context.TODO(), ctx.volID, ctx.AttachOptions)
 	if err != nil {
 		require.Equal(t, err, volume.ErrNotSupported, "Error on attach %v", err)
 	}
 	ctx.devicePath = p
 
-	p, err = ctx.Attach(ctx.volID, ctx.AttachOptions)
+	p, err = ctx.Attach(context.TODO(), ctx.volID, ctx.AttachOptions)
 	if err == nil {
 		require.Equal(t, p, ctx.devicePath, "Multiple calls to attach if not errored should return the same path")
 	}
@@ -218,7 +218,7 @@ func attach(t *testing.T, ctx *Context) {
 
 func detach(t *testing.T, ctx *Context) {
 	fmt.Println("detach")
-	err := ctx.Detach(ctx.volID, nil)
+	err := ctx.Detach(context.TODO(), ctx.volID, nil)
 	if err != nil {
 		require.Equal(t, ctx.devicePath, "", "Error on detach %s: %v", ctx.devicePath, err)
 	}
@@ -291,7 +291,7 @@ func io(t *testing.T, ctx *Context) {
 }
 
 func detachBad(t *testing.T, ctx *Context) {
-	err := ctx.Detach(ctx.volID, nil)
+	err := ctx.Detach(context.TODO(), ctx.volID, nil)
 	require.True(t, (err == nil || err == volume.ErrNotSupported),
 		"Detach on mounted device should fail")
 }

--- a/volume/drivers/vfs/vfs.go
+++ b/volume/drivers/vfs/vfs.go
@@ -104,7 +104,7 @@ func (d *driver) Delete(volumeID string) error {
 
 }
 
-func (d *driver) MountedAt(mountpath string) string {
+func (d *driver) MountedAt(ctx context.Context, mountpath string) string {
 	return ""
 }
 

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -255,7 +255,7 @@ type ProtoDriver interface {
 	// Errors ErrEnoEnt, ErrVolDetached may be returned.
 	Mount(ctx context.Context, volumeID string, mountPath string, options map[string]string) error
 	// MountedAt return volume mounted at specified mountpath.
-	MountedAt(mountPath string) string
+	MountedAt(ctx context.Context, mountPath string) string
 	// Unmount volume at specified path
 	// Errors ErrEnoEnt, ErrVolDetached may be returned.
 	Unmount(ctx context.Context, volumeID string, mountPath string, options map[string]string) error
@@ -297,10 +297,10 @@ type BlockDriver interface {
 	// Attach map device to the host.
 	// On success the devicePath specifies location where the device is exported
 	// Errors ErrEnoEnt, ErrVolAttached may be returned.
-	Attach(volumeID string, attachOptions map[string]string) (string, error)
+	Attach(ctx context.Context, volumeID string, attachOptions map[string]string) (string, error)
 	// Detach device from the host.
 	// Errors ErrEnoEnt, ErrVolDetached may be returned.
-	Detach(volumeID string, options map[string]string) error
+	Detach(ctx context.Context, volumeID string, options map[string]string) error
 }
 
 // CredsDriver provides methods to handle credentials

--- a/volume/volume_not_supported.go
+++ b/volume/volume_not_supported.go
@@ -1,6 +1,8 @@
 package volume
 
 import (
+	"context"
+
 	"github.com/libopenstorage/openstorage/api"
 )
 
@@ -38,11 +40,11 @@ var (
 
 type blockNotSupported struct{}
 
-func (b *blockNotSupported) Attach(volumeID string, attachOptions map[string]string) (string, error) {
+func (b *blockNotSupported) Attach(ctx context.Context, volumeID string, attachOptions map[string]string) (string, error) {
 	return "", ErrNotSupported
 }
 
-func (b *blockNotSupported) Detach(volumeID string, options map[string]string) error {
+func (b *blockNotSupported) Detach(ctx context.Context, volumeID string, options map[string]string) error {
 	return ErrNotSupported
 }
 


### PR DESCRIPTION
Cherry pick of #1930 on release-9.2.

#1930: Add correlation context to Attach/Detach/MountedAt

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.