### PR TITLE
Update on-pr action to remove warning about XL size

### DIFF
--- a/.github/workflows/on-pr.yml
+++ b/.github/workflows/on-pr.yml
@@ -24,7 +24,3 @@ jobs:
           m_max_size: '500'
           l_max_size: '1000'
           fail_if_xl: 'false'
-          message_if_xl: >
-            'This PR exceeds the recommended size of 1000 lines.
-            Please make sure you are NOT addressing multiple issues with one PR.
-            Note this PR might be rejected due to its size.’


### PR DESCRIPTION
We don't need this message, sometimes vendor or protobuf update PRs are large.