### PR TITLE
PWX-23690: missed pool maintenance severity

### DIFF
--- a/api/status.go
+++ b/api/status.go
@@ -27,6 +27,7 @@ var statusToStatusKind = map[Status]StatusKind{
 	Status_STATUS_STORAGE_REBALANCE:        StatusSeverityMedium,
 	Status_STATUS_STORAGE_DRIVE_REPLACE:    StatusSeverityMedium,
 	Status_STATUS_NOT_IN_QUORUM_NO_STORAGE: StatusSeverityHigh,
+	Status_STATUS_POOLMAINTENANCE:          StatusSeverityHigh,
 	// Add statuses before MAX
 	Status_STATUS_MAX: StatusSeverityHigh,
 }


### PR DESCRIPTION
Signed-off-by: Lakshmi Narasimhan Sundararajan <lns@portworx.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Pool maintenance status is incorrectly reported as operational.
This is because the severity flag of the status is not set.


**Which issue(s) this PR fixes** (optional)
Closes #https://portworx.atlassian.net/browse/PWX-23690

**Special notes for your reviewer**:
Logs are attached to the below PR
https://github.com/portworx/porx/pull/9315