### PR TITLE
Fix 7 years worth of openstorage typos with misspell linter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,14 @@ $(GOPATH)/bin/gotestcover:
 	@echo "Installing missing $@ ..."
 	GO111MODULE=off go get -u github.com/pierrre/gotestcover
 
+$(GOPATH)/bin/contextcheck:
+	@echo "Installing missing $@ ..."
+	GO111MODULE=off go get -u github.com/sylvia7788/contextcheck
+
+$(GOPATH)/bin/misspell:
+	@echo "Installing missing $@ ..."
+	GO111MODULE=off go get -u github.com/client9/misspell/cmd/misspell
+
 # DEPS build rules
 #
 
@@ -230,6 +238,12 @@ fmt:
 
 errcheck: $(GOPATH)/bin/errcheck
 	errcheck -tags "$(TAGS)" $(PKGS)
+
+contextcheck: $(GOPATH)/bin/contextcheck
+	contextcheck $(PKGS)
+
+misspell: $(GOPATH)/bin/misspell
+	git ls-files | grep -v vendor | grep -v .pb.go | grep -v .js | grep -v .css | xargs misspell
 
 pretest: lint vet errcheck
 

--- a/SDK_CHANGELOG.md
+++ b/SDK_CHANGELOG.md
@@ -442,7 +442,7 @@
 ### v0.34.0 - Tech Preview (1/2/2019)
 
 * Role support
-* Added Cluster Pair and Migrate to Capabilites since they were missing
+* Added Cluster Pair and Migrate to Capabilities since they were missing
 
 ### v0.33.0 - Tech Preview (12/05/2018)
 

--- a/SDK_CHANGELOG.md
+++ b/SDK_CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Releases
 
+### v0.138.0 - (4/12/2022)
+
+* Fixes many typos
+
 ### v0.137.0 - (3/31/2022)
 
 * Adds full_vol_name field to PureBlockSpec.

--- a/STYLEGUIDE.md
+++ b/STYLEGUIDE.md
@@ -1,6 +1,6 @@
 # Style Guide
 
-This is the official openstorage style guide for golang code. This is in addition to the offical style guide at https://github.com/golang/go/wiki/CodeReviewComments.
+This is the official openstorage style guide for golang code. This is in addition to the official style guide at https://github.com/golang/go/wiki/CodeReviewComments.
 
 This is just a rough outline for now, we will formalize this as we go.
 
