### PR TITLE
PWX-23028 & PWX-23107: Changes Pure DA checks for RWX block

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -379,12 +379,56 @@ func validateCreateVolumeCapabilities(caps []*csi.VolumeCapability) error {
 		if cap.GetBlock() != nil {
 			block = true
 		}
+	}
 
-		if block && shared {
-			return status.Errorf(
-				codes.InvalidArgument,
-				"Shared raw block volumes are not supported")
+	if block && shared {
+		return status.Errorf(
+			codes.InvalidArgument,
+			"Shared raw block volumes are not supported")
+	}
+
+	return nil
+}
+
+func validateCreateVolumeCapabilitiesPure(caps []*csi.VolumeCapability, proxySpec *api.ProxySpec) error {
+	if len(caps) == 0 {
+		return status.Error(codes.InvalidArgument, "Volume capabilities must be provided")
+	}
+
+	var shared bool
+	var block bool
+	var mount bool
+	for _, cap := range caps {
+		mode := cap.GetAccessMode().GetMode()
+		if mode == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER ||
+			mode == csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER ||
+			mode == csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY {
+			shared = true
 		}
+
+		if cap.GetBlock() != nil {
+			block = true
+		}
+
+		if cap.GetMount() != nil {
+			mount = true
+		}
+	}
+
+	// Check for FA DA volumes: all allowed except filesystem RWX
+	if proxySpec.ProxyProtocol == api.ProxyProtocol_PROXY_PROTOCOL_PURE_BLOCK && shared && mount {
+		return status.Errorf(
+			codes.InvalidArgument,
+			"FlashArray Direct Access shared filesystems are not supported",
+		)
+	}
+
+	// Check for FB DA volumes: all allowed except raw block
+	if proxySpec.ProxyProtocol == api.ProxyProtocol_PROXY_PROTOCOL_PURE_FILE && block {
+		return status.Errorf(
+			codes.InvalidArgument,
+			"FlashBlade Direct Access volumes do not support raw block",
+		)
 	}
 
 	return nil
@@ -403,9 +447,6 @@ func (s *OsdCsiServer) CreateVolume(
 	if len(req.GetName()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Name must be provided")
 	}
-	if err := validateCreateVolumeCapabilities(req.GetVolumeCapabilities()); err != nil {
-		return nil, err
-	}
 
 	// Get parameters
 	spec, locator, source, err := s.specHandler.SpecFromOpts(req.GetParameters())
@@ -413,6 +454,18 @@ func (s *OsdCsiServer) CreateVolume(
 		e := fmt.Sprintf("Unable to get parameters: %s\n", err.Error())
 		clogger.WithContext(ctx).Errorln(e)
 		return nil, status.Error(codes.InvalidArgument, e)
+	}
+
+	if spec.IsPureVolume() {
+		err = validateCreateVolumeCapabilitiesPure(req.GetVolumeCapabilities(), spec.GetProxySpec())
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		err = validateCreateVolumeCapabilities(req.GetVolumeCapabilities())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Get PVC Metadata and add to locator.VolumeLabels


### PR DESCRIPTION
Signed-off-by: Adam Krpan <akrpan@purestorage.com>

**What this PR does / why we need it**:
Currently we cannot create Pure FA RWX volumes (which should be supported) due to this check. This will check if the proxy spec is a pure type: if it is, it will go through a different set of checks for which volumes are or are not allowed.

**Which issue(s) this PR fixes** (optional)
PWX-23028 & PWX-23107

**Special notes for your reviewer**:
This has now been tested with all the various permutations of RWO/RWX, PX or Pure DA volumes, and block/file access modes. All performed as expected (e.g. PX raw RWX is blocked, FA filesystem RWX is blocked, everything else is allowed)
