### PR TITLE
Register bucket server on rest gateway and update handler on sdk server.

### DIFF
--- a/api/server/sdk/rest_gateway.go
+++ b/api/server/sdk/rest_gateway.go
@@ -153,6 +153,7 @@ func (s *sdkRestGateway) restServerSetupHandlers() (http.Handler, error) {
 		api.RegisterOpenStorageRoleHandler,
 		api.RegisterOpenStoragePolicyHandler,
 		api.RegisterOpenStorageDiagsHandler,
+		api.RegisterOpenStorageBucketHandler,
 	}
 
 	// REST Gateway extensions

--- a/cmd/osd/main.go
+++ b/cmd/osd/main.go
@@ -560,6 +560,10 @@ func start(c *cli.Context) error {
 		if err != nil {
 			return fmt.Errorf("Failed to start SDK server for driver %s: %v", d, err)
 		}
+
+		// Set the fake bucket driver handler on SDK server
+		sdkServer.UseBucketDrivers(fakeDriver)
+
 		sdkServer.Start()
 	}
 


### PR DESCRIPTION
Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Bucker handler wasn't set at SDK server and bucket server was not updated at rest gateway server. This was causing Rest and gRPC calls to fail. This change fixes the issue. 
**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
tester.server.UseBucketDrivers(tester.b) was setting the driver on the grpc server and hence the unit tests were passing. When executing the Rest API or the grpc,  call was failing because the driver handler was not set. For now. I have updated fake driver handler on the sdk server.
