### PR TITLE
correlation: fix log level for correlation log hook

### DIFF
--- a/pkg/correlation/hook.go
+++ b/pkg/correlation/hook.go
@@ -54,7 +54,7 @@ const (
 // Levels describes which levels this logrus hook
 // should run with.
 func (lh *LogHook) Levels() []logrus.Level {
-	return []logrus.Level{logrus.InfoLevel}
+	return logrus.AllLevels
 }
 
 // Fire is used to add correlation context info in each log line


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>
**What this PR does / why we need it**:
Fixes correlation log hook to fire for all log levels

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

