### PR TITLE
Automated cherry pick of #1966: correlation: fix log level correlation log hook

### DIFF
--- a/pkg/correlation/hook.go
+++ b/pkg/correlation/hook.go
@@ -54,7 +54,7 @@ const (
 // Levels describes which levels this logrus hook
 // should run with.
 func (lh *LogHook) Levels() []logrus.Level {
-	return []logrus.Level{logrus.InfoLevel}
+	return logrus.AllLevels
 }
 
 // Fire is used to add correlation context info in each log line


### PR DESCRIPTION
Cherry pick of #1966 on release-9.2.

#1966: correlation: fix log level correlation log hook

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.