### PR TITLE
Fix error mask in pkg/mount Mount call

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -537,7 +537,7 @@ func (m *Mounter) Mount(
 			}
 		}
 
-		return fmt.Errorf("%s", err)
+		return err
 	}
 
 	info.Mountpoint = append(info.Mountpoint, &PathInfo{Path: path})


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What this PR does / why we need it**:
Returns the Mount error directly instead of masking it as a new error.

Callers may depend on this specific error type.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

