### PR TITLE
PWX-23290: handle spec updates with stale config

### DIFF
--- a/api/server/sdk/volume_ops.go
+++ b/api/server/sdk/volume_ops.go
@@ -19,7 +19,7 @@ package sdk
 import (
 	"context"
 	"fmt"
-	_ "math"
+	"math"
 	"strings"
 	"time"
 
@@ -574,9 +574,9 @@ func maskUnModified(spec *api.VolumeSpec, req *api.VolumeSpecUpdate) {
 		logrus.Infof("maskUnModified: spec.ScanPolicy set nil")
 	}
 
-	//if req.GetSnapshotIntervalOpt() == nil {
-	//	spec.SnapshotInterval = math.MaxUint32
-	//}
+	if req.GetSnapshotIntervalOpt() == nil {
+		spec.SnapshotInterval = math.MaxUint32
+	}
 
 	if req.GetSnapshotScheduleOpt() == nil {
 		spec.SnapshotSchedule = ""

--- a/api/server/sdk/volume_ops_test.go
+++ b/api/server/sdk/volume_ops_test.go
@@ -19,6 +19,7 @@ package sdk
 import (
 	"context"
 	"fmt"
+	"math"
 	"reflect"
 	"testing"
 
@@ -646,7 +647,7 @@ func TestSdkVolumeUpdate(t *testing.T) {
 		AnyTimes()
 	s.MockDriver().
 		EXPECT().
-		Set(id, &api.VolumeLocator{VolumeLabels: newlabels}, &api.VolumeSpec{}).
+		Set(id, &api.VolumeLocator{VolumeLabels: newlabels}, &api.VolumeSpec{SnapshotInterval:math.MaxUint32}).
 		Return(nil).
 		Times(1)
 
@@ -667,7 +668,7 @@ func TestSdkVolumeUpdate(t *testing.T) {
 
 	s.MockDriver().
 		EXPECT().
-		Set(id, nil, &api.VolumeSpec{Size: 1234}).
+		Set(id, nil, &api.VolumeSpec{Size: 1234, SnapshotInterval: math.MaxUint32}).
 		Return(nil).
 		Times(1)
 	_, err = c.Update(context.Background(), req)
@@ -689,7 +690,7 @@ func TestSdkVolumeUpdate(t *testing.T) {
 		Set(
 			id,
 			&api.VolumeLocator{VolumeLabels: newlabels},
-			&api.VolumeSpec{Size: 1234},
+			&api.VolumeSpec{Size: 1234, SnapshotInterval: math.MaxUint32},
 		).
 		Return(nil).
 		Times(1)
@@ -1160,6 +1161,7 @@ func TestSdkCloneOwnership(t *testing.T) {
 				Ownership: &api.Ownership{
 					Owner: user2,
 				},
+				SnapshotInterval: math.MaxUint32,
 			}).
 			Return(nil).
 			Times(1),
@@ -1286,6 +1288,7 @@ func TestSdkCloneOwnership(t *testing.T) {
 				Ownership: &api.Ownership{
 					Owner: user2,
 				},
+				SnapshotInterval: math.MaxUint32,
 			}).
 			Return(nil).
 			Times(1),

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -19,6 +19,7 @@ package csi
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/golang/protobuf/ptypes"
@@ -2675,7 +2676,8 @@ func TestControllerExpandVolume(t *testing.T) {
 		s.MockDriver().
 			EXPECT().
 			Set(gomock.Any(), gomock.Any(), &api.VolumeSpec{
-				Size: 46 * units.GiB, // Round up from 45.5 to 46
+				Size: uint64(46 * units.GiB), // Round up from 45.5 to 46
+				SnapshotInterval: math.MaxUint32,
 			}).
 			Return(nil).
 			Times(1),

--- a/volume/drivers/fake/fake.go
+++ b/volume/drivers/fake/fake.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -337,7 +338,9 @@ func (d *driver) Set(volumeID string, locator *api.VolumeLocator, spec *api.Volu
 		v.Spec.Shared = spec.Shared
 		v.Spec.Sharedv4 = spec.Sharedv4
 		v.Spec.Journal = spec.Journal
-		v.Spec.SnapshotInterval = spec.SnapshotInterval
+		if spec.SnapshotInterval != math.MaxUint32 {
+			v.Spec.SnapshotInterval = spec.SnapshotInterval
+		}
 		v.Spec.IoProfile = spec.IoProfile
 		v.Spec.SnapshotSchedule = spec.SnapshotSchedule
 		v.Spec.Ownership = spec.Ownership


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

When volume spec updates are requested, there is a spec reconciliation based on the current state of the volume.
This is done to validate policy settings.
For some volume update operations the spec gets updated only upon action from px-storage and may take time to complete action. Ex. HA Update on a volume needs action from px-storage before the HA level change gets reflected in  spec.
So, if there is a subsequent volume update, it is possible for the reconciliation action part of update to pick stale config,
and the final action may be inconsistent after.

To avoid this, whenever volume update is applied, only pass the relevant section of the spec that needs update, mask 
rest of the specs that have not been updated. 

This window of stale config is open only for defered spec updated and long running actions to complete the update operations. Boolean based state are mostly instantaneous updates to the spec and does not seem to have this problem.

**Which issue(s) this PR fixes** (optional)
Closes # PWX-23290
https://portworx.atlassian.net/browse/PWX-23290

**Special notes for your reviewer**:
The changes have been tested in 2.10.0-ea branch where the issue was reported.
