### PR TITLE
Use pushed quay.io image in docker-proto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,8 +173,7 @@ $(OSDSANITY)-clean:
 docker-build-proto:
 	docker build -t quay.io/openstorage/osd-proto --network=host -f Dockerfile.proto .
 
-# the docker-build-proto should be there temporarily for the go mod upgrade
-docker-proto: docker-build-proto $(GOPATH)/bin/protoc-gen-go
+docker-proto:  $(GOPATH)/bin/protoc-gen-go
 	docker run \
 		--privileged --rm \
 		-v $(shell pwd):/go/src/github.com/libopenstorage/openstorage \


### PR DESCRIPTION
Signed-off-by: dahuang <dahuang@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
We were previously building the osd-proto image on the fly. This might create inconsistency between different builds. The new image is push to quay.io and this PR removes the building step.

**Which issue(s) this PR fixes** (optional)
Closes # none

**Special notes for your reviewer**:
Built locally to test the changes. 
