### PR TITLE
IPv6 support - Use net.JoinHostPort to concat ip & port. Add '[]' to …

### DIFF
--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -438,7 +438,7 @@ func (c *ClusterManager) getNonDecommisionedPeers(
 			continue
 		}
 		peers[types.NodeId(nodeEntry.Id)] = types.NodeUpdate{
-			Addr:          nodeEntry.DataIp + ":" + c.gossipPort,
+			Addr:          net.JoinHostPort(nodeEntry.DataIp, c.gossipPort),
 			QuorumMember:  !nodeEntry.NonQuorumMember,
 			ClusterDomain: nodeEntry.ClusterDomain,
 		}
@@ -822,13 +822,13 @@ func (c *ClusterManager) startHeartBeat(
 			gossipPort = c.gossipPort
 		}
 
-		nodeIp := nodeEntry.DataIp + ":" + gossipPort
+		nodeIp := net.JoinHostPort(nodeEntry.DataIp, gossipPort)
 		gossipConfig.Nodes[types.NodeId(nodeId)] = types.GossipNodeConfiguration{
 			KnownUrl:      nodeIp,
 			ClusterDomain: nodeEntry.ClusterDomain,
 		}
 
-		nodeIps = append(nodeIps, nodeEntry.DataIp+":"+gossipPort)
+		nodeIps = append(nodeIps, nodeIp)
 	}
 	if len(nodeIps) > 0 {
 		logrus.Infof("Starting Gossip... Gossiping to these nodes : %v", nodeIps)
@@ -1482,8 +1482,12 @@ func (c *ClusterManager) StartWithConfiguration(
 		QuorumTimeout:    quorumTimeout,
 		SuspicionMult:    types.DEFAULT_SUSPICION_MULTIPLIER,
 	}
+
+	nodeIp := net.JoinHostPort(c.selfNode.DataIp, c.gossipPort)
+	logrus.Infoln("Init gossip: ", nodeIp)
+
 	c.gossip = gossip.New(
-		c.selfNode.DataIp+":"+c.gossipPort,
+		nodeIp,
 		types.NodeId(c.config.NodeId),
 		c.selfNode.GenNumber,
 		c.gossipIntervals,

--- a/pkg/mount/nfs.go
+++ b/pkg/mount/nfs.go
@@ -4,6 +4,7 @@ package mount
 
 import (
 	"fmt"
+	"net"
 	"regexp"
 	"strings"
 
@@ -81,8 +82,14 @@ func (m *nfsMounter) normalizeSource(info *mount.Info, host string) {
 	if info.Fstype != "nfs" {
 		return
 	}
+
 	s := strings.Split(info.Source, ":")
 	if len(s) == 2 && len(s[0]) == 0 {
+		if net.ParseIP(host) != nil { // Check for IPv6 IP Address
+			if strings.Contains(host, ":") && !strings.Contains(host, "[") {
+				host = fmt.Sprintf("[%s]", host)
+			}
+		}
 		info.Source = host + info.Source
 	}
 }


### PR DESCRIPTION
…host in nfs address if necessary.

Signed-off-by: Jose Rivera <jose@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Use Go pkg to handle concat IP & port which handles IPv6 addresses and NFS mounts with IPv6 addresses need to have IP enclosed in '[]'
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
These changes are already in master.  
