### PR TITLE
PWX-23061: Add new funcs to allow for dumping profiles to specific fi…

### DIFF
--- a/pkg/dbg/profile_dump.go
+++ b/pkg/dbg/profile_dump.go
@@ -12,7 +12,8 @@ import (
 )
 
 const (
-	path     = "/var/cores/"
+	// Path defailt location for debug/profile output
+	Path     = "/var/cores/"
 	fnameFmt = "2006-01-02T15:04:05.999999-0700MST"
 )
 
@@ -30,6 +31,26 @@ func GetHostNamePrefix() string {
 	return hname
 }
 
+// GoProfileDump output goroutines to file.
+func GoProfileDump(fname string) error {
+	trace := make([]byte, 5120*1024)
+	len := runtime.Stack(trace, true)
+	return ioutil.WriteFile(fname, trace[:len], 0644)
+}
+
+// HeapDump output heap to filename.
+func HeapDump(fname string) {
+	f, err := os.Create(fname)
+	if err != nil {
+		logrus.Errorf("could not create memory profile: %v", err)
+		return
+	}
+	defer f.Close()
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		logrus.Errorf("could not write memory profile: %v", err)
+	}
+}
+
 // DumpGoMemoryTrace output memory profile to logs.
 func DumpGoMemoryTrace() {
 	m := &runtime.MemStats{}
@@ -41,19 +62,10 @@ func DumpGoMemoryTrace() {
 
 // DumpGoProfile output goroutines to file.
 func DumpGoProfile() error {
-	trace := make([]byte, 5120*1024)
-	len := runtime.Stack(trace, true)
-	return ioutil.WriteFile(path+GetHostNamePrefix()+"-"+GetTimeStamp()+".stack", trace[:len], 0644)
+	return GoProfileDump(Path + GetHostNamePrefix() + "-" + GetTimeStamp() + ".stack")
 }
 
+// DumpHeap output heap to file.
 func DumpHeap() {
-	f, err := os.Create(path + GetHostNamePrefix() + "-" + GetTimeStamp() + ".heap")
-	if err != nil {
-		logrus.Errorf("could not create memory profile: %v", err)
-		return
-	}
-	defer f.Close()
-	if err := pprof.WriteHeapProfile(f); err != nil {
-		logrus.Errorf("could not write memory profile: %v", err)
-	}
+	HeapDump(Path + GetHostNamePrefix() + "-" + GetTimeStamp() + ".heap")
 }


### PR DESCRIPTION
…lenames.

Signed-off-by: Jose Rivera <jose@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
We had an issue where the stats profile dumps where being cleaned up and lost.  These dumps help with debugging issues.   This change is to allow stats thread in PX to use its own filename when producing profile dumps.    Doing this will allow us to provide separate cleanup method for these files and we can retain them separately and help prevent losing them during cleanup.

**Which issue(s) this PR fixes** (optional)
PWX-23061

**Special notes for your reviewer**:
This is part of the fix and another PR will be submitted for the portworx/porx side.