@@ -64,7 +64,7 @@ func init() {
 // foo.go
 package foo
 
-type Runner interace {
+type Runner interface {
   Run(one string, i int) error
 }
 

--- a/api/api.go
+++ b/api/api.go
@@ -345,7 +345,7 @@ type CloudBackupCreateRequest struct {
 	// Labels are list of key value pairs to tag the cloud backup. These labels
 	// are stored in the metadata associated with the backup.
 	Labels map[string]string
-	// FullBackupFrequency indicates number of incremental backup after whcih
+	// FullBackupFrequency indicates number of incremental backup after which
 	// a fullbackup must be created. This is to override the default value for
 	// manual/user triggerred backups and not applicable for scheduled backups.
 	// Value of 0 retains the default behavior.
@@ -627,7 +627,7 @@ type CloudBackupScheduleInfo struct {
 	SrcVolumeID string
 	// CredentialUUID is the cloud credential used with this schedule
 	CredentialUUID string
-	// Schedule is the frequence of backup
+	// Schedule is the frequencies of backup
 	Schedule string
 	// MaxBackups are the maximum number of backups retained
 	// in cloud.Older backups are deleted

--- a/api/api.pb.go
+++ b/api/api.pb.go
@@ -1043,13 +1043,13 @@ type ExportProtocol int32
 const (
 	// Invalid uninitialized value
 	ExportProtocol_INVALID ExportProtocol = 0
-	// PXD the volume is exported over Portworx block interace.
+	// PXD the volume is exported over Portworx block interface.
 	ExportProtocol_PXD ExportProtocol = 1
 	// ISCSI the volume is exported over ISCSI.
 	ExportProtocol_ISCSI ExportProtocol = 2
 	// NFS the volume is exported over NFS.
 	ExportProtocol_NFS ExportProtocol = 3
-	// Custom the volume is exported over custom interace.
+	// Custom the volume is exported over custom interface.
 	ExportProtocol_CUSTOM ExportProtocol = 4
 )
 
@@ -1521,7 +1521,7 @@ func (SdkCloudBackupOpType) EnumDescriptor() ([]byte, []int) {
 type SdkCloudBackupStatusType int32
 
 const (
-	// Unkonwn
+	// Unknown
 	SdkCloudBackupStatusType_SdkCloudBackupStatusTypeUnknown SdkCloudBackupStatusType = 0
 	// Not started
 	SdkCloudBackupStatusType_SdkCloudBackupStatusTypeNotStarted SdkCloudBackupStatusType = 1
@@ -2145,7 +2145,7 @@ const (
 	StorageNode_SECURED StorageNode_SecurityStatus = 2
 	// Node is secured, but in the process of removing security. This state allows
 	// other unsecured nodes to join the cluster since the cluster is in the process
-	// of removing secuirty authenticaiton and authorization.
+	// of removing security authentication and authorization.
 	StorageNode_SECURED_ALLOW_SECURITY_REMOVAL StorageNode_SecurityStatus = 3
 )
 
@@ -2390,7 +2390,7 @@ const (
 	// AbsolutePercent indicates absolute percent comparison.
 	// Example, 75 % used of capacity, or 50 % provisioned of capacity.
 	StorageRebalanceTriggerThreshold_ABSOLUTE_PERCENT StorageRebalanceTriggerThreshold_Type = 0
-	// DeltaMeanPercent indicates mean percent comparision threshold.
+	// DeltaMeanPercent indicates mean percent comparison threshold.
 	// Example, 10 % more than mean for cluster.
 	StorageRebalanceTriggerThreshold_DELTA_MEAN_PERCENT StorageRebalanceTriggerThreshold_Type = 1
 )
@@ -2991,7 +2991,7 @@ const (
 	// SDK version major value of this specification
 	SdkVersion_Major SdkVersion_Version = 0
 	// SDK version minor value of this specification
-	SdkVersion_Minor SdkVersion_Version = 137
+	SdkVersion_Minor SdkVersion_Version = 138
 	// SDK version patch value of this specification
 	SdkVersion_Patch SdkVersion_Version = 0
 )
@@ -3001,13 +3001,13 @@ var (
 	SdkVersion_Version_name = map[int32]string{
 		0: "MUST_HAVE_ZERO_VALUE",
 		// Duplicate value: 0: "Major",
-		137: "Minor",
+		138: "Minor",
 		// Duplicate value: 0: "Patch",
 	}
 	SdkVersion_Version_value = map[string]int32{
 		"MUST_HAVE_ZERO_VALUE": 0,
 		"Major":                0,
-		"Minor":                137,
+		"Minor":                138,
 		"Patch":                0,
 	}
 )
@@ -8171,7 +8171,7 @@ func (x *Stats) GetUniqueBlocks() uint64 {
 
 // Provides details on exclusive and shared storage used by
 // snapshot/volume specifically for copy-on-write(COW) snapshots. Deletion
-// of snapshots and overwirte of volume will affect the exclusive storage
+// of snapshots and overwrite of volume will affect the exclusive storage
 // used by the other dependent snaps and parent volume.
 type CapacityUsageInfo struct {
 	state         protoimpl.MessageState
@@ -8626,11 +8626,11 @@ type Alert struct {
 	AlertType int64 `protobuf:"varint,3,opt,name=alert_type,json=alertType,proto3" json:"alert_type,omitempty"`
 	// Message describing the Alert
 	Message string `protobuf:"bytes,4,opt,name=message,proto3" json:"message,omitempty"`
-	//Timestamp when Alert occured
+	//Timestamp when Alert occurred
 	Timestamp *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=timestamp,proto3" json:"timestamp,omitempty"`
-	// ResourceId where Alert occured
+	// ResourceId where Alert occurred
 	ResourceId string `protobuf:"bytes,6,opt,name=resource_id,json=resourceId,proto3" json:"resource_id,omitempty"`
-	// Resource where Alert occured
+	// Resource where Alert occurred
 	Resource ResourceType `protobuf:"varint,7,opt,name=resource,proto3,enum=openstorage.api.ResourceType" json:"resource,omitempty"`
 	// Cleared Flag
 	Cleared bool `protobuf:"varint,8,opt,name=cleared,proto3" json:"cleared,omitempty"`
@@ -8766,9 +8766,9 @@ type SdkAlertsTimeSpan struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//Start timestamp when Alert occured
+	//Start timestamp when Alert occurred
 	StartTime *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=start_time,json=startTime,proto3" json:"start_time,omitempty"`
-	//End timestamp when Alert occured
+	//End timestamp when Alert occurred
 	EndTime *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=end_time,json=endTime,proto3" json:"end_time,omitempty"`
 }
 
@@ -15330,7 +15330,7 @@ func (*SdkVolumeUpdateResponse) Descriptor() ([]byte, []int) {
 	return file_api_api_proto_rawDescGZIP(), []int{149}
 }
 
-// Defines a request to retreive volume statistics
+// Defines a request to retrieve volume statistics
 type SdkVolumeStatsRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -20410,7 +20410,7 @@ type SdkCloudBackupCreateRequest struct {
 	// Labels are list of key value pairs to tag the cloud backup. These labels
 	// are stored in the metadata associated with the backup.
 	Labels map[string]string `protobuf:"bytes,5,rep,name=labels,proto3" json:"labels,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	// FullBackupFrequency indicates number of incremental backup after whcih
+	// FullBackupFrequency indicates number of incremental backup after which
 	// a fullbackup must be created. This is to override the default value for
 	// manual/user triggerred backups and not applicable for scheduled backups
 	// Value of 0 retains the default behavior.
@@ -21552,7 +21552,7 @@ func (x *SdkCloudBackupStatus) GetGroupId() string {
 	return ""
 }
 
-// Defines a request to retreive the status of a backup or restore for a
+// Defines a request to retrieve the status of a backup or restore for a
 // specified volume
 type SdkCloudBackupStatusRequest struct {
 	state         protoimpl.MessageState
@@ -21849,7 +21849,7 @@ func (x *SdkCloudBackupHistoryItem) GetStatus() SdkCloudBackupStatusType {
 	return SdkCloudBackupStatusType_SdkCloudBackupStatusTypeUnknown
 }
 
-// Defines a request to retreive the history of the backups for
+// Defines a request to retrieve the history of the backups for
 // a specific volume to a cloud provider
 type SdkCloudBackupHistoryRequest struct {
 	state         protoimpl.MessageState
@@ -24257,13 +24257,13 @@ func (*SdkIdentityCapabilitiesRequest) Descriptor() ([]byte, []int) {
 	return file_api_api_proto_rawDescGZIP(), []int{304}
 }
 
-// Defines a response containing the capabilites of the cluster
+// Defines a response containing the capabilities of the cluster
 type SdkIdentityCapabilitiesResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Provides all the capabilites supported by the cluster
+	// Provides all the capabilities supported by the cluster
 	Capabilities []*SdkServiceCapability `protobuf:"bytes,1,rep,name=capabilities,proto3" json:"capabilities,omitempty"`
 }
 
@@ -26431,7 +26431,7 @@ func (x *SdkClusterPairInspectRequest) GetId() string {
 	return ""
 }
 
-// Reponse to get a cluster pair
+// Response to get a cluster pair
 type ClusterPairGetResponse struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -31340,7 +31340,7 @@ var file_api_api_proto_rawDesc = []byte{
 	0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x18, 0x0a, 0x14, 0x4d, 0x55, 0x53, 0x54, 0x5f, 0x48,
 	0x41, 0x56, 0x45, 0x5f, 0x5a, 0x45, 0x52, 0x4f, 0x5f, 0x56, 0x41, 0x4c, 0x55, 0x45, 0x10, 0x00,
 	0x12, 0x09, 0x0a, 0x05, 0x4d, 0x61, 0x6a, 0x6f, 0x72, 0x10, 0x00, 0x12, 0x0a, 0x0a, 0x05, 0x4d,
-	0x69, 0x6e, 0x6f, 0x72, 0x10, 0x89, 0x01, 0x12, 0x09, 0x0a, 0x05, 0x50, 0x61, 0x74, 0x63, 0x68,
+	0x69, 0x6e, 0x6f, 0x72, 0x10, 0x8a, 0x01, 0x12, 0x09, 0x0a, 0x05, 0x50, 0x61, 0x74, 0x63, 0x68,
 	0x10, 0x00, 0x1a, 0x02, 0x10, 0x01, 0x22, 0xc6, 0x01, 0x0a, 0x0e, 0x53, 0x74, 0x6f, 0x72, 0x61,
 	0x67, 0x65, 0x56, 0x65, 0x72, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x16, 0x0a, 0x06, 0x64, 0x72, 0x69,
 	0x76, 0x65, 0x72, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x06, 0x64, 0x72, 0x69, 0x76, 0x65,
@@ -38895,7 +38895,7 @@ type OpenStorageAlertsClient interface {
 	//
 	// #### Input
 	// SdkAlertsEnumerateRequest takes a list of such queries and the returned
-	// output is a collective ouput from each of these queries. In that sense,
+	// output is a collective output from each of these queries. In that sense,
 	// the filtering of these queries has a behavior of OR operation.
 	// Each query also has a list of optional options. These options allow
 	// narrowing down the scope of alerts search. These options have a
@@ -38990,7 +38990,7 @@ type OpenStorageAlertsServer interface {
 	//
 	// #### Input
 	// SdkAlertsEnumerateRequest takes a list of such queries and the returned
-	// output is a collective ouput from each of these queries. In that sense,
+	// output is a collective output from each of these queries. In that sense,
 	// the filtering of these queries has a behavior of OR operation.
 	// Each query also has a list of optional options. These options allow
 	// narrowing down the scope of alerts search. These options have a
@@ -41321,7 +41321,7 @@ type OpenStorageVolumeClient interface {
 	SnapshotEnumerate(ctx context.Context, in *SdkVolumeSnapshotEnumerateRequest, opts ...grpc.CallOption) (*SdkVolumeSnapshotEnumerateResponse, error)
 	// SnapshotEnumerate returns a list of snapshots.
 	// To filter all the snapshots for a specific volume which may no longer exist,
-	// specifiy a volume id.
+	// specify a volume id.
 	// Labels can also be used to filter the snapshot list.
 	// If neither are provided all snapshots will be returned.
 	SnapshotEnumerateWithFilters(ctx context.Context, in *SdkVolumeSnapshotEnumerateWithFiltersRequest, opts ...grpc.CallOption) (*SdkVolumeSnapshotEnumerateWithFiltersResponse, error)
@@ -41567,7 +41567,7 @@ type OpenStorageVolumeServer interface {
 	SnapshotEnumerate(context.Context, *SdkVolumeSnapshotEnumerateRequest) (*SdkVolumeSnapshotEnumerateResponse, error)
 	// SnapshotEnumerate returns a list of snapshots.
 	// To filter all the snapshots for a specific volume which may no longer exist,
-	// specifiy a volume id.
+	// specify a volume id.
 	// Labels can also be used to filter the snapshot list.
 	// If neither are provided all snapshots will be returned.
 	SnapshotEnumerateWithFilters(context.Context, *SdkVolumeSnapshotEnumerateWithFiltersRequest) (*SdkVolumeSnapshotEnumerateWithFiltersResponse, error)

--- a/api/api.proto
+++ b/api/api.proto
@@ -342,13 +342,13 @@ message Xattr {
 enum ExportProtocol  {
   // Invalid uninitialized value
   INVALID = 0;
-  // PXD the volume is exported over Portworx block interace.
+  // PXD the volume is exported over Portworx block interface.
   PXD = 1;
   // ISCSI the volume is exported over ISCSI.
   ISCSI = 2;
   // NFS the volume is exported over NFS.
   NFS = 3;
-  // Custom the volume is exported over custom interace.
+  // Custom the volume is exported over custom interface.
   CUSTOM = 4;
 }
 
@@ -1032,7 +1032,7 @@ message Stats {
 
 // Provides details on exclusive and shared storage used by
 // snapshot/volume specifically for copy-on-write(COW) snapshots. Deletion
-// of snapshots and overwirte of volume will affect the exclusive storage
+// of snapshots and overwrite of volume will affect the exclusive storage
 // used by the other dependent snaps and parent volume.
 message CapacityUsageInfo {
   // Storage consumed exclusively by this single snapshot. Deletion of this
@@ -1120,11 +1120,11 @@ message Alert {
   int64 alert_type = 3;
   // Message describing the Alert
   string message = 4;
-  //Timestamp when Alert occured
+  //Timestamp when Alert occurred
   google.protobuf.Timestamp timestamp = 5;
-  // ResourceId where Alert occured
+  // ResourceId where Alert occurred
   string resource_id = 6;
-  // Resource where Alert occured
+  // Resource where Alert occurred
   ResourceType resource = 7;
   // Cleared Flag
   bool cleared = 8;
@@ -1140,9 +1140,9 @@ message Alert {
 
 // SdkAlertsTimeSpan to store time window information.
 message SdkAlertsTimeSpan {
-    //Start timestamp when Alert occured
+    //Start timestamp when Alert occurred
     google.protobuf.Timestamp start_time = 1;
-    //End timestamp when Alert occured
+    //End timestamp when Alert occurred
     google.protobuf.Timestamp end_time = 2;
 }
 
@@ -1250,7 +1250,7 @@ service OpenStorageAlerts {
     //
     // #### Input
     // SdkAlertsEnumerateRequest takes a list of such queries and the returned
-    // output is a collective ouput from each of these queries. In that sense,
+    // output is a collective output from each of these queries. In that sense,
     // the filtering of these queries has a behavior of OR operation.
     // Each query also has a list of optional options. These options allow
     // narrowing down the scope of alerts search. These options have a
@@ -1533,7 +1533,7 @@ message StorageNode {
     SECURED = 2;
     // Node is secured, but in the process of removing security. This state allows
     // other unsecured nodes to join the cluster since the cluster is in the process
-    // of removing secuirty authenticaiton and authorization.
+    // of removing security authentication and authorization.
     SECURED_ALLOW_SECURITY_REMOVAL = 3;
   }
 
@@ -2274,7 +2274,7 @@ service OpenStorageVolume {
 
   // SnapshotEnumerate returns a list of snapshots.
   // To filter all the snapshots for a specific volume which may no longer exist,
-  // specifiy a volume id.
+  // specify a volume id.
   // Labels can also be used to filter the snapshot list.
   // If neither are provided all snapshots will be returned.
   rpc SnapshotEnumerateWithFilters(SdkVolumeSnapshotEnumerateWithFiltersRequest)
@@ -3405,7 +3405,7 @@ message SdkVolumeUpdateRequest {
 message SdkVolumeUpdateResponse {
 }
 
-// Defines a request to retreive volume statistics
+// Defines a request to retrieve volume statistics
 message SdkVolumeStatsRequest {
   // Id of the volume to get statistics
   string volume_id = 1;
@@ -3956,7 +3956,7 @@ message StorageRebalanceTriggerThreshold {
     // AbsolutePercent indicates absolute percent comparison.
     // Example, 75 % used of capacity, or 50 % provisioned of capacity.
     ABSOLUTE_PERCENT = 0;
-    // DeltaMeanPercent indicates mean percent comparision threshold.
+    // DeltaMeanPercent indicates mean percent comparison threshold.
     // Example, 10 % more than mean for cluster.
     DELTA_MEAN_PERCENT = 1;
   }
@@ -4258,7 +4258,7 @@ message SdkCloudBackupCreateRequest {
   // Labels are list of key value pairs to tag the cloud backup. These labels
   // are stored in the metadata associated with the backup.
   map<string, string> labels = 5;
-  // FullBackupFrequency indicates number of incremental backup after whcih
+  // FullBackupFrequency indicates number of incremental backup after which
   // a fullbackup must be created. This is to override the default value for
   // manual/user triggerred backups and not applicable for scheduled backups
   // Value of 0 retains the default behavior.
@@ -4454,7 +4454,7 @@ enum SdkCloudBackupOpType {
 
 // CloudBackup status types
 enum SdkCloudBackupStatusType {
-  // Unkonwn
+  // Unknown
   SdkCloudBackupStatusTypeUnknown = 0;
   // Not started
   SdkCloudBackupStatusTypeNotStarted = 1;
@@ -4508,7 +4508,7 @@ message SdkCloudBackupStatus {
   string group_id = 13;
 }
 
-// Defines a request to retreive the status of a backup or restore for a
+// Defines a request to retrieve the status of a backup or restore for a
 // specified volume
 message SdkCloudBackupStatusRequest {
   // (optional) VolumeId is a value which is used to get information on the
@@ -4555,7 +4555,7 @@ message SdkCloudBackupHistoryItem {
   SdkCloudBackupStatusType status = 3;
 }
 
-// Defines a request to retreive the history of the backups for
+// Defines a request to retrieve the history of the backups for
 // a specific volume to a cloud provider
 message SdkCloudBackupHistoryRequest {
   // This optional value defines which history of backups is being
@@ -4971,9 +4971,9 @@ message SdkFilesystemCheckStopResponse{
 message SdkIdentityCapabilitiesRequest {
 }
 
-// Defines a response containing the capabilites of the cluster
+// Defines a response containing the capabilities of the cluster
 message SdkIdentityCapabilitiesResponse {
-  // Provides all the capabilites supported by the cluster
+  // Provides all the capabilities supported by the cluster
   repeated SdkServiceCapability capabilities = 1;
 }
 
@@ -5391,7 +5391,7 @@ message SdkClusterPairInspectRequest{
     string id = 1;
 }
 
-// Reponse to get a cluster pair
+// Response to get a cluster pair
 message ClusterPairGetResponse {
     // Info about the cluster pair
     ClusterPairInfo pair_info = 1;

--- a/api/api.proto
+++ b/api/api.proto
@@ -5053,7 +5053,7 @@ message SdkVersion {
     // SDK version major value of this specification
     Major = 0;
     // SDK version minor value of this specification
-    Minor = 137;
+    Minor = 138;
     // SDK version patch value of this specification
     Patch = 0;
   }

--- a/api/client/volume/client.go
+++ b/api/client/volume/client.go
@@ -733,7 +733,7 @@ func (v *volumeClient) CloudBackupHistory(
 }
 
 // CloudBackupState allows a current backup
-// state transisions(pause/resume/stop)
+// state transitions(pause/resume/stop)
 func (v *volumeClient) CloudBackupStateChange(
 	input *api.CloudBackupStateChangeRequest,
 ) error {

--- a/api/server/cluster_test.go
+++ b/api/server/cluster_test.go
@@ -249,7 +249,7 @@ func TestClusterNodeStatusSuccess(t *testing.T) {
 	restClient, err := clusterclient.NewClusterClient(ts.URL, "v1")
 	assert.NoError(t, err)
 
-	// Set expections
+	// Set exceptions
 	tc.MockCluster().
 		EXPECT().
 		NodeStatus().
@@ -588,7 +588,7 @@ func TestClusterNodeStatusFailed(t *testing.T) {
 	restClient, err := clusterclient.NewClusterClient(ts.URL, "v1")
 	assert.NoError(t, err)
 
-	// Set expections
+	// Set exceptions
 	tc.MockCluster().
 		EXPECT().
 		NodeStatus().

--- a/api/server/middleware_auth.go
+++ b/api/server/middleware_auth.go
@@ -491,7 +491,7 @@ func (a *authMiddleware) parseSecret(
 }
 
 func parseSecretFromLabels(specLabels, locatorLabels map[string]string) (*api.TokenSecretContext, error) {
-	// Locator labels take precendence
+	// Locator labels take precedence
 	secretName := locatorLabels[osecrets.SecretNameKey]
 	secretNamespace := locatorLabels[osecrets.SecretNamespaceKey]
 	if secretName == "" {

--- a/api/server/schedpolicy_test.go
+++ b/api/server/schedpolicy_test.go
@@ -149,7 +149,7 @@ func TestSchedPolicyDeleteWithCaseSensitiveName(t *testing.T) {
 
 	name := "TestSchedPolicy1"
 	// mock the cluster schedulePolicy response
-	// this should be recived it as "TestSchedPolicy1" only
+	// this should be received it as "TestSchedPolicy1" only
 	tc.MockCluster().
 		EXPECT().
 		SchedPolicyDelete(name).

--- a/api/server/sdk/api/api.swagger.json
+++ b/api/server/sdk/api/api.swagger.json
@@ -212,7 +212,7 @@
       },
       "StorageNodeSecurityStatus": {
         "default": "UNSPECIFIED",
-        "description": " - UNSPECIFIED: Security status type is unknown\n - UNSECURED: Node is unsecure\n - SECURED: Node is secured with authentication and authorization\n - SECURED_ALLOW_SECURITY_REMOVAL: Node is secured, but in the process of removing security. This state allows\nother unsecured nodes to join the cluster since the cluster is in the process\nof removing secuirty authenticaiton and authorization.",
+        "description": " - UNSPECIFIED: Security status type is unknown\n - UNSECURED: Node is unsecure\n - SECURED: Node is secured with authentication and authorization\n - SECURED_ALLOW_SECURITY_REMOVAL: Node is secured, but in the process of removing security. This state allows\nother unsecured nodes to join the cluster since the cluster is in the process\nof removing security authentication and authorization.",
         "enum": [
           "UNSPECIFIED",
           "UNSECURED",
@@ -286,7 +286,7 @@
             "$ref": "#/components/schemas/apiResourceType"
           },
           "resource_id": {
-            "title": "ResourceId where Alert occured",
+            "title": "ResourceId where Alert occurred",
             "type": "string"
           },
           "severity": {
@@ -294,7 +294,7 @@
           },
           "timestamp": {
             "format": "date-time",
-            "title": "Timestamp when Alert occured",
+            "title": "Timestamp when Alert occurred",
             "type": "string"
           },
           "ttl": {
@@ -321,7 +321,7 @@
         "type": "string"
       },
       "apiCapacityUsageInfo": {
-        "description": "Provides details on exclusive and shared storage used by\nsnapshot/volume specifically for copy-on-write(COW) snapshots. Deletion\nof snapshots and overwirte of volume will affect the exclusive storage\nused by the other dependent snaps and parent volume.",
+        "description": "Provides details on exclusive and shared storage used by\nsnapshot/volume specifically for copy-on-write(COW) snapshots. Deletion\nof snapshots and overwrite of volume will affect the exclusive storage\nused by the other dependent snaps and parent volume.",
         "properties": {
           "exclusive_bytes": {
             "description": "Storage consumed exclusively by this single snapshot. Deletion of this\nsnapshot may increase the free storage available by this amount.",
@@ -593,7 +593,7 @@
             "$ref": "#/components/schemas/apiClusterPairInfo"
           }
         },
-        "title": "Reponse to get a cluster pair",
+        "title": "Response to get a cluster pair",
         "type": "object"
       },
       "apiClusterPairInfo": {
@@ -797,7 +797,7 @@
       },
       "apiExportProtocol": {
         "default": "INVALID",
-        "description": "ExportProtocol defines how the device is exported..\n\n - INVALID: Invalid uninitialized value\n - PXD: PXD the volume is exported over Portworx block interace.\n - ISCSI: ISCSI the volume is exported over ISCSI.\n - NFS: NFS the volume is exported over NFS.\n - CUSTOM: Custom the volume is exported over custom interace.",
+        "description": "ExportProtocol defines how the device is exported..\n\n - INVALID: Invalid uninitialized value\n - PXD: PXD the volume is exported over Portworx block interface.\n - ISCSI: ISCSI the volume is exported over ISCSI.\n - NFS: NFS the volume is exported over NFS.\n - CUSTOM: Custom the volume is exported over custom interface.",
         "enum": [
           "INVALID",
           "PXD",
@@ -1782,12 +1782,12 @@
         "properties": {
           "end_time": {
             "format": "date-time",
-            "title": "End timestamp when Alert occured",
+            "title": "End timestamp when Alert occurred",
             "type": "string"
           },
           "start_time": {
             "format": "date-time",
-            "title": "Start timestamp when Alert occured",
+            "title": "Start timestamp when Alert occurred",
             "type": "string"
           }
         },
@@ -1964,7 +1964,7 @@
             "type": "boolean"
           },
           "full_backup_frequency": {
-            "description": "FullBackupFrequency indicates number of incremental backup after whcih\na fullbackup must be created. This is to override the default value for\nmanual/user triggerred backups and not applicable for scheduled backups\nValue of 0 retains the default behavior.",
+            "description": "FullBackupFrequency indicates number of incremental backup after which\na fullbackup must be created. This is to override the default value for\nmanual/user triggerred backups and not applicable for scheduled backups\nValue of 0 retains the default behavior.",
             "format": "int64",
             "type": "integer"
           },
@@ -2483,7 +2483,7 @@
             "type": "string"
           }
         },
-        "title": "Defines a request to retreive the status of a backup or restore for a\nspecified volume",
+        "title": "Defines a request to retrieve the status of a backup or restore for a\nspecified volume",
         "type": "object"
       },
       "apiSdkCloudBackupStatusResponse": {
@@ -2501,7 +2501,7 @@
       },
       "apiSdkCloudBackupStatusType": {
         "default": "SdkCloudBackupStatusTypeUnknown",
-        "description": "- SdkCloudBackupStatusTypeUnknown: Unkonwn\n - SdkCloudBackupStatusTypeNotStarted: Not started\n - SdkCloudBackupStatusTypeDone: Done\n - SdkCloudBackupStatusTypeAborted: Aborted\n - SdkCloudBackupStatusTypePaused: Paused\n - SdkCloudBackupStatusTypeStopped: Stopped\n - SdkCloudBackupStatusTypeActive: Active\n - SdkCloudBackupStatusTypeFailed: Failed\n - SdkCloudBackupStatusTypeQueued: Queued\n - SdkCloudBackupStatusTypeInvalid: Invalid, used by enumerate, includes failed,\nstopped and aborted",
+        "description": "- SdkCloudBackupStatusTypeUnknown: Unknown\n - SdkCloudBackupStatusTypeNotStarted: Not started\n - SdkCloudBackupStatusTypeDone: Done\n - SdkCloudBackupStatusTypeAborted: Aborted\n - SdkCloudBackupStatusTypePaused: Paused\n - SdkCloudBackupStatusTypeStopped: Stopped\n - SdkCloudBackupStatusTypeActive: Active\n - SdkCloudBackupStatusTypeFailed: Failed\n - SdkCloudBackupStatusTypeQueued: Queued\n - SdkCloudBackupStatusTypeInvalid: Invalid, used by enumerate, includes failed,\nstopped and aborted",
         "enum": [
           "SdkCloudBackupStatusTypeUnknown",
           "SdkCloudBackupStatusTypeNotStarted",
@@ -3054,11 +3054,11 @@
             "items": {
               "$ref": "#/components/schemas/apiSdkServiceCapability"
             },
-            "title": "Provides all the capabilites supported by the cluster",
+            "title": "Provides all the capabilities supported by the cluster",
             "type": "array"
           }
         },
-        "title": "Defines a response containing the capabilites of the cluster",
+        "title": "Defines a response containing the capabilities of the cluster",
         "type": "object"
       },
       "apiSdkIdentityVersionResponse": {
@@ -4712,7 +4712,7 @@
       },
       "apiStorageRebalanceTriggerThresholdType": {
         "default": "ABSOLUTE_PERCENT",
-        "description": "- ABSOLUTE_PERCENT: AbsolutePercent indicates absolute percent comparison.\nExample, 75 % used of capacity, or 50 % provisioned of capacity.\n - DELTA_MEAN_PERCENT: DeltaMeanPercent indicates mean percent comparision threshold.\nExample, 10 % more than mean for cluster.",
+        "description": "- ABSOLUTE_PERCENT: AbsolutePercent indicates absolute percent comparison.\nExample, 75 % used of capacity, or 50 % provisioned of capacity.\n - DELTA_MEAN_PERCENT: DeltaMeanPercent indicates mean percent comparison threshold.\nExample, 10 % more than mean for cluster.",
         "enum": [
           "ABSOLUTE_PERCENT",
           "DELTA_MEAN_PERCENT"
@@ -5714,7 +5714,7 @@
   },
   "info": {
     "title": "OpenStorage SDK",
-    "version": "0.137.0"
+    "version": "0.138.0"
   },
   "openapi": "3.0.0",
   "paths": {
@@ -5762,7 +5762,7 @@
     },
     "/v1/alerts/filters": {
       "post": {
-        "description": "EnumerateWithFilters allows 3 different types of queries as defined below:\n\n* Query that takes only resource type as input\n* Query that takes resource type and alert type as input and\n* Query that takes resource id, alert type and resource type as input.\n\n#### Input\nSdkAlertsEnumerateRequest takes a list of such queries and the returned\noutput is a collective ouput from each of these queries. In that sense,\nthe filtering of these queries has a behavior of OR operation.\nEach query also has a list of optional options. These options allow\nnarrowing down the scope of alerts search. These options have a\nbehavior of an AND operation.\n\n#### Examples\nTo search by a resource type in a given time window would require\ninitializing SdkAlertsResourceTypeQuery query and pass in\nSdkAlertsTimeSpan option into SdkAlertsQuery struct and finally\npacking any other such queries into SdkAlertsEnumerateRequest object.\nAlternatively, to search by both resource type and alert type, use\nSdkAlertsAlertTypeQuery as query builder.\nFinally to search all alerts of a given resource type and some\nalerts of another resource type but with specific alert type,\nuse two queries, first initialized with SdkAlertsResourceTypeQuery\nand second initialized with SdkAlertsAlertTypeQuery and both\neventually packed as list in SdkAlertsEnumerateRequest.",
+        "description": "EnumerateWithFilters allows 3 different types of queries as defined below:\n\n* Query that takes only resource type as input\n* Query that takes resource type and alert type as input and\n* Query that takes resource id, alert type and resource type as input.\n\n#### Input\nSdkAlertsEnumerateRequest takes a list of such queries and the returned\noutput is a collective output from each of these queries. In that sense,\nthe filtering of these queries has a behavior of OR operation.\nEach query also has a list of optional options. These options allow\nnarrowing down the scope of alerts search. These options have a\nbehavior of an AND operation.\n\n#### Examples\nTo search by a resource type in a given time window would require\ninitializing SdkAlertsResourceTypeQuery query and pass in\nSdkAlertsTimeSpan option into SdkAlertsQuery struct and finally\npacking any other such queries into SdkAlertsEnumerateRequest object.\nAlternatively, to search by both resource type and alert type, use\nSdkAlertsAlertTypeQuery as query builder.\nFinally to search all alerts of a given resource type and some\nalerts of another resource type but with specific alert type,\nuse two queries, first initialized with SdkAlertsResourceTypeQuery\nand second initialized with SdkAlertsAlertTypeQuery and both\neventually packed as list in SdkAlertsEnumerateRequest.",
         "operationId": "OpenStorageAlerts_EnumerateWithFilters",
         "requestBody": {
           "content": {
@@ -9890,7 +9890,7 @@
             "description": "An unexpected error response."
           }
         },
-        "summary": "SnapshotEnumerate returns a list of snapshots.\nTo filter all the snapshots for a specific volume which may no longer exist,\nspecifiy a volume id.\nLabels can also be used to filter the snapshot list.\nIf neither are provided all snapshots will be returned.",
+        "summary": "SnapshotEnumerate returns a list of snapshots.\nTo filter all the snapshots for a specific volume which may no longer exist,\nspecify a volume id.\nLabels can also be used to filter the snapshot list.\nIf neither are provided all snapshots will be returned.",
         "tags": [
           "OpenStorageVolume"
         ]

--- a/api/server/sdk/credentials.go
+++ b/api/server/sdk/credentials.go
@@ -535,7 +535,7 @@ func (s *CredentialServer) getOwnershipFromCred(cred interface{}) (*api.Ownershi
 		if err != nil {
 			return nil, status.Errorf(
 				codes.Internal,
-				"Failed to retreive ownership from credential object: %v", err)
+				"Failed to retrieve ownership from credential object: %v", err)
 		}
 	}
 	return ownership, nil

--- a/api/server/sdk/utils.go
+++ b/api/server/sdk/utils.go
@@ -218,7 +218,7 @@ func retainInternalSpecYamlByteToSdkSched(
 	var specs []sched.RetainIntervalSpec
 	err := yaml.Unmarshal(in, &specs)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Failed to retreive schedule: %v", err)
+		return nil, status.Errorf(codes.Internal, "Failed to retrieve schedule: %v", err)
 	}
 
 	// Convert each one to Sdk messages

--- a/api/server/secrets.go
+++ b/api/server/secrets.go
@@ -199,7 +199,7 @@ func (c *clusterApi) setSecret(w http.ResponseWriter, r *http.Request) {
 // parameters:
 // - name: id
 //   in: query
-//   description: secret id/key whose value to be retrived
+//   description: secret id/key whose value to be retrieved
 //   type: string
 //   required: true
 // responses:

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -33,7 +33,7 @@ var (
 	ErrNodeRemovePending = errors.New("Node remove is pending")
 	ErrInitNodeNotFound  = errors.New("This node is already initialized but " +
 		"could not be found in the cluster map.")
-	ErrNodeDecommissioned   = errors.New("Node is decomissioned.")
+	ErrNodeDecommissioned   = errors.New("Node is decommissioned.")
 	ErrRemoveCausesDataLoss = errors.New("Cannot remove node without data loss")
 	ErrNotImplemented       = errors.New("Not Implemented")
 )

--- a/cluster/manager/pair.go
+++ b/cluster/manager/pair.go
@@ -180,7 +180,7 @@ func (c *ClusterManager) RefreshPair(
 			Token:            pair.Token,
 		}
 		// Use original options and override with updates ones. This
-		// prevents any options we created locally from getting overriden
+		// prevents any options we created locally from getting overridden
 		pairInfo.Options = pair.Options
 		for k, v := range resp.Options {
 			pairInfo.Options[k] = v
@@ -419,7 +419,7 @@ func pairCreate(info *api.ClusterPairInfo, setDefault bool) error {
 
 	defaultId, err := getDefaultPairId()
 	// Set this pair as the default if no default is set or it has
-	// explicilty been asked
+	// explicitly been asked
 	if setDefault || err == kvdb.ErrNotFound || defaultId == "" {
 		err = setDefaultPairId(info.Id)
 		if err != nil {

--- a/csi/controller.go
+++ b/csi/controller.go
@@ -741,7 +741,7 @@ func isFilesystemSpecSet(params map[string]string) bool {
 
 // resolveSharedSpec makes the following assumptions:
 // 1. When a volume is set to RWX or a similar multi-node access mode, we default to Sharedv4
-// 2. If a user prefers shared over sharedv4, they may still use it by explicity declaring "shared": true
+// 2. If a user prefers shared over sharedv4, they may still use it by explicitly declaring "shared": true
 func resolveSharedSpec(spec *api.VolumeSpec, req *csi.CreateVolumeRequest) (*api.VolumeSpec, error) {
 	// shared or sharedv4 parameter doesn't apply to pure backends so don't set them
 	if spec.IsPureVolume() {

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -2379,7 +2379,7 @@ func TestControllerCreateVolumeWithTopology(t *testing.T) {
 	assert.Nil(t, r)
 
 	// TestCase: Pure volume and topology requirement present.
-	// This tests mulitple things -
+	// This tests multiple things -
 	// - Multiple topologies are sent by the provisioner in both preferred and requisite sections
 	// - Topologies are de-duped from the requirement
 	// - Retry volume creation only if the create fails because of topology placement

--- a/docs/dev-driver.md
+++ b/docs/dev-driver.md
@@ -12,9 +12,9 @@ library and the community and you will try to keep it up to date.
 
 Adding a driver is fairly straightforward:
 
-1. Add your driver decleration in `volumes/drivers.go`
+1. Add your driver declaration in `volumes/drivers.go`
 2. Add your driver `mydriver` implementation in the `volumes/drivers/mydriver` directory.  The driver must implement the `VolumeDriver` interface specified in [`volumes/volume.go`](https://github.com/libopenstorage/openstorage/blob/master/volume/volume.go).  This interface is an implementation of the specification available at [api.openstorage.org](http://api.openstorage.org/).
-3. You're driver must be a `File Volume` driver or a `Block Volume` driver.  A `File Volume` driver will not implement a few low level primatives, such as `Format`, `Attach` and `Detach`.
+3. You're driver must be a `File Volume` driver or a `Block Volume` driver.  A `File Volume` driver will not implement a few low level primitives, such as `Format`, `Attach` and `Detach`.
 
 Here is an example of `drivers.go`:
 

--- a/graph/drivers/chainfs/README.md
+++ b/graph/drivers/chainfs/README.md
@@ -26,7 +26,7 @@ Note that the `chainfs.volume_driver` parameter will indicate the actual volume 
 
 ### Building
 
-#### Installing Dependancies
+#### Installing Dependencies
 1. Make sure you have `fuse` installed.
 2. Make sure you have `libchainfs` installed.  Visit https://github.com/libopenstorage/chainfs to obtain `libchainfs`.
 

--- a/pkg/keylock/keylock.go
+++ b/pkg/keylock/keylock.go
@@ -39,7 +39,7 @@ type KeyLock interface {
 	Dump() []string
 }
 
-// LockHandle is an opaque handle to an aquired lock.
+// LockHandle is an opaque handle to an acquired lock.
 type LockHandle struct {
 	id     string
 	genNum int64

--- a/pkg/role/sdkserviceapi.go
+++ b/pkg/role/sdkserviceapi.go
@@ -445,7 +445,7 @@ func VerifyRules(rules []*api.SdkRule, rootPath, fullmethod string) error {
 		}
 	}
 
-	return fmt.Errorf("no accessable rule to authorize access found")
+	return fmt.Errorf("no accessible rule to authorize access found")
 }
 
 func (r *SdkRoleManager) validateRole(role *api.SdkRole) error {

--- a/pkg/sanity/backup_restore.go
+++ b/pkg/sanity/backup_restore.go
@@ -265,7 +265,7 @@ var _ = Describe("Volume [Backup Restore Tests]", func() {
 				Expect(str).NotTo(BeNil())
 
 				_, err = volumedriver.CloudBackupCreate(bkpReq)
-				Expect(err).To(BeNil()) // give 3 attempts for backup to be successfull before declaring failed
+				Expect(err).To(BeNil()) // give 3 attempts for backup to be successful before declaring failed
 
 				By("Checking backup status")
 

--- a/pkg/sanity/cluster.go
+++ b/pkg/sanity/cluster.go
@@ -182,7 +182,7 @@ var _ = Describe("Cluster [Cluster Tests]", func() {
 					noOfOccurence++
 				}
 			}
-			// No of occurence should be 2  [one for create and one for delete]
+			// No of occurrence should be 2  [one for create and one for delete]
 			Expect(noOfOccurence).To(BeEquivalentTo(2))
 		})
 

--- a/pkg/sched/intervals.go
+++ b/pkg/sched/intervals.go
@@ -29,7 +29,7 @@ var (
 	speedUp = false
 )
 
-// SpeedUp advances teh clock faster for tests.
+// SpeedUp advances the clock faster for tests.
 func SpeedUp() {
 	speedUp = true
 }

--- a/pkg/sched/sched.go
+++ b/pkg/sched/sched.go
@@ -60,7 +60,7 @@ type taskInfo struct {
 
 type manager struct {
 	sync.Mutex
-	// minimumInterval defines minumum task scheduling interval
+	// minimumInterval defines minimum task scheduling interval
 	minimumInterval time.Duration
 	// tasks is list of scheduled tasks
 	tasks *list.List

--- a/pkg/storagepolicy/sdkstoragepolicy.go
+++ b/pkg/storagepolicy/sdkstoragepolicy.go
@@ -229,7 +229,7 @@ func (p *SdkPolicyManager) Delete(
 	return &api.SdkOpenStoragePolicyDeleteResponse{}, nil
 }
 
-// Inspect storage policy specifed by name
+// Inspect storage policy specified by name
 func (p *SdkPolicyManager) Inspect(
 	ctx context.Context,
 	req *api.SdkOpenStoragePolicyInspectRequest,

--- a/pkg/storagepolicy/sdkstoragepolicy_test.go
+++ b/pkg/storagepolicy/sdkstoragepolicy_test.go
@@ -289,7 +289,7 @@ func TestSdkStoragePolicyUpdateBadArgument(t *testing.T) {
 
 	updateReq = &api.SdkOpenStoragePolicyUpdateRequest{
 		StoragePolicy: &api.SdkStoragePolicy{
-			Name:   "non-existant-key",
+			Name:   "non-existent-key",
 			Policy: volSpec,
 		},
 	}

--- a/secrets/secrets.go
+++ b/secrets/secrets.go
@@ -7,7 +7,7 @@ import (
 var (
 	// ErrNotImplemented default secrets in OSD
 	ErrNotImplemented = errors.New("Not Implemented")
-	// ErrKeyEmpty returned when the secrety key provided is empty
+	// ErrKeyEmpty returned when the secretly key provided is empty
 	ErrKeyEmpty = errors.New("Secret key cannot be empty")
 	// ErrNotAuthenticated returned when not authenticated with secrets endpoint
 	ErrNotAuthenticated = errors.New("Not authenticated with the secrets endpoint")

--- a/volume/drivers/fake/fake.go
+++ b/volume/drivers/fake/fake.go
@@ -824,7 +824,7 @@ func (d *driver) CloudBackupHistory(input *api.CloudBackupHistoryRequest) (*api.
 	}, nil
 }
 
-// CloudBackupStateChange allows a current backup state transisions(pause/resume/stop)
+// CloudBackupStateChange allows a current backup state transitions(pause/resume/stop)
 func (d *driver) CloudBackupStateChange(input *api.CloudBackupStateChangeRequest) error {
 
 	if len(input.Name) == 0 {

--- a/volume/drivers/pwx/connection.go
+++ b/volume/drivers/pwx/connection.go
@@ -220,11 +220,11 @@ func (cpb *ConnectionParamsBuilder) checkStaticEndpoints() (string, string, erro
 	}
 
 	if sdkPort < 1 {
-		return "", "", fmt.Errorf("static SDK port value sould be greater than 0")
+		return "", "", fmt.Errorf("static SDK port value should be greater than 0")
 	}
 
 	if restPort < 1 {
-		return "", "", fmt.Errorf("static REST port value sould be greater than 0")
+		return "", "", fmt.Errorf("static REST port value should be greater than 0")
 	}
 
 	pxMgmtEndpoint, sdkEndpoint := fmt.Sprintf("http://%s:%d", endpoint, restPort), fmt.Sprintf("%s:%d", endpoint, sdkPort)

--- a/volume/drivers/pwx/connection_test.go
+++ b/volume/drivers/pwx/connection_test.go
@@ -196,7 +196,7 @@ func TestPortworx_buildClientsEndpoints_OK_WithDefaultNsAndService(t *testing.T)
 
 	_, _, err = paramsBuilder.BuildClientsEndpoints()
 	if err != nil {
-		t.Fatalf("should build endpoints when service and ns is not defined in env varaibles: %+v", err)
+		t.Fatalf("should build endpoints when service and ns is not defined in env variables: %+v", err)
 	}
 }
 
@@ -211,7 +211,7 @@ func TestPortworx_buildClientsEndpoints_OK_WithNonDefaultNsAndService(t *testing
 
 	pxMgmtEndpoint, sdkEndpoint, err := paramsBuilder.BuildClientsEndpoints()
 	if err != nil {
-		t.Fatalf("should build endpoints when service and ns is not defined in env varaibles: %+v", err)
+		t.Fatalf("should build endpoints when service and ns is not defined in env variables: %+v", err)
 	}
 
 	if pxMgmtEndpoint != "http://portworx-service.non-default-ns:9901" {
@@ -234,7 +234,7 @@ func TestPortworx_buildClientsEndpoints_OK_WithStaticEndpointAndPorts(t *testing
 
 	pxMgmtEndpoint, sdkEndpoint, err := paramsBuilder.BuildClientsEndpoints()
 	if err != nil {
-		t.Fatalf("should build endpoints when service and ns is not defined in env varaibles: %+v", err)
+		t.Fatalf("should build endpoints when service and ns is not defined in env variables: %+v", err)
 	}
 
 	if pxMgmtEndpoint != "http://k8s-node-0:9001" {
@@ -317,7 +317,7 @@ func TestPortworx_buildClientsEndpoints_OK_WithDefaultNsAndServiceWithEmptyStati
 
 	pxMgmtEndpoint, sdkEndpoint, err := paramsBuilder.BuildClientsEndpoints()
 	if err != nil {
-		t.Fatalf("should build endpoints when service and ns is not defined in env varaibles: %+v", err)
+		t.Fatalf("should build endpoints when service and ns is not defined in env variables: %+v", err)
 	}
 
 	if pxMgmtEndpoint != "http://portworx-service.kube-system:9901" {
@@ -476,13 +476,13 @@ func setEnvs(t *testing.T, vars ...string) func() {
 		existingValue := os.Getenv(env)
 		err := os.Setenv(env, value)
 		if err != nil {
-			t.Fatalf("cannot set env varaibles for test: %+v", err)
+			t.Fatalf("cannot set env variables for test: %+v", err)
 		}
 
 		cleanUp = append(cleanUp, func() {
 			err = os.Setenv(env, existingValue)
 			if err != nil {
-				t.Errorf("cannot set back env varaibles for test: %+v", err)
+				t.Errorf("cannot set back env variables for test: %+v", err)
 			}
 		})
 	}

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -179,7 +179,7 @@ type CloudBackupDriver interface {
 	CloudBackupCatalog(input *api.CloudBackupCatalogRequest) (*api.CloudBackupCatalogResponse, error)
 	// CloudBackupHistory displays past backup/restore operations on a volume
 	CloudBackupHistory(input *api.CloudBackupHistoryRequest) (*api.CloudBackupHistoryResponse, error)
-	// CloudBackupStateChange allows a current backup state transisions(pause/resume/stop)
+	// CloudBackupStateChange allows a current backup state transitions(pause/resume/stop)
 	CloudBackupStateChange(input *api.CloudBackupStateChangeRequest) error
 	// CloudBackupSchedCreate creates a schedule to backup volume to cloud
 	CloudBackupSchedCreate(input *api.CloudBackupSchedCreateRequest) (*api.CloudBackupSchedCreateResponse, error)


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <ggriffiths@purestorage.com>

**What this PR does / why we need it**:
Adds misspell linter to our makefile, similar to csi-release-tools upstream

Mostly comments, but found some error messages worth fixing too.

**Which issue(s) this PR fixes** (optional)

**Special notes for your reviewer**:

