### PR TITLE
PWX-23530: Disables Pure shared RWX volumes temporarily

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -428,12 +428,21 @@ func validateCreateVolumeCapabilitiesPure(caps []*csi.VolumeCapability, proxySpe
 		}
 	}
 
-	// Check for FA DA volumes: all allowed except filesystem RWX
-	if proxySpec.ProxyProtocol == api.ProxyProtocol_PROXY_PROTOCOL_PURE_BLOCK && shared && mount {
-		return status.Errorf(
-			codes.InvalidArgument,
-			"FlashArray Direct Access shared filesystems are not supported",
-		)
+	// Check for shared FA DA volumes. Shared filesystems aren't supported.
+	// Shared raw block volumes are temporarily disabled due to PWX-23530.
+	if proxySpec.ProxyProtocol == api.ProxyProtocol_PROXY_PROTOCOL_PURE_BLOCK && shared {
+		if mount {
+			return status.Errorf(
+				codes.InvalidArgument,
+				"FlashArray Direct Access shared filesystems are not supported",
+			)
+		}
+		if block {
+			return status.Errorf(
+				codes.InvalidArgument,
+				"FlashArray Direct Access shared block devices are not yet supported",
+			)
+		}
 	}
 
 	// Check for FB DA volumes: all allowed except raw block


### PR DESCRIPTION
**What this PR does / why we need it**:
Temporarily blocks Pure shared raw block volumes.
