### PR TITLE
PWX-23394 Use ipv6 friendly px/sdk endpoint building

### DIFF
--- a/api/server/sdk/node.go
+++ b/api/server/sdk/node.go
@@ -18,6 +18,7 @@ package sdk
 
 import (
 	"context"
+	"net"
 
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/libopenstorage/openstorage/api/errors"
@@ -232,7 +233,7 @@ func (s *NodeServer) needsProxyRequest(
 func (s *NodeServer) getProxyClient(
 	host string,
 ) (api.OpenStorageNodeClient, error) {
-	endpoint := host + ":" + s.server.port()
+	endpoint := net.JoinHostPort(host, s.server.port())
 	// TODO TLS
 	dialOpts := []grpc.DialOption{
 		grpc.WithInsecure(),

--- a/cluster/manager/pair.go
+++ b/cluster/manager/pair.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
+	"net"
 	"strconv"
 	"time"
 
@@ -48,7 +49,7 @@ func (c *ClusterManager) CreatePair(
 		CredentialId:       request.CredentialId,
 	}
 
-	endpoint := remoteIp + ":" + strconv.FormatUint(uint64(request.RemoteClusterPort), 10)
+	endpoint := net.JoinHostPort(remoteIp, strconv.FormatUint(uint64(request.RemoteClusterPort), 10))
 	clnt, err := clusterclient.NewInsecureTLSAuthClusterClient(endpoint, cluster.APIVersion, request.RemoteClusterToken, "")
 	if err != nil {
 		return nil, err

--- a/volume/drivers/pwx/connection.go
+++ b/volume/drivers/pwx/connection.go
@@ -2,6 +2,7 @@ package pwx
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -142,6 +143,7 @@ func (cpb *ConnectionParamsBuilder) BuildClientsEndpoints() (string, string, err
 	}
 
 	// PX mgmt API was decided not to be protected with TLS
+	// Using names not IP, so no need for ipv6 protection here
 	pxMgmtEndpoint = fmt.Sprintf("http://%s:%d", endpoint, restPort)
 	sdkEndpoint = fmt.Sprintf("%s:%d", endpoint, sdkPort)
 
@@ -227,7 +229,8 @@ func (cpb *ConnectionParamsBuilder) checkStaticEndpoints() (string, string, erro
 		return "", "", fmt.Errorf("static REST port value sould be greater than 0")
 	}
 
-	pxMgmtEndpoint, sdkEndpoint := fmt.Sprintf("http://%s:%d", endpoint, restPort), fmt.Sprintf("%s:%d", endpoint, sdkPort)
+	pxMgmtEndpoint := fmt.Sprintf("http://%s", net.JoinHostPort(endpoint, strconv.Itoa(restPort)))
+	sdkEndpoint := net.JoinHostPort(endpoint, strconv.Itoa(sdkPort))
 
 	return pxMgmtEndpoint, sdkEndpoint, nil
 }


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Use ipv6 friendly px/sdk endpoint building so ipv6 are in in brackets when combining with port

**Which issue(s) this PR fixes** (optional)
Closes #PWX-23394

**Special notes for your reviewer**:
NOT TESTED YET
