### PR TITLE
Update server name to CSI 1.6 to match vendor version

### DIFF
--- a/csi/csi.go
+++ b/csi/csi.go
@@ -116,7 +116,7 @@ func NewOsdCsiServer(config *OsdCsiServerConfig) (grpcserver.Server, error) {
 
 	// Create server
 	gServer, err := grpcserver.New(&grpcserver.GrpcServerConfig{
-		Name:    "CSI 1.5",
+		Name:    "CSI 1.6",
 		Net:     config.Net,
 		Address: config.Address,
 		Opts:    opts,


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <ggriffiths@purestorage.com>

**What this PR does / why we need it**:
Need to also rename server to CSI 1.6

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

