### PR TITLE
Allow cloudbackup restore sts with empty volID

### DIFF
--- a/api/server/sdk/cloud_backup.go
+++ b/api/server/sdk/cloud_backup.go
@@ -406,7 +406,8 @@ func (s *CloudBackupServer) Status(
 		if sts.OpType == api.CloudRestoreOp &&
 			(sts.Status == api.CloudBackupStatusFailed ||
 				sts.Status == api.CloudBackupStatusAborted ||
-				sts.Status == api.CloudBackupStatusStopped) {
+				sts.Status == api.CloudBackupStatusStopped ||
+				sts.SrcVolumeID == "") {
 			continue
 		}
 		if err := checkAccessFromDriverForVolumeIds(ctx, s.driver(ctx), []string{sts.SrcVolumeID}, api.Ownership_Read); err != nil {


### PR DESCRIPTION
Enforce auth checks when retoreVolumeID is non-empty.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

