### PR TITLE
PWX-23088: expose gossip intervals

### DIFF
--- a/api/client/cluster/client.go
+++ b/api/client/cluster/client.go
@@ -318,6 +318,11 @@ func (c *clusterClient) GetGossipState() *cluster.ClusterState {
 	return status
 }
 
+func (c *clusterClient) GetGossipIntervals() types.GossipIntervals {
+	// not implemented
+	return types.GossipIntervals{}
+}
+
 func (c *clusterClient) EnumerateAlerts(ts, te time.Time, resource api.ResourceType) (*api.Alerts, error) {
 	a := api.Alerts{}
 	request := c.c.Get().Resource(clusterPath + "/alerts/" + strconv.FormatInt(int64(resource), 10))

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -386,6 +386,9 @@ type Cluster interface {
 	// cluster manager of an update on cluster domains
 	ClusterNotifyClusterDomainsUpdate(types.ClusterDomainsActiveMap) error
 
+	// GetGossipIntervals returns the configured values for the gossip intervals
+	GetGossipIntervals() types.GossipIntervals
+
 	ClusterRemove
 	ClusterData
 	ClusterStatus

--- a/cluster/cluster_not_supported.go
+++ b/cluster/cluster_not_supported.go
@@ -171,6 +171,11 @@ func (m *NullClusterData) GetGossipState() *ClusterState {
 	return nil
 }
 
+// GetGossipIntervals
+func (c *NullClusterData) GetGossipIntervals() types.GossipIntervals {
+	return types.GossipIntervals{}
+}
+
 // NullClusterRemove implementations
 
 // Remove

--- a/cluster/mock/cluster.mock.go
+++ b/cluster/mock/cluster.mock.go
@@ -363,6 +363,20 @@ func (mr *MockClusterMockRecorder) GetData() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetData", reflect.TypeOf((*MockCluster)(nil).GetData))
 }
 
+// GetGossipIntervals mocks base method.
+func (m *MockCluster) GetGossipIntervals() types.GossipIntervals {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGossipIntervals")
+	ret0, _ := ret[0].(types.GossipIntervals)
+	return ret0
+}
+
+// GetGossipIntervals indicates an expected call of GetGossipIntervals.
+func (mr *MockClusterMockRecorder) GetGossipIntervals() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGossipIntervals", reflect.TypeOf((*MockCluster)(nil).GetGossipIntervals))
+}
+
 // GetGossipState mocks base method.
 func (m *MockCluster) GetGossipState() *cluster.ClusterState {
 	m.ctrl.T.Helper()

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/imdario/mergo v0.3.10 // indirect
 	github.com/johannesboyne/gofakes3 v0.0.0-20210819161434-5c8dfcfe5310
 	github.com/kubernetes-csi/csi-test v2.2.0+incompatible
-	github.com/libopenstorage/gossip v0.0.0-20200808224301-d5287c7c8b24
+	github.com/libopenstorage/gossip v0.0.0-20220309192431-44c895e0923e
 	github.com/libopenstorage/secrets v0.0.0-20200207034622-cdb443738c67
 	github.com/libopenstorage/systemutils v0.0.0-20160208220149-44ac83be3ce1
 	github.com/mattn/go-colorable v0.1.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -494,8 +494,8 @@ github.com/libopenstorage/autopilot-api v0.6.1-0.20210128210103-5fbb67948648/go.
 github.com/libopenstorage/autopilot-api v1.3.0/go.mod h1:6JLrPbR3ZJQFbUY/+QJMl/aF00YdIrLf8/GWAplgvJs=
 github.com/libopenstorage/external-storage v0.20.4-openstorage-rc3/go.mod h1:nffpoeodwwp+wwngmBGbLBCd7TZ9GxHLtxKoaLRW6K4=
 github.com/libopenstorage/gossip v0.0.0-20190507031959-c26073a01952/go.mod h1:TjXt2Iz2bTkpfc4Q6xN0ttiNipTVwEEYoZSMZHlfPek=
-github.com/libopenstorage/gossip v0.0.0-20200808224301-d5287c7c8b24 h1:9PX7cJJDrFo0IbmWI6Np3wNDAwkgUHKg1dXo4VGaLus=
-github.com/libopenstorage/gossip v0.0.0-20200808224301-d5287c7c8b24/go.mod h1:TjXt2Iz2bTkpfc4Q6xN0ttiNipTVwEEYoZSMZHlfPek=
+github.com/libopenstorage/gossip v0.0.0-20220309192431-44c895e0923e h1:4l9N2Sw8VGGUqe50yC2BnTFMRJuHJGpIGZcCUZ2S6gg=
+github.com/libopenstorage/gossip v0.0.0-20220309192431-44c895e0923e/go.mod h1:TjXt2Iz2bTkpfc4Q6xN0ttiNipTVwEEYoZSMZHlfPek=
 github.com/libopenstorage/openstorage v1.0.0/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=
 github.com/libopenstorage/openstorage v8.0.0+incompatible/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=
 github.com/libopenstorage/openstorage v8.0.1-0.20190926212733-daaed777713e+incompatible/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=

--- a/vendor/github.com/libopenstorage/gossip/.travis.yml
+++ b/vendor/github.com/libopenstorage/gossip/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: go
 go:
   - 1.10.4

--- a/vendor/github.com/libopenstorage/gossip/types/types.go
+++ b/vendor/github.com/libopenstorage/gossip/types/types.go
@@ -46,13 +46,14 @@ type ClusterDomainsQuorumMembersMap map[string]int
 // Constant Definitions
 
 const (
-	DEFAULT_GOSSIP_INTERVAL    time.Duration = 2 * time.Second
-	DEFAULT_PUSH_PULL_INTERVAL time.Duration = 2 * time.Second
-	DEFAULT_PROBE_INTERVAL     time.Duration = 5 * time.Second
-	DEFAULT_PROBE_TIMEOUT      time.Duration = 200 * time.Millisecond
-	DEFAULT_QUORUM_TIMEOUT     time.Duration = 1 * time.Minute
-	DEFAULT_GOSSIP_VERSION     string        = "v1"
-	GOSSIP_VERSION_2           string        = "v2"
+	DEFAULT_GOSSIP_INTERVAL      time.Duration = 2 * time.Second
+	DEFAULT_PUSH_PULL_INTERVAL   time.Duration = 2 * time.Second
+	DEFAULT_PROBE_INTERVAL       time.Duration = 5 * time.Second
+	DEFAULT_PROBE_TIMEOUT        time.Duration = 200 * time.Millisecond
+	DEFAULT_QUORUM_TIMEOUT       time.Duration = 1 * time.Minute
+	DEFAULT_SUSPICION_MULTIPLIER int           = 5
+	DEFAULT_GOSSIP_VERSION       string        = "v1"
+	GOSSIP_VERSION_2             string        = "v2"
 )
 
 const (
@@ -164,6 +165,9 @@ type GossipIntervals struct {
 	// QuorumTimeout is the timeout for which a node will stay in the SUSPECT_NOT_IN_QUORUM
 	// and then transition to NOT_IN_QUORUM (Not UP) if quorum is not satisfied
 	QuorumTimeout time.Duration
+	// SuspicionMult is the multiplier for determining the time an
+	// inaccessible node is considered suspect before declaring it dead.
+	SuspicionMult int
 }
 
 // GossipNodeConfiguration is the peer node configuration with which gossip on this

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -296,7 +296,7 @@ github.com/json-iterator/go
 ## explicit
 github.com/kubernetes-csi/csi-test/pkg/sanity
 github.com/kubernetes-csi/csi-test/utils
-# github.com/libopenstorage/gossip v0.0.0-20200808224301-d5287c7c8b24
+# github.com/libopenstorage/gossip v0.0.0-20220309192431-44c895e0923e
 ## explicit
 github.com/libopenstorage/gossip
 github.com/libopenstorage/gossip/pkg/probation


### PR DESCRIPTION
**What this PR does / why we need it**:
Added a method to allow consumers to retrieve the configured values
of the gossip settings.

Signed-off-by: Neelesh Thakur <neelesh.thakur@purestorage.com>
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**Which issue(s) this PR fixes** (optional)
PWX-23088

**Special notes for your reviewer**:
will remove the replace directive once the gossip PR is merged
