### PR TITLE
Automated cherry pick of #1933: Remove error when we can't get correlation context

### DIFF
--- a/pkg/correlation/hook.go
+++ b/pkg/correlation/hook.go
@@ -17,7 +17,6 @@ package correlation
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -79,7 +78,7 @@ func (lh *LogHook) Fire(entry *logrus.Entry) error {
 
 		correlationContext, ok := ctxKeyValue.(*RequestContext)
 		if !ok {
-			return fmt.Errorf("failed to get request context for correlation logging hook")
+			return nil
 		}
 
 		entry.Data[LogFieldID] = correlationContext.ID


### PR DESCRIPTION
Cherry pick of #1933 on release-9.2.

#1933: Remove error when we can't get correlation context

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.