### PR TITLE
Autofstrim's default value in volume spec

### DIFF
--- a/api/spec/spec_handler.go
+++ b/api/spec/spec_handler.go
@@ -210,7 +210,6 @@ func (d *specHandler) UpdateSpecFromOpts(opts map[string]string, spec *api.Volum
 			VolumeLabels: make(map[string]string),
 		}
 	}
-
 	for k, v := range opts {
 		switch k {
 		case api.SpecNodes:
@@ -385,6 +384,10 @@ func (d *specHandler) UpdateSpecFromOpts(opts map[string]string, spec *api.Volum
 				return nil, nil, nil, err
 			} else {
 				spec.Nodiscard = nodiscard
+				// autofstrim to follow nodiscard when not explicitly specified
+				if _, exists := opts[api.SpecAutoFstrim]; !exists {
+					spec.AutoFstrim = nodiscard
+				}
 			}
 		case api.Token:
 			// skip, if not it would be added to the labels
@@ -767,6 +770,11 @@ func (d *specHandler) SpecOptsFromString(
 	}
 	if ok, nodiscard := d.getVal(nodiscardRegex, str); ok {
 		opts[api.SpecNodiscard] = nodiscard
+		// if nodiscard was specified and autofstrim was not specified
+		// autfstrim will follow nodoscard
+		if ok, _ := d.getVal(AutoFstrimRegex, str); !ok {
+			opts[api.SpecAutoFstrim] = nodiscard
+		}
 	}
 	if ok, storagepolicy := d.getVal(storagePolicyRegex, str); ok {
 		opts[api.StoragePolicy] = storagepolicy

--- a/api/spec/spec_handler_test.go
+++ b/api/spec/spec_handler_test.go
@@ -503,6 +503,12 @@ func TestOptAutoFstrim(t *testing.T) {
 
 	spec = testSpecFromString(t, api.SpecAutoFstrim, "false")
 	require.False(t, spec.AutoFstrim, "Failed to parse auto_fstrim option into spec")
+	// with Nodiscard, when autoFstrim is not specified
+	spec = testSpecFromString(t, api.SpecNodiscard, "true")
+	require.Equal(t, spec.AutoFstrim, true, "AutoFstrim value does not match nodiscard")
+
+	spec = testSpecFromString(t, api.SpecNodiscard, "false")
+	require.Equal(t, spec.AutoFstrim, false, "AutoFstrim value does not match Nodiscard")
 }
 
 func TestOptReadahead(t *testing.T) {


### PR DESCRIPTION
When explicitly not specified, autofstrim to inherit its value from
nodiscard filed on volume spec.

Signed-off-by: veda <veda@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

