### PR TITLE
PWX-21840: add an error return to NodeRemoveDone()

### DIFF
--- a/api/client/cluster/client.go
+++ b/api/client/cluster/client.go
@@ -279,7 +279,8 @@ func (c *clusterClient) Remove(nodes []api.Node, forceRemove bool) error {
 	return nil
 }
 
-func (c *clusterClient) NodeRemoveDone(nodeID string, result error) {
+func (c *clusterClient) NodeRemoveDone(nodeID string, result error) error {
+	return nil
 }
 
 func (c *clusterClient) Shutdown() error {

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -298,7 +298,7 @@ type ClusterRemove interface {
 	// Remove node(s) from the cluster permanently.
 	Remove(nodes []api.Node, forceRemove bool) error
 	// NodeRemoveDone notify cluster manager NodeRemove is done.
-	NodeRemoveDone(nodeID string, result error)
+	NodeRemoveDone(nodeID string, result error) error
 }
 
 type ClusterAlerts interface {

--- a/cluster/cluster_not_supported.go
+++ b/cluster/cluster_not_supported.go
@@ -179,8 +179,8 @@ func (m *NullClusterRemove) Remove(arg0 []api.Node, arg1 bool) error {
 }
 
 // NodeRemoveDone
-func (m *NullClusterRemove) NodeRemoveDone(arg0 string, arg1 error) {
-	return
+func (m *NullClusterRemove) NodeRemoveDone(arg0 string, arg1 error) error {
+	return ErrNotImplemented
 }
 
 // NullClusterStatus implementations

--- a/cluster/mock/cluster.mock.go
+++ b/cluster/mock/cluster.mock.go
@@ -513,9 +513,11 @@ func (mr *MockClusterMockRecorder) InspectDomain(arg0 interface{}) *gomock.Call 
 }
 
 // NodeRemoveDone mocks base method.
-func (m *MockCluster) NodeRemoveDone(arg0 string, arg1 error) {
+func (m *MockCluster) NodeRemoveDone(arg0 string, arg1 error) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "NodeRemoveDone", arg0, arg1)
+	ret := m.ctrl.Call(m, "NodeRemoveDone", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // NodeRemoveDone indicates an expected call of NodeRemoveDone.


### PR DESCRIPTION
**What this PR does / why we need it**:
Added a return parameter to be able to indicate a failure
in NodeRemoveDone function.

Signed-off-by: Neelesh Thakur <neelesh.thakur@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->



**Which issue(s) this PR fixes** (optional)
PWX-21840

**Special notes for your reviewer**:

