### PR TITLE
PWX-23408: Added missing Pure backend volume name parsing

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -98,6 +98,7 @@ const (
 	SpecSharedv4ExternalAccess              = "sharedv4_external_access"
 	SpecFastpath                            = "fastpath"
 	SpecAutoFstrim                          = "auto_fstrim"
+	SpecBackendVolName                      = "pure_vol_name"
 	SpecBackendType                         = "backend"
 	SpecBackendPureBlock                    = "pure_block"
 	SpecBackendPureFile                     = "pure_file"
@@ -1354,6 +1355,14 @@ func ParseProxyEndpoint(proxyEndpoint string) (ProxyProtocol, string) {
 func (s *ProxySpec) IsPureBackend() bool {
 	return s.ProxyProtocol == ProxyProtocol_PROXY_PROTOCOL_PURE_BLOCK ||
 		s.ProxyProtocol == ProxyProtocol_PROXY_PROTOCOL_PURE_FILE
+}
+
+func (s *ProxySpec) IsPureImport() bool {
+	if !s.IsPureBackend() {
+		return false
+	}
+
+	return (s.PureBlockSpec != nil && s.PureBlockSpec.FullVolName != "") || (s.PureFileSpec != nil && s.PureFileSpec.FullVolName != "")
 }
 
 // GetAllEnumInfo returns an EnumInfo for every proto enum


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
It looks like this change was brought in to vendor manually but somehow didn't actually make it into openstorage? This PR catches it up with all that should be there. Genuinely not sure how this built before...

