### PR TITLE
pass remote cred uuid while calling refresh cluster pair

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -167,6 +167,8 @@ const (
 	OptCredProxy = "CredProxy"
 	// OptCredIAMPolicy if "true", indicates IAM creds to be used
 	OptCredIAMPolicy = "CredIAMPolicy"
+	// OptRemoteCredUUID is the UUID of the remote cluster credential
+	OptRemoteCredUUID = "RemoteCredUUID"
 	// OptCloudBackupID is the backID in the cloud
 	OptCloudBackupID = "CloudBackID"
 	// OptCloudBackupIgnoreCreds ignores credentials for incr backups

--- a/cluster/manager/pair.go
+++ b/cluster/manager/pair.go
@@ -143,6 +143,7 @@ func (c *ClusterManager) RefreshPair(
 	processRequest := &api.ClusterPairProcessRequest{
 		SourceClusterId:    c.Uuid(),
 		RemoteClusterToken: pair.Token,
+		CredentialId:       pair.Options[api.OptRemoteCredUUID],
 	}
 
 	endpoints := pair.CurrentEndpoints


### PR DESCRIPTION

**What this PR does / why we need it**:
Add option to pass remote cluster credential details for RefreshPair api

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

