### PR TITLE
Automated cherry pick of #2003: Update Create/Delete to use context.Context

### DIFF
--- a/api/client/volume/client.go
+++ b/api/client/volume/client.go
@@ -131,7 +131,7 @@ func (v *volumeClient) GraphDriverDiffSize(id string, parent string) (int, error
 
 // Create a new Vol for the specific volume spev.c.
 // It returns a system generated VolumeID that uniquely identifies the volume
-func (v *volumeClient) Create(locator *api.VolumeLocator, source *api.Source,
+func (v *volumeClient) Create(ctx context.Context, locator *api.VolumeLocator, source *api.Source,
 	spec *api.VolumeSpec) (string, error) {
 	response := &api.VolumeCreateResponse{}
 	request := &api.VolumeCreateRequest{
@@ -172,7 +172,7 @@ func (v *volumeClient) Inspect(ids []string) ([]*api.Volume, error) {
 
 // Delete volume.
 // Errors ErrEnoEnt, ErrVolHasSnaps may be returned.
-func (v *volumeClient) Delete(volumeID string) error {
+func (v *volumeClient) Delete(ctx context.Context, volumeID string) error {
 	response := &api.VolumeResponse{}
 	if err := v.c.Delete().Resource(volumePath).Instance(volumeID).Do().Unmarshal(response); err != nil {
 		return err

--- a/api/server/backup_test.go
+++ b/api/server/backup_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"testing"
 
 	"github.com/libopenstorage/openstorage/api"
@@ -38,10 +39,10 @@ func TestClientBackupCreateSuccess(t *testing.T) {
 
 	// Create a volume client
 	driverclient := client.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
-	defer driverclient.Delete(id)
+	defer driverclient.Delete(context.TODO(), id)
 
 	// Create a backup
 	resp, err := driverclient.CloudBackupCreate(&api.CloudBackupCreateRequest{
@@ -285,10 +286,10 @@ func TestClientBackupEnumerateSuccess(t *testing.T) {
 
 	// Create a volume client
 	driverclient := client.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
-	defer driverclient.Delete(id)
+	defer driverclient.Delete(context.TODO(), id)
 
 	// Create a backup
 	resp, err := driverclient.CloudBackupCreate(&api.CloudBackupCreateRequest{
@@ -347,10 +348,10 @@ func TestClientBackupEnumerateFailed(t *testing.T) {
 
 	// Create a volume client
 	driverclient := client.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
-	defer driverclient.Delete(id)
+	defer driverclient.Delete(context.TODO(), id)
 
 	// Create a backup
 	resp, err := driverclient.CloudBackupCreate(&api.CloudBackupCreateRequest{
@@ -515,10 +516,10 @@ func TestClientBackupSchedCreateSuccess(t *testing.T) {
 
 	// Create a volume client
 	driverclient := client.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
-	defer driverclient.Delete(id)
+	defer driverclient.Delete(context.TODO(), id)
 
 	goodRequest := api.CloudBackupSchedCreateRequest{}
 	goodRequest.SrcVolumeID = id
@@ -562,10 +563,10 @@ func TestClientBackupSchedCreateFailed(t *testing.T) {
 
 	// Create a volume client
 	driverclient := client.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
-	defer driverclient.Delete(id)
+	defer driverclient.Delete(context.TODO(), id)
 
 	// Cannot get this to fail.
 	badRequest := api.CloudBackupSchedCreateRequest{}

--- a/api/server/migrate_test.go
+++ b/api/server/migrate_test.go
@@ -2,10 +2,11 @@ package server
 
 import (
 	"context"
+	"testing"
+
 	"github.com/libopenstorage/openstorage/api"
 	volumeclient "github.com/libopenstorage/openstorage/api/client/volume"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestMigrateStart(t *testing.T) {
@@ -38,7 +39,7 @@ func TestMigrateStart(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 

--- a/api/server/sdk/server_interceptors_test.go
+++ b/api/server/sdk/server_interceptors_test.go
@@ -125,7 +125,7 @@ func TestAuthorizationServerInterceptorCreateVolume(t *testing.T) {
 				AnyTimes(),
 			s.MockDriver().
 				EXPECT().
-				Create(gomock.Any(), gomock.Any(), gomock.Any()).
+				Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(id, nil).
 				AnyTimes(),
 		)

--- a/api/server/sdk/volume_ops.go
+++ b/api/server/sdk/volume_ops.go
@@ -200,7 +200,7 @@ func (s *VolumeServer) create(
 		// New volume, set ownership
 		spec.Ownership = api.OwnershipSetUsernameFromContext(ctx, spec.Ownership)
 		// Create the volume
-		id, err = s.driver(ctx).Create(locator, source, spec)
+		id, err = s.driver(ctx).Create(ctx, locator, source, spec)
 		if err != nil {
 			return "", status.Errorf(
 				codes.Internal,
@@ -344,7 +344,7 @@ func (s *VolumeServer) Delete(
 	}
 
 	// Delete the volume
-	err = s.driver(ctx).Delete(req.GetVolumeId())
+	err = s.driver(ctx).Delete(ctx, req.GetVolumeId())
 	if err != nil {
 		return nil, status.Errorf(
 			codes.Internal,

--- a/api/server/sdk/volume_ops_test.go
+++ b/api/server/sdk/volume_ops_test.go
@@ -100,7 +100,7 @@ func TestSdkVolumeCreateCheckIdempotencyWaitForRemoved(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Create(&api.VolumeLocator{
+			Create(gomock.Any(), &api.VolumeLocator{
 				Name: name,
 			}, &api.Source{}, &api.VolumeSpec{Size: size}).
 			Return(id, nil),
@@ -242,7 +242,7 @@ func TestSdkVolumeCreate(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Create(&api.VolumeLocator{
+			Create(gomock.Any(), &api.VolumeLocator{
 				Name: name,
 			}, &api.Source{}, &api.VolumeSpec{Size: size}).
 			Return(id, nil).
@@ -358,7 +358,7 @@ func TestSdkVolumeDelete(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Delete(id).
+			Delete(gomock.Any(), id).
 			Return(nil).
 			Times(1),
 	)
@@ -943,7 +943,7 @@ func TestSdkDeleteOnlyByOwner(t *testing.T) {
 		Return([]*api.Volume{vpublic}, nil)
 	mv.
 		EXPECT().
-		Delete(id).
+		Delete(gomock.Any(), id).
 		Return(nil)
 	_, err := s.Delete(ctxNoAuth, &api.SdkVolumeDeleteRequest{
 		VolumeId: id,
@@ -959,7 +959,7 @@ func TestSdkDeleteOnlyByOwner(t *testing.T) {
 		Return([]*api.Volume{vpublic}, nil)
 	mv.
 		EXPECT().
-		Delete(id).
+		Delete(gomock.Any(), id).
 		Return(nil)
 	_, err = s.Delete(ctxWithNotOwner, &api.SdkVolumeDeleteRequest{
 		VolumeId: id,
@@ -975,7 +975,7 @@ func TestSdkDeleteOnlyByOwner(t *testing.T) {
 		Return([]*api.Volume{vauth}, nil)
 	mv.
 		EXPECT().
-		Delete(id).
+		Delete(gomock.Any(), id).
 		Return(nil)
 	_, err = s.Delete(ctxNoAuth, &api.SdkVolumeDeleteRequest{
 		VolumeId: id,
@@ -1004,7 +1004,7 @@ func TestSdkDeleteOnlyByOwner(t *testing.T) {
 		Return([]*api.Volume{vauth}, nil)
 	mv.
 		EXPECT().
-		Delete(id).
+		Delete(gomock.Any(), id).
 		Return(nil)
 	_, err = s.Delete(ctxWithTrusted, &api.SdkVolumeDeleteRequest{
 		VolumeId: id,
@@ -1395,7 +1395,7 @@ func TestSdkVolumeCreateEnforced(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Create(&api.VolumeLocator{
+			Create(gomock.Any(), &api.VolumeLocator{
 				Name: name,
 			}, &api.Source{}, updatedSpec).
 			Return(id, nil).
@@ -1569,7 +1569,7 @@ func TestSdkVolumeCreateDefaultPolicyOwnership(t *testing.T) {
 			Times(1),
 
 		mv.EXPECT().
-			Create(&api.VolumeLocator{
+			Create(gomock.Any(), &api.VolumeLocator{
 				Name: name,
 			}, &api.Source{}, updatedSpec).
 			Return(id, nil).
@@ -1622,7 +1622,7 @@ func TestSdkVolumeCreateDefaultPolicyOwnership(t *testing.T) {
 			Times(1),
 
 		mv.EXPECT().
-			Create(&api.VolumeLocator{
+			Create(gomock.Any(), &api.VolumeLocator{
 				Name: name,
 			}, &api.Source{}, upSpec).
 			Return(id, nil).
@@ -1768,7 +1768,7 @@ func TestSdkVolumeUpdatePolicyOwnership(t *testing.T) {
 			Times(1),
 
 		mv.EXPECT().
-			Create(&api.VolumeLocator{
+			Create(gomock.Any(), &api.VolumeLocator{
 				Name: name,
 			}, &api.Source{}, volPolSpec).
 			Return(id, nil).

--- a/api/server/volume_test.go
+++ b/api/server/volume_test.go
@@ -114,7 +114,7 @@ func TestVolumeNoAuth(t *testing.T) {
 
 	// CREATE
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -137,7 +137,7 @@ func TestVolumeNoAuth(t *testing.T) {
 	assert.EqualValues(t, newsize, res[0].Spec.Size)
 
 	// DELETE
-	err = driverclient.Delete(id)
+	err = driverclient.Delete(context.TODO(), id)
 	assert.Nil(t, err)
 }
 
@@ -205,7 +205,7 @@ func TestVolumeCreateSuccess(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -278,14 +278,14 @@ func TestMiddlewareVolumeCreateFailure(t *testing.T) {
 	c, err := volumeclient.NewDriverClient(testMockURL, fakeWithSched, version, "")
 	assert.NoError(t, err, "Unexpected error on NewDriverClient")
 	driverclient := volumeclient.VolumeDriver(c)
-	_, err = driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	_, err = driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Error(t, err, "Expected an error on Create")
 
 	// Send a request without labels
 	c, err = volumeclient.NewDriverClient(testMockURL, fakeWithSched, version, fakeWithSched)
 	assert.NoError(t, err, "Unexpected error on NewDriverClient")
 	driverclient = volumeclient.VolumeDriver(c)
-	_, err = driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	_, err = driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Error(t, err, "Expected an error on Create")
 
 	req = &api.VolumeCreateRequest{
@@ -319,7 +319,7 @@ func TestMiddlewareVolumeCreateFailure(t *testing.T) {
 	c, err = volumeclient.NewDriverClient(testMockURL, fakeWithSched, version, fakeWithSched)
 	assert.NoError(t, err, "Unexpected error on NewDriverClient")
 	driverclient = volumeclient.VolumeDriver(c)
-	_, err = driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	_, err = driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Error(t, err, "Expected an error on Create")
 	mockSecret.EXPECT().
 		String().
@@ -339,7 +339,7 @@ func TestMiddlewareVolumeCreateFailure(t *testing.T) {
 	c, err = volumeclient.NewDriverClient(testMockURL, fakeWithSched, version, fakeWithSched)
 	assert.NoError(t, err, "Unexpected error on NewDriverClient")
 	driverclient = volumeclient.VolumeDriver(c)
-	_, err = driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	_, err = driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Error(t, err, "Expected an error on Create")
 
 }
@@ -375,7 +375,7 @@ func TestVolumeCreateFailedToAuthenticate(t *testing.T) {
 
 	// create a volume client
 	driverclient := volumeclient.VolumeDriver(client)
-	_, err = driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	_, err = driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Error(t, err)
 }
 
@@ -417,7 +417,7 @@ func TestVolumeCreateGetNodeIdFromIpFailed(t *testing.T) {
 	// create a volume client
 	driverclient := volumeclient.VolumeDriver(client)
 
-	res, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	res, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.NotNil(t, err)
 	assert.EqualValues(t, "", res)
 	assert.Contains(t, err.Error(), "Failed to locate IP")
@@ -457,7 +457,7 @@ func TestVolumeSnapshotCreateSuccess(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -515,7 +515,7 @@ func TestVolumeSnapshotCreateFailed(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -571,7 +571,7 @@ func TestVolumeInspectSuccess(t *testing.T) {
 		},
 	}
 
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -628,7 +628,7 @@ func TestVolumeInspectFailed(t *testing.T) {
 		},
 	}
 
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -682,7 +682,7 @@ func TestVolumeSnapshotList(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -777,7 +777,7 @@ func TestVolumeSetSuccess(t *testing.T) {
 		},
 	}
 
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.NoError(t, err)
 	assert.NotEmpty(t, id)
 
@@ -864,7 +864,7 @@ func TestVolumeSetFailed(t *testing.T) {
 		},
 	}
 
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.NoError(t, err)
 	assert.NotEmpty(t, id)
 
@@ -1012,7 +1012,7 @@ func TestVolumeAttachSuccess(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -1062,7 +1062,7 @@ func TestVolumeAttachFailed(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -1112,7 +1112,7 @@ func TestVolumeDetachSuccess(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -1165,7 +1165,7 @@ func TestVolumeDetachFailed(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -1221,7 +1221,7 @@ func TestVolumeMountSuccess(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -1271,7 +1271,7 @@ func TestVolumeMountFailedNoMountPath(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -1324,7 +1324,7 @@ func TestVolumeStatsSuccess(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.NoError(t, err)
 	assert.NotEmpty(t, id)
 
@@ -1373,7 +1373,7 @@ func TestVolumeStatsFailed(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -1422,7 +1422,7 @@ func TestVolumeUnmountSuccess(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -1477,7 +1477,7 @@ func TestVolumeUnmountFailed(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -1641,7 +1641,7 @@ func TestVolumeRestoreSuccess(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -1702,7 +1702,7 @@ func TestVolumeRestoreFailed(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -1764,7 +1764,7 @@ func TestVolumeUsedSizeSuccess(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -1813,7 +1813,7 @@ func TestVolumeUsedSizeFailed(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -1869,7 +1869,7 @@ func TestVolumeEnumerateSuccess(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -1941,7 +1941,7 @@ func TestVolumeEnumerateFailed(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -2447,11 +2447,11 @@ func TestVolumeDeleteSuccess(t *testing.T) {
 	driverclient := volumeclient.VolumeDriver(client)
 
 	// Create volume.
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
-	err = driverclient.Delete(id)
+	err = driverclient.Delete(context.TODO(), id)
 	assert.Nil(t, err)
 }
 
@@ -2490,7 +2490,7 @@ func TestMiddlewareVolumeDeleteSuccess(t *testing.T) {
 		Return(map[string]interface{}{secrets.SecretTokenKey: token}, nil).
 		AnyTimes()
 
-	err = driverclient.Delete(id)
+	err = driverclient.Delete(context.TODO(), id)
 	assert.Nil(t, err)
 
 }
@@ -2566,7 +2566,7 @@ func TestMiddlewareVolumeInspectFailureVolumeNotFound(t *testing.T) {
 
 	// Create a volume
 	driverclient := volumeclient.VolumeDriver(c)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
@@ -2597,7 +2597,7 @@ func TestMiddlewareVolumeDeleteFailureVolumeNotFound(t *testing.T) {
 
 	// Deleteing an ID that does not exist should return success since the call is idempotent
 	driverclient := volumeclient.VolumeDriver(c)
-	err = driverclient.Delete("fakeid")
+	err = driverclient.Delete(context.TODO(), "fakeid")
 	assert.Nil(t, err)
 }
 
@@ -2662,7 +2662,7 @@ func TestMiddlewareVolumeDeleteFailureIncorrectToken(t *testing.T) {
 
 	// Create a volume client
 	driverclient := volumeclient.VolumeDriver(c)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.NoError(t, err, "Unexpected error on Create")
 	mockSecret.EXPECT().
 		String().
@@ -2679,7 +2679,7 @@ func TestMiddlewareVolumeDeleteFailureIncorrectToken(t *testing.T) {
 		Return(map[string]interface{}{secrets.SecretTokenKey: incorrectToken}, nil).
 		Times(1)
 
-	err = driverclient.Delete(id)
+	err = driverclient.Delete(context.TODO(), id)
 	assert.Error(t, err, "Expected an error on Delete")
 	mockSecret.EXPECT().
 		String().
@@ -2695,7 +2695,7 @@ func TestMiddlewareVolumeDeleteFailureIncorrectToken(t *testing.T) {
 		Return(nil, fmt.Errorf("incorrect secret")).
 		AnyTimes()
 
-	err = driverclient.Delete(id)
+	err = driverclient.Delete(context.TODO(), id)
 	assert.Error(t, err, "Expected an error on Delete")
 
 }
@@ -2747,7 +2747,7 @@ func testMiddlewareCreateVolume(
 		AnyTimes()
 
 	// Create a volume
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
@@ -2789,11 +2789,11 @@ func TestStorkVolumeInspect(t *testing.T) {
 	driverclient := volumeclient.VolumeDriver(client)
 
 	// Create volume.
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
-	err = driverclient.Delete(id)
+	err = driverclient.Delete(context.TODO(), id)
 	assert.Nil(t, err)
 
 	vols, err := driverclient.Inspect([]string{id})
@@ -2858,7 +2858,7 @@ func TestThousandsOfVolumes(t *testing.T) {
 		go func() {
 			for i := range ch {
 				req.GetLocator().Name = fmt.Sprintf("myvol-%d", i)
-				id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+				id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 				assert.Nil(t, err)
 				assert.NotEmpty(t, id)
 			}
@@ -2960,12 +2960,12 @@ func TestRequestOnAuthWithMiddlewareForGuest(t *testing.T) {
 
 	// CREATE
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
 	// DELETE
-	err = driverclient.Delete(id)
+	err = driverclient.Delete(context.TODO(), id)
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 }
@@ -3015,7 +3015,7 @@ func TestRequestOnAuthWithMiddlewareForGuestWithoutGuestMode(t *testing.T) {
 
 	// CREATE
 	driverclient := volumeclient.VolumeDriver(cl)
-	_, err = driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	_, err = driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Error(t, err)
 }
 
@@ -3049,12 +3049,12 @@ func TestRequestOnAuthWithMiddlewareForUser(t *testing.T) {
 
 	// CREATE
 	driverclient := volumeclient.VolumeDriver(cl)
-	id, err := driverclient.Create(req.GetLocator(), req.GetSource(), req.GetSpec())
+	id, err := driverclient.Create(context.TODO(), req.GetLocator(), req.GetSource(), req.GetSpec())
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 
 	// DELETE
-	err = driverclient.Delete(id)
+	err = driverclient.Delete(context.TODO(), id)
 	assert.Nil(t, err)
 	assert.NotEmpty(t, id)
 }

--- a/cli/volumes.go
+++ b/cli/volumes.go
@@ -108,7 +108,7 @@ func (v *volDriver) volumeCreate(cliContext *cli.Context) {
 	source := &api.Source{
 		Seed: cliContext.String("seed"),
 	}
-	if id, err = v.volDriver.Create(locator, source, spec); err != nil {
+	if id, err = v.volDriver.Create(context.Background(), locator, source, spec); err != nil {
 		cmdError(cliContext, fn, err)
 		return
 	}
@@ -270,7 +270,7 @@ func (v *volDriver) volumeDelete(cliContext *cli.Context) {
 	}
 	volumeID := cliContext.Args()[0]
 	v.volumeOptions(cliContext)
-	err := v.volDriver.Delete(volumeID)
+	err := v.volDriver.Delete(context.Background(), volumeID)
 	if err != nil {
 		cmdError(cliContext, fn, err)
 		return

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -1028,8 +1028,9 @@ func TestControllerCreateVolumeNoCapacity(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Create(gomock.Any(), gomock.Any(), gomock.Any()).
+			Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(
+				ctx context.Context,
 				locator *api.VolumeLocator,
 				Source *api.Source,
 				spec *api.VolumeSpec,
@@ -1382,7 +1383,7 @@ func TestControllerCreateVolumeWithSharedv4Volume(t *testing.T) {
 
 			s.MockDriver().
 				EXPECT().
-				Create(gomock.Any(), gomock.Any(), gomock.Any()).
+				Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(id, nil).
 				Times(1),
 
@@ -1466,7 +1467,7 @@ func TestControllerCreateVolumeWithSharedVolume(t *testing.T) {
 
 			s.MockDriver().
 				EXPECT().
-				Create(gomock.Any(), gomock.Any(), gomock.Any()).
+				Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(id, nil).
 				Times(1),
 
@@ -1537,7 +1538,7 @@ func TestControllerCreateVolumeFails(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Create(gomock.Any(), gomock.Any(), gomock.Any()).
+			Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("", fmt.Errorf("createerror")).
 			Times(1),
 	)
@@ -1587,7 +1588,7 @@ func TestControllerCreateVolumeNoNewVolumeInfo(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Create(gomock.Any(), gomock.Any(), gomock.Any()).
+			Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(id, nil).
 			Times(1),
 
@@ -1651,7 +1652,7 @@ func TestControllerCreateVolume(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Create(gomock.Any(), gomock.Any(), gomock.Any()).
+			Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(id, nil).
 			Times(1),
 
@@ -1728,7 +1729,7 @@ func TestControllerCreateVolumeRoundUp(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Create(gomock.Any(), gomock.Any(), &api.VolumeSpec{
+			Create(gomock.Any(), gomock.Any(), gomock.Any(), &api.VolumeSpec{
 				Size:      uint64(units.GiB) * 2, // round up to 2GiB from 1.5 GiB
 				Format:    api.FSType_FS_TYPE_EXT4,
 				HaLevel:   1,
@@ -2084,7 +2085,7 @@ func TestControllerCreateVolumeBlock(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Create(gomock.Any(), gomock.Any(), gomock.Any()).
+			Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(id, nil).
 			Times(1),
 
@@ -2204,7 +2205,7 @@ func TestControllerDeleteVolumeError(t *testing.T) {
 			Times(1),
 		s.MockDriver().
 			EXPECT().
-			Delete(myid).
+			Delete(gomock.Any(), myid).
 			Return(fmt.Errorf("MOCKERRORTEST")).
 			Times(1),
 	)
@@ -2259,7 +2260,7 @@ func TestControllerDeleteVolume(t *testing.T) {
 			Times(1),
 		s.MockDriver().
 			EXPECT().
-			Delete(myid).
+			Delete(gomock.Any(), myid).
 			Return(nil).
 			Times(1),
 	)
@@ -2596,7 +2597,7 @@ func TestControllerDeleteSnapshot(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Delete(id).
+			Delete(gomock.Any(), id).
 			Return(nil).
 			Times(1),
 	)

--- a/csi/node_test.go
+++ b/csi/node_test.go
@@ -604,7 +604,7 @@ func TestNodePublishVolumeEphemeralEnabled(t *testing.T) {
 			Times(1),
 		s.MockDriver().
 			EXPECT().
-			Create(gomock.Any(), gomock.Any(), gomock.Any()).
+			Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(name, nil).
 			Times(1),
 		s.MockDriver().

--- a/csi/v0.3/controller.go
+++ b/csi/v0.3/controller.go
@@ -408,7 +408,7 @@ func (s *OsdCsiServer) CreateVolume(
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, err.Error())
 		}
-		id, err = s.driver.Create(locator, source, spec)
+		id, err = s.driver.Create(context.TODO(), locator, source, spec)
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}
@@ -449,7 +449,7 @@ func (s *OsdCsiServer) DeleteVolume(
 	}
 
 	// Delete volume
-	err = s.driver.Delete(req.GetVolumeId())
+	err = s.driver.Delete(context.TODO(), req.GetVolumeId())
 	if err != nil {
 		e := fmt.Sprintf("Unable to delete volume with id %s: %s",
 			req.GetVolumeId(),
@@ -579,7 +579,7 @@ func (s *OsdCsiServer) DeleteSnapshot(
 		return nil, err
 	}
 
-	err = s.driver.Delete(req.GetSnapshotId())
+	err = s.driver.Delete(context.TODO(), req.GetSnapshotId())
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Unable to delete snapshot %s: %v",
 			req.GetSnapshotId(),

--- a/csi/v0.3/controller_test.go
+++ b/csi/v0.3/controller_test.go
@@ -1070,8 +1070,9 @@ func TestControllerCreateVolumeNoCapacity(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Create(gomock.Any(), gomock.Any(), gomock.Any()).
+			Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Do(func(
+				ctx context.Context,
 				locator *api.VolumeLocator,
 				Source *api.Source,
 				spec *api.VolumeSpec,
@@ -1375,7 +1376,7 @@ func TestControllerCreateVolumeWithSharedVolume(t *testing.T) {
 
 			s.MockDriver().
 				EXPECT().
-				Create(gomock.Any(), gomock.Any(), gomock.Any()).
+				Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 				Return(id, nil).
 				Times(1),
 
@@ -1443,7 +1444,7 @@ func TestControllerCreateVolumeFails(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Create(gomock.Any(), gomock.Any(), gomock.Any()).
+			Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return("", fmt.Errorf("createerror")).
 			Times(1),
 	)
@@ -1492,7 +1493,7 @@ func TestControllerCreateVolumeNoNewVolumeInfo(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Create(gomock.Any(), gomock.Any(), gomock.Any()).
+			Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(id, nil).
 			Times(1),
 
@@ -1553,7 +1554,7 @@ func TestControllerCreateVolume(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Create(gomock.Any(), gomock.Any(), gomock.Any()).
+			Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 			Return(id, nil).
 			Times(1),
 
@@ -1805,7 +1806,7 @@ func TestControllerDeleteVolumeError(t *testing.T) {
 			Times(1),
 		s.MockDriver().
 			EXPECT().
-			Delete(myid).
+			Delete(context.TODO(), myid).
 			Return(fmt.Errorf("MOCKERRORTEST")).
 			Times(1),
 	)
@@ -1866,7 +1867,7 @@ func TestControllerDeleteVolume(t *testing.T) {
 			Times(1),
 		s.MockDriver().
 			EXPECT().
-			Delete(myid).
+			Delete(context.TODO(), myid).
 			Return(nil).
 			Times(1),
 	)
@@ -2064,7 +2065,7 @@ func TestControllerDeleteSnapshot(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Delete(id).
+			Delete(context.TODO(), id).
 			Return(nil).
 			Times(1),
 	)

--- a/pkg/sanity/backup_restore.go
+++ b/pkg/sanity/backup_restore.go
@@ -105,7 +105,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = volumedriver.Delete(volumeID)
+			err = volumedriver.Delete(context.TODO(), volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
@@ -137,7 +137,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking if volume created successfully with the provided params")
@@ -213,7 +213,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = volumedriver.Delete(volumeID)
+			err = volumedriver.Delete(context.TODO(), volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
@@ -244,7 +244,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking if volume created successfully with the provided params")
@@ -336,10 +336,10 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = volumedriver.Delete(volumeID)
+			err = volumedriver.Delete(context.TODO(), volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = volumedriver.Delete(restoredVolume)
+			err = volumedriver.Delete(context.TODO(), restoredVolume)
 			Expect(err).ToNot(HaveOccurred())
 
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
@@ -371,7 +371,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking if volume created successfully with the provided params")
@@ -478,7 +478,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = volumedriver.Delete(volumeID)
+			err = volumedriver.Delete(context.TODO(), volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
@@ -510,7 +510,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking if volume created successfully with the provided params")
@@ -556,7 +556,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = volumedriver.Delete(volumeID)
+			err = volumedriver.Delete(context.TODO(), volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
@@ -588,7 +588,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking if volume created successfully with the provided params")
@@ -648,7 +648,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = volumedriver.Delete(volumeID)
+			err = volumedriver.Delete(context.TODO(), volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
@@ -680,7 +680,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking if volume created successfully with the provided params")
@@ -737,7 +737,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = volumedriver.Delete(volumeID)
+			err = volumedriver.Delete(context.TODO(), volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
@@ -769,7 +769,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking if volume created successfully with the provided params")

--- a/pkg/sanity/cluster.go
+++ b/pkg/sanity/cluster.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sanity
 
 import (
+	"context"
 	"time"
 
 	"github.com/libopenstorage/openstorage/api"
@@ -158,7 +159,7 @@ var _ = Describe("Cluster [Cluster Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking if no of volumes present in cluster increases by 1")
@@ -166,7 +167,7 @@ var _ = Describe("Cluster [Cluster Tests]", func() {
 
 			By("Deleting the created volume")
 
-			err = volumedriver.Delete(volumeID)
+			err = volumedriver.Delete(context.TODO(), volumeID)
 			Expect(err).NotTo(HaveOccurred())
 
 			endTime := time.Now()

--- a/pkg/sanity/snapshot.go
+++ b/pkg/sanity/snapshot.go
@@ -17,6 +17,7 @@ limitations under the License.
 package sanity
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/libopenstorage/openstorage/api"
@@ -66,10 +67,10 @@ var _ = Describe("Volume [Snapshot Tests]", func() {
 		AfterEach(func() {
 			var err error
 
-			err = volumedriver.Delete(volumeID)
+			err = volumedriver.Delete(context.TODO(), volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = volumedriver.Delete(snapID)
+			err = volumedriver.Delete(context.TODO(), snapID)
 			Expect(err).ToNot(HaveOccurred())
 
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
@@ -101,7 +102,7 @@ var _ = Describe("Volume [Snapshot Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 
 			Expect(err).NotTo(HaveOccurred())
 
@@ -149,11 +150,11 @@ var _ = Describe("Volume [Snapshot Tests]", func() {
 		AfterEach(func() {
 			var err error
 
-			err = volumedriver.Delete(volumeID)
+			err = volumedriver.Delete(context.TODO(), volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
 			for _, snapID := range snapIDs {
-				err = volumedriver.Delete(snapID)
+				err = volumedriver.Delete(context.TODO(), snapID)
 				Expect(err).ToNot(HaveOccurred())
 			}
 
@@ -186,7 +187,7 @@ var _ = Describe("Volume [Snapshot Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 
 			Expect(err).NotTo(HaveOccurred())
 
@@ -249,10 +250,10 @@ var _ = Describe("Volume [Snapshot Tests]", func() {
 		AfterEach(func() {
 			var err error
 
-			err = volumedriver.Delete(volumeID)
+			err = volumedriver.Delete(context.TODO(), volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = volumedriver.Delete(snapID)
+			err = volumedriver.Delete(context.TODO(), snapID)
 			Expect(err).ToNot(HaveOccurred())
 
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
@@ -284,7 +285,7 @@ var _ = Describe("Volume [Snapshot Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 
 			Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/sanity/volume.go
+++ b/pkg/sanity/volume.go
@@ -68,7 +68,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 		AfterEach(func() {
 			var err error
 			if volumeID != "" {
-				err = volumedriver.Delete(volumeID)
+				err = volumedriver.Delete(context.TODO(), volumeID)
 				Expect(err).ToNot(HaveOccurred())
 
 				volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
@@ -100,7 +100,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(volumeID).ToNot(BeNil())
@@ -131,7 +131,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(volumeID).ToNot(BeNil())
@@ -166,7 +166,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 					},
 				}
 
-				volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+				volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("empty volume name"))
@@ -188,7 +188,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 
 			if volumesToCreate != 0 {
 				for i := 0; i < len(volumeIDs); i++ {
-					err = volumedriver.Delete(volumeIDs[i])
+					err = volumedriver.Delete(context.TODO(), volumeIDs[i])
 					Expect(err).ToNot(HaveOccurred())
 				}
 
@@ -230,7 +230,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 					},
 				}
 
-				volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+				volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(volumeID).ToNot(BeNil())
 
@@ -293,14 +293,14 @@ var _ = Describe("Volume [Volume Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(volumeID).ToNot(BeNil())
 
 			By("Deleting the volume")
 
-			err = volumedriver.Delete(volumeID)
+			err = volumedriver.Delete(context.TODO(), volumeID)
 			Expect(err).To(Not(HaveOccurred()))
 
 		})
@@ -310,7 +310,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 
 			By("Trying to delete a volume that doesn't exist")
 
-			err = volumedriver.Delete("id-doesnt-exist")
+			err = volumedriver.Delete(context.TODO(), "id-doesnt-exist")
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -326,7 +326,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 		AfterEach(func() {
 
 			for _, id := range volumeIDs {
-				err := volumedriver.Delete(id)
+				err := volumedriver.Delete(context.TODO(), id)
 				Expect(err).ToNot(HaveOccurred())
 			}
 
@@ -358,7 +358,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 					},
 				}
 
-				volumeID, err := volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+				volumeID, err := volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 				Expect(err).NotTo(HaveOccurred())
 				Expect(volumeID).ToNot(BeNil())
 
@@ -399,7 +399,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 		AfterEach(func() {
 			var err error
 
-			err = volumedriver.Delete(volumeID)
+			err = volumedriver.Delete(context.TODO(), volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
@@ -429,7 +429,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(volumeID).ToNot(BeNil())
@@ -482,7 +482,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = volumedriver.Delete(volumeID)
+			err = volumedriver.Delete(context.TODO(), volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
@@ -513,7 +513,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(volumeID).ToNot(BeNil())
@@ -558,7 +558,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 
 			By("Deleting the volume successfully")
 
-			err = volumedriver.Delete(volumeID)
+			err = volumedriver.Delete(context.TODO(), volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
@@ -589,7 +589,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(volumeID).ToNot(BeNil())
@@ -658,7 +658,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(volumeID).ToNot(BeNil())
@@ -710,7 +710,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 		AfterEach(func() {
 			var err error
 
-			err = volumedriver.Delete(volumeID)
+			err = volumedriver.Delete(context.TODO(), volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
@@ -743,7 +743,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(volumeID).ToNot(BeNil())
@@ -778,7 +778,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 		AfterEach(func() {
 			var err error
 
-			err = volumedriver.Delete(volumeID)
+			err = volumedriver.Delete(context.TODO(), volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
@@ -810,7 +810,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(volumeID).ToNot(BeNil())
@@ -844,7 +844,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 		AfterEach(func() {
 			var err error
 
-			err = volumedriver.Delete(volumeID)
+			err = volumedriver.Delete(context.TODO(), volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
@@ -876,7 +876,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(volumeID).ToNot(BeNil())
@@ -916,7 +916,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 			err = volumedriver.Detach(context.TODO(), volumeID, nil)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = volumedriver.Delete(volumeID)
+			err = volumedriver.Delete(context.TODO(), volumeID)
 			Expect(err).ToNot(HaveOccurred())
 
 			volumes, err := volumedriver.Enumerate(&api.VolumeLocator{}, nil)
@@ -948,7 +948,7 @@ var _ = Describe("Volume [Volume Tests]", func() {
 				},
 			}
 
-			volumeID, err = volumedriver.Create(vr.GetLocator(), vr.GetSource(), vr.GetSpec())
+			volumeID, err = volumedriver.Create(context.TODO(), vr.GetLocator(), vr.GetSource(), vr.GetSpec())
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Checking if volume created successfully with the provided params")

--- a/volume/drivers/btrfs/btrfs.go
+++ b/volume/drivers/btrfs/btrfs.go
@@ -80,6 +80,7 @@ func (d *driver) Version() (*api.StorageVersion, error) {
 
 // Create a new subvolume. The volume spec is not taken into account.
 func (d *driver) Create(
+	ctx context.Context,
 	locator *api.VolumeLocator,
 	source *api.Source,
 	spec *api.VolumeSpec,
@@ -108,7 +109,7 @@ func (d *driver) Create(
 	return volume.Id, d.UpdateVol(volume)
 }
 
-func (d *driver) Delete(volumeID string) error {
+func (d *driver) Delete(ctx context.Context, volumeID string) error {
 	if err := d.DeleteVol(volumeID); err != nil {
 		return err
 	}

--- a/volume/drivers/fake/fake.go
+++ b/volume/drivers/fake/fake.go
@@ -156,6 +156,7 @@ func (d *driver) Inspect(volumeIDs []string) ([]*api.Volume, error) {
 //
 
 func (d *driver) Create(
+	ctx context.Context,
 	locator *api.VolumeLocator,
 	source *api.Source,
 	spec *api.VolumeSpec) (string, error) {
@@ -191,7 +192,7 @@ func (d *driver) Create(
 	return v.Id, nil
 }
 
-func (d *driver) Delete(volumeID string) error {
+func (d *driver) Delete(ctx context.Context, volumeID string) error {
 	_, err := d.GetVol(volumeID)
 	if err != nil {
 		logrus.Println(err)
@@ -245,7 +246,7 @@ func (d *driver) Snapshot(volumeID string, readonly bool, locator *api.VolumeLoc
 	}
 	source := &api.Source{Parent: volumeID}
 	logrus.Infof("Creating snap %s for vol %s", locator.Name, volumeID)
-	newVolumeID, err := d.Create(locator, source, vols[0].Spec)
+	newVolumeID, err := d.Create(context.TODO(), locator, source, vols[0].Spec)
 	if err != nil {
 		return "", nil
 	}
@@ -575,7 +576,7 @@ func (d *driver) CloudBackupRestore(
 		return nil, err
 	}
 
-	volid, err := d.Create(&api.VolumeLocator{Name: input.RestoreVolumeName}, &api.Source{}, backup.Volume.GetSpec())
+	volid, err := d.Create(context.TODO(), &api.VolumeLocator{Name: input.RestoreVolumeName}, &api.Source{}, backup.Volume.GetSpec())
 	if err != nil {
 		return nil, err
 	}

--- a/volume/drivers/fake/fake_test.go
+++ b/volume/drivers/fake/fake_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fake
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -84,7 +85,7 @@ func TestFakeCreateVolume(t *testing.T) {
 	d, err := newFakeDriver(map[string]string{})
 	assert.NoError(t, err)
 
-	vid, err := d.Create(&api.VolumeLocator{
+	vid, err := d.Create(context.TODO(), &api.VolumeLocator{
 		Name: "myvol",
 	}, &api.Source{}, &api.VolumeSpec{
 		Size: 1234,
@@ -92,7 +93,7 @@ func TestFakeCreateVolume(t *testing.T) {
 	assert.Error(t, err)
 	assert.Empty(t, vid)
 
-	vid, err = d.Create(&api.VolumeLocator{
+	vid, err = d.Create(context.TODO(), &api.VolumeLocator{
 		Name: "myvol",
 	}, &api.Source{}, &api.VolumeSpec{
 		Size:    1234,
@@ -124,7 +125,7 @@ func TestFakeInspect(t *testing.T) {
 func TestFakeCapacityUsage(t *testing.T) {
 	d, err := newFakeDriver(map[string]string{})
 	assert.NoError(t, err)
-	vid, err := d.Create(&api.VolumeLocator{
+	vid, err := d.Create(context.TODO(), &api.VolumeLocator{
 		Name: "myvol",
 	}, &api.Source{}, &api.VolumeSpec{
 		Size:    87654321,
@@ -155,7 +156,7 @@ func TestFakeCloudBackupCreate(t *testing.T) {
 	// Create a vol
 	name := "myvol"
 	size := uint64(1234)
-	volid, err := d.Create(&api.VolumeLocator{Name: name}, &api.Source{}, &api.VolumeSpec{
+	volid, err := d.Create(context.TODO(), &api.VolumeLocator{Name: name}, &api.Source{}, &api.VolumeSpec{
 		Size:    size,
 		HaLevel: 1,
 	})
@@ -185,7 +186,7 @@ func testInitForCloudBackups(t *testing.T, d *driver) (string, string, *api.Clou
 	// Create a vol
 	name := "myvol"
 	size := uint64(1234)
-	volid, err := d.Create(&api.VolumeLocator{Name: name}, &api.Source{}, &api.VolumeSpec{
+	volid, err := d.Create(context.TODO(), &api.VolumeLocator{Name: name}, &api.Source{}, &api.VolumeSpec{
 		Size:    size,
 		HaLevel: 1,
 	})
@@ -706,7 +707,7 @@ func TestFakeSet(t *testing.T) {
 	// Create a vol
 	name := "myvol"
 	size := uint64(1234)
-	volid, err := d.Create(&api.VolumeLocator{Name: name}, &api.Source{}, &api.VolumeSpec{
+	volid, err := d.Create(context.TODO(), &api.VolumeLocator{Name: name}, &api.Source{}, &api.VolumeSpec{
 		Size:    size,
 		HaLevel: 1,
 	})

--- a/volume/drivers/fuse/volume_driver.go
+++ b/volume/drivers/fuse/volume_driver.go
@@ -76,6 +76,7 @@ func (v *volumeDriver) Version() (*api.StorageVersion, error) {
 }
 
 func (v *volumeDriver) Create(
+	ctx context.Context,
 	volumeLocator *api.VolumeLocator,
 	source *api.Source,
 	spec *api.VolumeSpec,
@@ -102,7 +103,7 @@ func (v *volumeDriver) Create(
 	return volume.Id, nil
 }
 
-func (v *volumeDriver) Delete(volumeID string) error {
+func (v *volumeDriver) Delete(ctx context.Context, volumeID string) error {
 	if _, err := v.GetVol(volumeID); err != nil {
 		return err
 	}

--- a/volume/drivers/mock/driver.mock.go
+++ b/volume/drivers/mock/driver.mock.go
@@ -404,18 +404,18 @@ func (mr *MockVolumeDriverMockRecorder) CloudMigrateStatus(arg0 interface{}) *go
 }
 
 // Create mocks base method.
-func (m *MockVolumeDriver) Create(arg0 *api.VolumeLocator, arg1 *api.Source, arg2 *api.VolumeSpec) (string, error) {
+func (m *MockVolumeDriver) Create(arg0 context.Context, arg1 *api.VolumeLocator, arg2 *api.Source, arg3 *api.VolumeSpec) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "Create", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockVolumeDriverMockRecorder) Create(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockVolumeDriverMockRecorder) Create(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockVolumeDriver)(nil).Create), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockVolumeDriver)(nil).Create), arg0, arg1, arg2, arg3)
 }
 
 // CredsCreate mocks base method.
@@ -505,17 +505,17 @@ func (mr *MockVolumeDriverMockRecorder) CredsValidate(arg0 interface{}) *gomock.
 }
 
 // Delete mocks base method.
-func (m *MockVolumeDriver) Delete(arg0 string) error {
+func (m *MockVolumeDriver) Delete(arg0 context.Context, arg1 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", arg0)
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockVolumeDriverMockRecorder) Delete(arg0 interface{}) *gomock.Call {
+func (mr *MockVolumeDriverMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockVolumeDriver)(nil).Delete), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockVolumeDriver)(nil).Delete), arg0, arg1)
 }
 
 // Detach mocks base method.

--- a/volume/drivers/test/driver.go
+++ b/volume/drivers/test/driver.go
@@ -109,6 +109,7 @@ func create(t *testing.T, ctx *Context) {
 	fmt.Println("create")
 
 	volID, err := ctx.Create(
+		context.TODO(),
 		&api.VolumeLocator{Name: "foo", VolumeLabels: map[string]string{"oh": "create"}},
 		nil,
 		&api.VolumeSpec{
@@ -300,13 +301,13 @@ func deleteBad(t *testing.T, ctx *Context) {
 	fmt.Println("deleteBad")
 	require.NotEqual(t, ctx.mountPath, "", "Device is not mounted")
 
-	err := ctx.Delete(ctx.volID)
+	err := ctx.Delete(context.TODO(), ctx.volID)
 	require.Error(t, err, "Delete on mounted device must fail")
 }
 
 func delete(t *testing.T, ctx *Context) {
 	fmt.Println("delete")
-	err := ctx.Delete(ctx.volID)
+	err := ctx.Delete(context.TODO(), ctx.volID)
 	require.NoError(t, err, "Delete failed")
 	ctx.volID = ""
 }

--- a/volume/drivers/vfs/vfs.go
+++ b/volume/drivers/vfs/vfs.go
@@ -72,7 +72,7 @@ func (d *driver) Version() (*api.StorageVersion, error) {
 	}, nil
 }
 
-func (d *driver) Create(locator *api.VolumeLocator, source *api.Source, spec *api.VolumeSpec) (string, error) {
+func (d *driver) Create(ctx context.Context, locator *api.VolumeLocator, source *api.Source, spec *api.VolumeSpec) (string, error) {
 	volumeID := strings.TrimSuffix(uuid.New(), "\n")
 	// Create a directory on the Local machine with this UUID.
 	if err := os.MkdirAll(filepath.Join(volume.VolumeBase, string(volumeID)), 0744); err != nil {
@@ -92,7 +92,7 @@ func (d *driver) Create(locator *api.VolumeLocator, source *api.Source, spec *ap
 	return v.Id, d.UpdateVol(v)
 }
 
-func (d *driver) Delete(volumeID string) error {
+func (d *driver) Delete(ctx context.Context, volumeID string) error {
 	if _, err := d.GetVol(volumeID); err != nil {
 		return err
 	}

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -257,10 +257,10 @@ type ProtoDriver interface {
 	Version() (*api.StorageVersion, error)
 	// Create a new Vol for the specific volume spec.
 	// It returns a system generated VolumeID that uniquely identifies the volume
-	Create(locator *api.VolumeLocator, Source *api.Source, spec *api.VolumeSpec) (string, error)
+	Create(ctx context.Context, locator *api.VolumeLocator, Source *api.Source, spec *api.VolumeSpec) (string, error)
 	// Delete volume.
 	// Errors ErrEnoEnt, ErrVolHasSnaps may be returned.
-	Delete(volumeID string) error
+	Delete(ctx context.Context, volumeID string) error
 	// Mount volume at specified path
 	// Errors ErrEnoEnt, ErrVolDetached may be returned.
 	Mount(ctx context.Context, volumeID string, mountPath string, options map[string]string) error


### PR DESCRIPTION
Cherry pick of #2003 on release-9.4.

#2003: Update Create/Delete to use context.Context

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.