### PR TITLE
NEWSTACK-5: Add a flag for FA direct access volume in node server

### DIFF
--- a/csi/node.go
+++ b/csi/node.go
@@ -135,6 +135,9 @@ func (s *OsdCsiServer) NodePublishVolume(
 		if mountFlags != "" {
 			driverOpts[api.SpecCSIMountOptions] = mountFlags
 		}
+		if req.GetVolumeCapability().GetMount().GetFsType() != "" {
+			driverOpts[api.SpecFilesystem] = req.GetVolumeCapability().GetMount().GetFsType()
+		}
 	}
 
 	// can use either spec.Ephemeral or VolumeContext label


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
We need to pass in a CSI file system flag to the filter chain so NSM filter can use it for FA directAccess volume
**Which issue(s) this PR fixes** (optional)
Closes #
NEWSTACK-5
**Special notes for your reviewer**:

