### PR TITLE
PWX-23689: surface error from Unmount when path is not mounted

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -643,7 +643,7 @@ func (m *Mounter) Unmount(
 		return nil
 	}
 	logrus.Warnf("Device %q is not mounted at path %q", device, path)
-	return nil
+	return ErrEnoent
 }
 
 func (m *Mounter) removeMountPath(path string) error {


### PR DESCRIPTION
**What this PR does / why we need it**:
We were swallowing the "path not mounted" error in Unmount(). This
prevented the callers from executing the cleanup such as removing
the path. This patch exposes that error.

Signed-off-by: Neelesh Thakur <neelesh.thakur@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->



**Which issue(s) this PR fixes** (optional)
PWX-23689

**Special notes for your reviewer**:

