### PR TITLE
PWX-21966: Increase retry interval and timeout

### DIFF
--- a/api/server/sdk/volume_ops.go
+++ b/api/server/sdk/volume_ops.go
@@ -40,14 +40,14 @@ func (s *VolumeServer) waitForVolumeReady(ctx context.Context, id string) (*api.
 
 	minTimeout := 1 * time.Second
 	maxTimeout := 60 * time.Minute
-	defaultTimeout := 10 * time.Minute
+	defaultTimeout := 5 * time.Minute
 
 	logrus.Infof("Waiting for volume %s to become available", id)
 
 	e := util.WaitForWithContext(
 		ctx,
 		minTimeout, maxTimeout, defaultTimeout, // timeouts
-		250*time.Millisecond, // period
+		5*time.Second, // period
 		func() (bool, error) {
 			var err error
 			// Get the latest status from the volume


### PR DESCRIPTION
  250 ms of retry interval is too frequent for k8s api calls. This is
      resulting in us hitting the k8s rate limiting and a bunch of
      issues following that. This patch decreases the frequency and also
      the timeout.


**What this PR does / why we need it**:
  250 ms of retry interval is too frequent for k8s api calls. This is
      resulting in us hitting the k8s rate limiting and a bunch of
      issues following that. This patch decreases the frequency and also
      the timeout.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-21966

**Special notes for your reviewer**:



