### PR TITLE
IPv6 support - Use net.JoinHostPort to concat ip & port. Add '[]' to …

### DIFF
--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -429,15 +429,6 @@ func (c *ClusterManager) getCurrentState() *api.Node {
 	return nodeCopy
 }
 
-// Return ip:port string
-func getPeerAddress(ip string, port string) string {
-	if strings.Contains(ip, ":") {
-		// IPv6 addresses and '[]'
-		ip = fmt.Sprintf("[%s]", ip)
-	}
-	return fmt.Sprintf("%s:%s", ip, port)
-}
-
 func (c *ClusterManager) getNonDecommisionedPeers(
 	db cluster.ClusterInfo,
 ) map[types.NodeId]types.NodeUpdate {
@@ -447,7 +438,7 @@ func (c *ClusterManager) getNonDecommisionedPeers(
 			continue
 		}
 		peers[types.NodeId(nodeEntry.Id)] = types.NodeUpdate{
-			Addr:          getPeerAddress(nodeEntry.DataIp, c.gossipPort),
+			Addr:          net.JoinHostPort(nodeEntry.DataIp, c.gossipPort),
 			QuorumMember:  !nodeEntry.NonQuorumMember,
 			ClusterDomain: nodeEntry.ClusterDomain,
 		}
@@ -831,7 +822,7 @@ func (c *ClusterManager) startHeartBeat(
 			gossipPort = c.gossipPort
 		}
 
-		nodeIp := getPeerAddress(nodeEntry.DataIp, gossipPort)
+		nodeIp := net.JoinHostPort(nodeEntry.DataIp, gossipPort)
 		gossipConfig.Nodes[types.NodeId(nodeId)] = types.GossipNodeConfiguration{
 			KnownUrl:      nodeIp,
 			ClusterDomain: nodeEntry.ClusterDomain,
@@ -1492,7 +1483,7 @@ func (c *ClusterManager) StartWithConfiguration(
 		SuspicionMult:    types.DEFAULT_SUSPICION_MULTIPLIER,
 	}
 
-	nodeIp := getPeerAddress(c.selfNode.DataIp, c.gossipPort)
+	nodeIp := net.JoinHostPort(c.selfNode.DataIp, c.gossipPort)
 	logrus.Infoln("Init gossip: ", nodeIp)
 
 	c.gossip = gossip.New(

--- a/csi/controller.go
+++ b/csi/controller.go
@@ -379,12 +379,56 @@ func validateCreateVolumeCapabilities(caps []*csi.VolumeCapability) error {
 		if cap.GetBlock() != nil {
 			block = true
 		}
+	}
 
-		if block && shared {
-			return status.Errorf(
-				codes.InvalidArgument,
-				"Shared raw block volumes are not supported")
+	if block && shared {
+		return status.Errorf(
+			codes.InvalidArgument,
+			"Shared raw block volumes are not supported")
+	}
+
+	return nil
+}
+
+func validateCreateVolumeCapabilitiesPure(caps []*csi.VolumeCapability, proxySpec *api.ProxySpec) error {
+	if len(caps) == 0 {
+		return status.Error(codes.InvalidArgument, "Volume capabilities must be provided")
+	}
+
+	var shared bool
+	var block bool
+	var mount bool
+	for _, cap := range caps {
+		mode := cap.GetAccessMode().GetMode()
+		if mode == csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER ||
+			mode == csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER ||
+			mode == csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY {
+			shared = true
 		}
+
+		if cap.GetBlock() != nil {
+			block = true
+		}
+
+		if cap.GetMount() != nil {
+			mount = true
+		}
+	}
+
+	// Check for FA DA volumes: all allowed except filesystem RWX
+	if proxySpec.ProxyProtocol == api.ProxyProtocol_PROXY_PROTOCOL_PURE_BLOCK && shared && mount {
+		return status.Errorf(
+			codes.InvalidArgument,
+			"FlashArray Direct Access shared filesystems are not supported",
+		)
+	}
+
+	// Check for FB DA volumes: all allowed except raw block
+	if proxySpec.ProxyProtocol == api.ProxyProtocol_PROXY_PROTOCOL_PURE_FILE && block {
+		return status.Errorf(
+			codes.InvalidArgument,
+			"FlashBlade Direct Access volumes do not support raw block",
+		)
 	}
 
 	return nil
@@ -403,9 +447,6 @@ func (s *OsdCsiServer) CreateVolume(
 	if len(req.GetName()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Name must be provided")
 	}
-	if err := validateCreateVolumeCapabilities(req.GetVolumeCapabilities()); err != nil {
-		return nil, err
-	}
 
 	// Get parameters
 	spec, locator, source, err := s.specHandler.SpecFromOpts(req.GetParameters())
@@ -413,6 +454,18 @@ func (s *OsdCsiServer) CreateVolume(
 		e := fmt.Sprintf("Unable to get parameters: %s\n", err.Error())
 		clogger.WithContext(ctx).Errorln(e)
 		return nil, status.Error(codes.InvalidArgument, e)
+	}
+
+	if spec.IsPureVolume() {
+		err = validateCreateVolumeCapabilitiesPure(req.GetVolumeCapabilities(), spec.GetProxySpec())
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		err = validateCreateVolumeCapabilities(req.GetVolumeCapabilities())
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// Get PVC Metadata and add to locator.VolumeLabels

--- a/pkg/mount/nfs.go
+++ b/pkg/mount/nfs.go
@@ -81,8 +81,12 @@ func (m *nfsMounter) normalizeSource(info *mount.Info, host string) {
 	if info.Fstype != "nfs" {
 		return
 	}
+
 	s := strings.Split(info.Source, ":")
 	if len(s) == 2 && len(s[0]) == 0 {
+		if strings.Contains(host, ":") && !strings.Contains(host, "[") {
+			host = fmt.Sprintf("[%s]", host)
+		}
 		info.Source = host + info.Source
 	}
 }

--- a/pkg/mount/nfs.go
+++ b/pkg/mount/nfs.go
@@ -4,6 +4,7 @@ package mount
 
 import (
 	"fmt"
+	"net"
 	"regexp"
 	"strings"
 
@@ -84,8 +85,10 @@ func (m *nfsMounter) normalizeSource(info *mount.Info, host string) {
 
 	s := strings.Split(info.Source, ":")
 	if len(s) == 2 && len(s[0]) == 0 {
-		if strings.Contains(host, ":") && !strings.Contains(host, "[") {
-			host = fmt.Sprintf("[%s]", host)
+		if net.ParseIP(host) != nil { // Check for IPv6 IP Address
+			if strings.Contains(host, ":") && !strings.Contains(host, "[") {
+				host = fmt.Sprintf("[%s]", host)
+			}
 		}
 		info.Source = host + info.Source
 	}


### PR DESCRIPTION
…host in nfs address if necessary.

Signed-off-by: Jose Rivera <jose@portworx.com>

**What this PR does / why we need it**:
Use Go pkg to handle concat IP & port which handles IPv6 addresses and NFS mounts with IPv6 addresses need to have IP enclosed in '[]'
 
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

