### PR TITLE
Automated cherry pick of #2048: Add CSI VolumeCreate node round-robin

### DIFF
--- a/cmd/osd/main.go
+++ b/cmd/osd/main.go
@@ -480,12 +480,14 @@ func start(c *cli.Context) error {
 		if err != nil {
 			return fmt.Errorf("Unable to find cluster instance: %v", err)
 		}
+		sdkPort := c.String("sdkport")
 		csiServer, err := csi.NewOsdCsiServer(&csi.OsdCsiServerConfig{
 			Net:           "unix",
 			Address:       csisock,
 			DriverName:    d,
 			Cluster:       cm,
 			SdkUds:        sdksocket,
+			SdkPort:       sdkPort,
 			CsiDriverName: c.String("csidrivername"),
 		})
 		if err != nil {
@@ -511,7 +513,7 @@ func start(c *cli.Context) error {
 		os.Remove(sdksocket)
 		sdkServer, err := sdk.New(&sdk.ServerConfig{
 			Net:           "tcp",
-			Address:       ":" + c.String("sdkport"),
+			Address:       ":" + sdkPort,
 			RestPort:      c.String("sdkrestport"),
 			Socket:        sdksocket,
 			DriverName:    d,

--- a/csi/controller.go
+++ b/csi/controller.go
@@ -524,7 +524,7 @@ func (s *OsdCsiServer) CreateVolume(
 	locator.VolumeLabels = cleanupVolumeLabels(locator.VolumeLabels)
 
 	// Get grpc connection
-	conn, err := s.getRemoteConn()
+	conn, err := s.getRemoteConn(ctx)
 	if err != nil {
 		logrus.Errorf("failed to get remote connection: %v, continuing with local node instead", err)
 		conn, err = s.getConn()

--- a/csi/controller.go
+++ b/csi/controller.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 
 	"github.com/portworx/kvdb"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/libopenstorage/openstorage/api"
@@ -523,11 +524,15 @@ func (s *OsdCsiServer) CreateVolume(
 	locator.VolumeLabels = cleanupVolumeLabels(locator.VolumeLabels)
 
 	// Get grpc connection
-	conn, err := s.getConn()
+	conn, err := s.getRemoteConn()
 	if err != nil {
-		return nil, status.Errorf(
-			codes.Internal,
-			"Unable to connect to SDK server: %v", err)
+		logrus.Errorf("failed to get remote connection: %v, continuing with local node instead", err)
+		conn, err = s.getConn()
+		if err != nil {
+			return nil, status.Errorf(
+				codes.Internal,
+				"Unable to connect to SDK server: %v", err)
+		}
 	}
 
 	// Get secret if any was passed

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -916,6 +916,16 @@ func TestControllerCreateVolumeFoundByVolumeFromNameConflict(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: "node-1",
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "[::]:",
+			}},
+		}, nil).
+		AnyTimes()
 
 	// Setup request
 	tests := []struct {
@@ -1001,6 +1011,16 @@ func TestControllerCreateVolumeNoCapacity(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: "node-1",
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "[::]:",
+			}},
+		}, nil).
+		AnyTimes()
 
 	// Setup request
 	name := "myvol"
@@ -1075,6 +1095,16 @@ func TestControllerCreateVolumeFoundByVolumeFromName(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: "node-1",
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "[::]:",
+			}},
+		}, nil).
+		AnyTimes()
 
 	// Setup request
 	name := "myvol"
@@ -1170,6 +1200,16 @@ func TestControllerCreateVolumeBadParameters(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: "node-1",
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "[::]:",
+			}},
+		}, nil).
+		AnyTimes()
 
 	// Setup request
 	name := "myvol"
@@ -1201,6 +1241,16 @@ func TestControllerCreateVolumeBadParentId(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: "node-1",
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "[::]:",
+			}},
+		}, nil).
+		AnyTimes()
 
 	// Setup request
 	name := "myvol"
@@ -1270,6 +1320,16 @@ func TestControllerCreateVolumeBadSnapshot(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: "node-1",
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "[::]:",
+			}},
+		}, nil).
+		AnyTimes()
 
 	// Setup request
 	name := "myvol"
@@ -1341,6 +1401,16 @@ func TestControllerCreateVolumeWithSharedv4Volume(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: "node-1",
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "[::]:",
+			}},
+		}, nil).
+		AnyTimes()
 
 	modes := []csi.VolumeCapability_AccessMode_Mode{
 		csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
@@ -1422,6 +1492,16 @@ func TestControllerCreateVolumeWithSharedVolume(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: "node-1",
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "[::]:",
+			}},
+		}, nil).
+		AnyTimes()
 
 	modes := []csi.VolumeCapability_AccessMode_Mode{
 		csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
@@ -1507,6 +1587,16 @@ func TestControllerCreateVolumeFails(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: "node-1",
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "[::]:",
+			}},
+		}, nil).
+		AnyTimes()
 
 	// Setup request
 	name := "myvol"
@@ -1556,6 +1646,16 @@ func TestControllerCreateVolumeNoNewVolumeInfo(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: "node-1",
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "[::]:",
+			}},
+		}, nil).
+		AnyTimes()
 
 	// Setup request
 	name := "myvol"
@@ -1609,6 +1709,93 @@ func TestControllerCreateVolumeNoNewVolumeInfo(t *testing.T) {
 	assert.Contains(t, serverError.Message(), "not found")
 }
 
+func TestControllerCreateVolumeFailedRemoteConn(t *testing.T) {
+	// Create server and client connection
+	s := newTestServer(t)
+	defer s.Stop()
+	c := csi.NewControllerClient(s.Conn())
+	secretKeyForLabels := "key123"
+	secretValForLabels := "val123"
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: "node-1",
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "badip",
+			}},
+		}, nil).
+		AnyTimes()
+
+	// Setup request
+	name := "myvol"
+	size := int64(1234)
+	secretsMap := map[string]string{
+		authsecrets.SecretTokenKey: systemUserToken,
+		secretKeyForLabels:         secretValForLabels,
+	}
+	req := &csi.CreateVolumeRequest{
+		Name: name,
+		VolumeCapabilities: []*csi.VolumeCapability{
+			&csi.VolumeCapability{},
+		},
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: size,
+		},
+		Secrets: secretsMap,
+	}
+
+	// Setup mock functions
+	id := "myid"
+	gomock.InOrder(
+		s.MockDriver().
+			EXPECT().
+			Inspect([]string{name}).
+			Return(nil, fmt.Errorf("not found")).
+			Times(1),
+
+		s.MockDriver().
+			EXPECT().
+			Enumerate(&api.VolumeLocator{Name: name}, nil).
+			Return(nil, fmt.Errorf("not found")).
+			Times(1),
+
+		s.MockDriver().
+			EXPECT().
+			Create(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(id, nil).
+			Times(1),
+
+		s.MockDriver().
+			EXPECT().
+			Enumerate(&api.VolumeLocator{
+				VolumeIds: []string{id},
+			}, nil).
+			Return([]*api.Volume{
+				&api.Volume{
+					Id: id,
+					Locator: &api.VolumeLocator{
+						Name:         name,
+						VolumeLabels: secretsMap,
+					},
+					Spec: &api.VolumeSpec{
+						Size: uint64(size),
+					},
+				},
+			}, nil).
+			Times(1),
+	)
+
+	r, err := c.CreateVolume(context.Background(), req)
+	assert.Nil(t, err)
+	assert.NotNil(t, r)
+	volumeInfo := r.GetVolume()
+
+	assert.Equal(t, id, volumeInfo.GetVolumeId())
+	assert.Equal(t, size, volumeInfo.GetCapacityBytes())
+	assert.NotEqual(t, "true", volumeInfo.GetVolumeContext()[api.SpecSharedv4])
+}
+
 func TestControllerCreateVolume(t *testing.T) {
 	// Create server and client connection
 	s := newTestServer(t)
@@ -1616,6 +1803,16 @@ func TestControllerCreateVolume(t *testing.T) {
 	c := csi.NewControllerClient(s.Conn())
 	secretKeyForLabels := "key123"
 	secretValForLabels := "val123"
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: "node-1",
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "[::]:",
+			}},
+		}, nil).
+		AnyTimes()
 
 	// Setup request
 	name := "myvol"
@@ -1693,6 +1890,16 @@ func TestControllerCreateVolumeRoundUp(t *testing.T) {
 	c := csi.NewControllerClient(s.Conn())
 	secretKeyForLabels := "key123"
 	secretValForLabels := "val123"
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: "node-1",
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "[::]:",
+			}},
+		}, nil).
+		AnyTimes()
 
 	// Setup request
 	name := "myvol"
@@ -1777,6 +1984,16 @@ func TestControllerCreateVolumeFromSnapshot(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: "node-1",
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "[::]:",
+			}},
+		}, nil).
+		AnyTimes()
 
 	// Setup request
 	mockParentID := "parendId"
@@ -1891,6 +2108,16 @@ func TestControllerCreateVolumeSnapshotThroughParameters(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: "node-1",
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "[::]:",
+			}},
+		}, nil).
+		AnyTimes()
 
 	// Setup request
 	mockParentID := "parendId"
@@ -2045,6 +2272,16 @@ func TestControllerCreateVolumeBlock(t *testing.T) {
 	c := csi.NewControllerClient(s.Conn())
 	secretKeyForLabels := "key123"
 	secretValForLabels := "val123"
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: "node-1",
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "[::]:",
+			}},
+		}, nil).
+		AnyTimes()
 
 	// Setup request
 	name := "myvol"
@@ -2126,7 +2363,16 @@ func TestControllerCreateVolumeBlockSharedInvalid(t *testing.T) {
 	c := csi.NewControllerClient(s.Conn())
 	secretKeyForLabels := "key123"
 	secretValForLabels := "val123"
-
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: "node-1",
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "[::]:",
+			}},
+		}, nil).
+		AnyTimes()
 	// Setup request
 	name := "myvol"
 	size := int64(1234)
@@ -2166,6 +2412,16 @@ func TestControllerCreateVolumeWithoutTopology(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: "node-1",
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "[::]:",
+			}},
+		}, nil).
+		AnyTimes()
 
 	name := "myvol"
 	size := int64(1234)
@@ -2312,6 +2568,16 @@ func TestControllerCreateVolumeWithTopology(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: "node-1",
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "[::]:",
+			}},
+		}, nil).
+		AnyTimes()
 
 	name := "myvol"
 	size := int64(1234)

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -916,17 +916,7 @@ func TestControllerCreateVolumeFoundByVolumeFromNameConflict(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
-	s.MockCluster().EXPECT().
-		Enumerate().
-		Return(api.Cluster{
-			NodeId: "node-1",
-			Nodes: []*api.Node{{
-				Id:     "1",
-				MgmtIp: "[::]:",
-			}},
-		}, nil).
-		AnyTimes()
-
+	s.mockClusterEnumerateNode(t, "node-1")
 	// Setup request
 	tests := []struct {
 		name      string
@@ -1011,17 +1001,7 @@ func TestControllerCreateVolumeNoCapacity(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
-	s.MockCluster().EXPECT().
-		Enumerate().
-		Return(api.Cluster{
-			NodeId: "node-1",
-			Nodes: []*api.Node{{
-				Id:     "1",
-				MgmtIp: "[::]:",
-			}},
-		}, nil).
-		AnyTimes()
-
+	s.mockClusterEnumerateNode(t, "node-1")
 	// Setup request
 	name := "myvol"
 	req := &csi.CreateVolumeRequest{
@@ -1095,17 +1075,7 @@ func TestControllerCreateVolumeFoundByVolumeFromName(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
-	s.MockCluster().EXPECT().
-		Enumerate().
-		Return(api.Cluster{
-			NodeId: "node-1",
-			Nodes: []*api.Node{{
-				Id:     "1",
-				MgmtIp: "[::]:",
-			}},
-		}, nil).
-		AnyTimes()
-
+	s.mockClusterEnumerateNode(t, "node-1")
 	// Setup request
 	name := "myvol"
 	size := 2 * int64(units.GiB)
@@ -1200,17 +1170,7 @@ func TestControllerCreateVolumeBadParameters(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
-	s.MockCluster().EXPECT().
-		Enumerate().
-		Return(api.Cluster{
-			NodeId: "node-1",
-			Nodes: []*api.Node{{
-				Id:     "1",
-				MgmtIp: "[::]:",
-			}},
-		}, nil).
-		AnyTimes()
-
+	s.mockClusterEnumerateNode(t, "node-1")
 	// Setup request
 	name := "myvol"
 	size := int64(1234)
@@ -1241,17 +1201,7 @@ func TestControllerCreateVolumeBadParentId(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
-	s.MockCluster().EXPECT().
-		Enumerate().
-		Return(api.Cluster{
-			NodeId: "node-1",
-			Nodes: []*api.Node{{
-				Id:     "1",
-				MgmtIp: "[::]:",
-			}},
-		}, nil).
-		AnyTimes()
-
+	s.mockClusterEnumerateNode(t, "node-1")
 	// Setup request
 	name := "myvol"
 	size := int64(1234)
@@ -1320,17 +1270,7 @@ func TestControllerCreateVolumeBadSnapshot(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
-	s.MockCluster().EXPECT().
-		Enumerate().
-		Return(api.Cluster{
-			NodeId: "node-1",
-			Nodes: []*api.Node{{
-				Id:     "1",
-				MgmtIp: "[::]:",
-			}},
-		}, nil).
-		AnyTimes()
-
+	s.mockClusterEnumerateNode(t, "node-1")
 	// Setup request
 	name := "myvol"
 	size := int64(1234)
@@ -1401,17 +1341,7 @@ func TestControllerCreateVolumeWithSharedv4Volume(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
-	s.MockCluster().EXPECT().
-		Enumerate().
-		Return(api.Cluster{
-			NodeId: "node-1",
-			Nodes: []*api.Node{{
-				Id:     "1",
-				MgmtIp: "[::]:",
-			}},
-		}, nil).
-		AnyTimes()
-
+	s.mockClusterEnumerateNode(t, "node-1")
 	modes := []csi.VolumeCapability_AccessMode_Mode{
 		csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 		csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER,
@@ -1492,17 +1422,7 @@ func TestControllerCreateVolumeWithSharedVolume(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
-	s.MockCluster().EXPECT().
-		Enumerate().
-		Return(api.Cluster{
-			NodeId: "node-1",
-			Nodes: []*api.Node{{
-				Id:     "1",
-				MgmtIp: "[::]:",
-			}},
-		}, nil).
-		AnyTimes()
-
+	s.mockClusterEnumerateNode(t, "node-1")
 	modes := []csi.VolumeCapability_AccessMode_Mode{
 		csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 		csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER,
@@ -1587,17 +1507,7 @@ func TestControllerCreateVolumeFails(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
-	s.MockCluster().EXPECT().
-		Enumerate().
-		Return(api.Cluster{
-			NodeId: "node-1",
-			Nodes: []*api.Node{{
-				Id:     "1",
-				MgmtIp: "[::]:",
-			}},
-		}, nil).
-		AnyTimes()
-
+	s.mockClusterEnumerateNode(t, "node-1")
 	// Setup request
 	name := "myvol"
 	size := int64(1234)
@@ -1646,17 +1556,7 @@ func TestControllerCreateVolumeNoNewVolumeInfo(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
-	s.MockCluster().EXPECT().
-		Enumerate().
-		Return(api.Cluster{
-			NodeId: "node-1",
-			Nodes: []*api.Node{{
-				Id:     "1",
-				MgmtIp: "[::]:",
-			}},
-		}, nil).
-		AnyTimes()
-
+	s.mockClusterEnumerateNode(t, "node-1")
 	// Setup request
 	name := "myvol"
 	size := int64(1234)
@@ -1803,16 +1703,7 @@ func TestControllerCreateVolume(t *testing.T) {
 	c := csi.NewControllerClient(s.Conn())
 	secretKeyForLabels := "key123"
 	secretValForLabels := "val123"
-	s.MockCluster().EXPECT().
-		Enumerate().
-		Return(api.Cluster{
-			NodeId: "node-1",
-			Nodes: []*api.Node{{
-				Id:     "1",
-				MgmtIp: "[::]:",
-			}},
-		}, nil).
-		AnyTimes()
+	s.mockClusterEnumerateNode(t, "node-1")
 
 	// Setup request
 	name := "myvol"
@@ -1890,17 +1781,7 @@ func TestControllerCreateVolumeRoundUp(t *testing.T) {
 	c := csi.NewControllerClient(s.Conn())
 	secretKeyForLabels := "key123"
 	secretValForLabels := "val123"
-	s.MockCluster().EXPECT().
-		Enumerate().
-		Return(api.Cluster{
-			NodeId: "node-1",
-			Nodes: []*api.Node{{
-				Id:     "1",
-				MgmtIp: "[::]:",
-			}},
-		}, nil).
-		AnyTimes()
-
+	s.mockClusterEnumerateNode(t, "node-1")
 	// Setup request
 	name := "myvol"
 	size := int64(units.GiB * 1.5)
@@ -1984,17 +1865,7 @@ func TestControllerCreateVolumeFromSnapshot(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
-	s.MockCluster().EXPECT().
-		Enumerate().
-		Return(api.Cluster{
-			NodeId: "node-1",
-			Nodes: []*api.Node{{
-				Id:     "1",
-				MgmtIp: "[::]:",
-			}},
-		}, nil).
-		AnyTimes()
-
+	s.mockClusterEnumerateNode(t, "node-1")
 	// Setup request
 	mockParentID := "parendId"
 	name := "myvol"
@@ -2108,17 +1979,7 @@ func TestControllerCreateVolumeSnapshotThroughParameters(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
-	s.MockCluster().EXPECT().
-		Enumerate().
-		Return(api.Cluster{
-			NodeId: "node-1",
-			Nodes: []*api.Node{{
-				Id:     "1",
-				MgmtIp: "[::]:",
-			}},
-		}, nil).
-		AnyTimes()
-
+	s.mockClusterEnumerateNode(t, "node-1")
 	// Setup request
 	mockParentID := "parendId"
 	name := "myvol"
@@ -2272,17 +2133,7 @@ func TestControllerCreateVolumeBlock(t *testing.T) {
 	c := csi.NewControllerClient(s.Conn())
 	secretKeyForLabels := "key123"
 	secretValForLabels := "val123"
-	s.MockCluster().EXPECT().
-		Enumerate().
-		Return(api.Cluster{
-			NodeId: "node-1",
-			Nodes: []*api.Node{{
-				Id:     "1",
-				MgmtIp: "[::]:",
-			}},
-		}, nil).
-		AnyTimes()
-
+	s.mockClusterEnumerateNode(t, "node-1")
 	// Setup request
 	name := "myvol"
 	size := int64(1234)
@@ -2363,17 +2214,7 @@ func TestControllerCreateVolumeBlockSharedInvalid(t *testing.T) {
 	c := csi.NewControllerClient(s.Conn())
 	secretKeyForLabels := "key123"
 	secretValForLabels := "val123"
-	s.MockCluster().EXPECT().
-		Enumerate().
-		Return(api.Cluster{
-			NodeId: "node-1",
-			Nodes: []*api.Node{{
-				Id:     "1",
-				MgmtIp: "[::]:",
-			}},
-		}, nil).
-		AnyTimes()
-	// Setup request
+	s.mockClusterEnumerateNode(t, "node-1") // Setup request
 	name := "myvol"
 	size := int64(1234)
 	secretsMap := map[string]string{
@@ -2412,17 +2253,7 @@ func TestControllerCreateVolumeWithoutTopology(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
-	s.MockCluster().EXPECT().
-		Enumerate().
-		Return(api.Cluster{
-			NodeId: "node-1",
-			Nodes: []*api.Node{{
-				Id:     "1",
-				MgmtIp: "[::]:",
-			}},
-		}, nil).
-		AnyTimes()
-
+	s.mockClusterEnumerateNode(t, "node-1")
 	name := "myvol"
 	size := int64(1234)
 	id := "myid"
@@ -2568,17 +2399,7 @@ func TestControllerCreateVolumeWithTopology(t *testing.T) {
 	s := newTestServer(t)
 	defer s.Stop()
 	c := csi.NewControllerClient(s.Conn())
-	s.MockCluster().EXPECT().
-		Enumerate().
-		Return(api.Cluster{
-			NodeId: "node-1",
-			Nodes: []*api.Node{{
-				Id:     "1",
-				MgmtIp: "[::]:",
-			}},
-		}, nil).
-		AnyTimes()
-
+	s.mockClusterEnumerateNode(t, "node-1")
 	name := "myvol"
 	size := int64(1234)
 	id := "myid"

--- a/csi/csi.go
+++ b/csi/csi.go
@@ -17,6 +17,7 @@ limitations under the License.
 package csi
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"sync"
@@ -31,7 +32,6 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
@@ -44,7 +44,14 @@ import (
 	volumedrivers "github.com/libopenstorage/openstorage/volume/drivers"
 )
 
-var clogger *logrus.Logger
+var (
+	clogger *logrus.Logger
+)
+
+const (
+	connCleanupInterval = 15 * time.Minute
+	connIdleConnLength  = 30 * time.Minute
+)
 
 func init() {
 	clogger = correlation.NewPackageLogger(correlation.ComponentCSIDriver)
@@ -69,6 +76,12 @@ type OsdCsiServerConfig struct {
 	EnableInlineVolumes bool
 }
 
+// TimedSDKConn represents a gRPC connection and the last time it was used
+type TimedSDKConn struct {
+	Conn      *grpc.ClientConn
+	LastUsage time.Time
+}
+
 // OsdCsiServer is a OSD CSI compliant server which
 // proxies CSI requests for a single specific driver
 type OsdCsiServer struct {
@@ -83,11 +96,12 @@ type OsdCsiServer struct {
 	sdkUds               string
 	sdkPort              string
 	conn                 *grpc.ClientConn
-	connMap              map[string]*grpc.ClientConn
+	connMap              map[string]*TimedSDKConn
 	nextCreateNodeNumber int
 	mu                   sync.Mutex
 	csiDriverName        string
 	allowInlineVolumes   bool
+	stopCleanupCh        chan bool
 }
 
 // NewOsdCsiServer creates a gRPC CSI complient server on the
@@ -132,17 +146,13 @@ func NewOsdCsiServer(config *OsdCsiServerConfig) (grpcserver.Server, error) {
 		return nil, fmt.Errorf("Failed to create CSI server: %v", err)
 	}
 
-	sdkPort := config.SdkPort
-	if len(config.SdkPort) == 0 {
-		sdkPort = "9020"
-	}
 	return &OsdCsiServer{
 		specHandler:        spec.NewSpecHandler(),
 		GrpcServer:         gServer,
 		driver:             d,
 		cluster:            config.Cluster,
 		sdkUds:             config.SdkUds,
-		sdkPort:            sdkPort,
+		sdkPort:            config.SdkPort,
 		csiDriverName:      config.CsiDriverName,
 		allowInlineVolumes: config.EnableInlineVolumes,
 	}, nil
@@ -159,21 +169,16 @@ func (s *OsdCsiServer) getConn() (*grpc.ClientConn, error) {
 			[]grpc.DialOption{
 				grpc.WithInsecure(),
 				grpc.WithUnaryInterceptor(correlation.ContextUnaryClientInterceptor),
-				grpc.WithKeepaliveParams(keepalive.ClientParameters{
-					// Pings every 60 seconds to keep the connection alive.
-					// Each ping times out at 10s
-					Time:    60 * time.Second,
-					Timeout: 10 * time.Second,
-				}),
 			})
 		if err != nil {
 			return nil, fmt.Errorf("Failed to connect CSI to SDK uds %s: %v", s.sdkUds, err)
 		}
 	}
+
 	return s.conn, nil
 }
 
-func (s *OsdCsiServer) getRemoteConn() (*grpc.ClientConn, error) {
+func (s *OsdCsiServer) getRemoteConn(ctx context.Context) (*grpc.ClientConn, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -182,23 +187,18 @@ func (s *OsdCsiServer) getRemoteConn() (*grpc.ClientConn, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(nodesResp.Nodes) < 1 {
+		return nil, errors.New("cluster nodes for remote connection not found")
+	}
 	sort.Slice(nodesResp.Nodes, func(i, j int) bool {
 		return nodesResp.Nodes[i].Id < nodesResp.Nodes[j].Id
 	})
 
-	// Clean up connections for missing node
-	nodesMap := make(map[string]bool)
-	for _, node := range nodesResp.Nodes {
-		nodesMap[node.MgmtIp] = true
-	}
-	for ip := range s.connMap {
-		// If key in connmap is not in current nodes, remove it
-		if ok := nodesMap[ip]; !ok {
-			delete(s.connMap, ip)
-		}
-	}
+	// Clean up connections for missing nodes
+	s.cleanupMissingNodeConnections(ctx, nodesResp.Nodes)
 
-	// Get target node info and set next round robbin node
+	// Get target node info and set next round robbin node.
+	// nextNode is always lastNode + 1 mod (numOfNodes), to loop back to zero
 	var targetNodeNumber int
 	if s.nextCreateNodeNumber != 0 {
 		targetNodeNumber = s.nextCreateNodeNumber
@@ -208,29 +208,30 @@ func (s *OsdCsiServer) getRemoteConn() (*grpc.ClientConn, error) {
 
 	// Get conn for this node, otherwise create new conn
 	if len(s.connMap) == 0 {
-		s.connMap = make(map[string]*grpc.ClientConn)
+		s.connMap = make(map[string]*TimedSDKConn)
 	}
 	if s.connMap[targetNodeEndpoint] == nil {
 		var err error
-		logrus.Infof("Round-robin connecting to node %v - %s:%s", targetNodeNumber, targetNodeEndpoint, s.sdkPort)
-		s.connMap[targetNodeEndpoint], err = grpcserver.ConnectWithTimeout(
+		clogger.WithContext(ctx).Infof("Round-robin connecting to node %v - %s:%s", targetNodeNumber, targetNodeEndpoint, s.sdkPort)
+		remoteConn, err := grpcserver.ConnectWithTimeout(
 			fmt.Sprintf("%s:%s", targetNodeEndpoint, s.sdkPort),
 			[]grpc.DialOption{
 				grpc.WithInsecure(),
 				grpc.WithUnaryInterceptor(correlation.ContextUnaryClientInterceptor),
-				grpc.WithKeepaliveParams(keepalive.ClientParameters{
-					// Pings every 60 seconds to keep the connection alive.
-					// Each ping times out at 10s
-					Time:    60 * time.Second,
-					Timeout: 10 * time.Second,
-				}),
 			}, 10*time.Second)
 		if err != nil {
 			return nil, err
 		}
+
+		s.connMap[targetNodeEndpoint] = &TimedSDKConn{
+			Conn: remoteConn,
+		}
 	}
 
-	return s.connMap[targetNodeEndpoint], nil
+	// Keep track of when this conn was last accessed
+	clogger.WithContext(ctx).Infof("Using remote connection to SDK node %v - %s:%s", targetNodeNumber, targetNodeEndpoint, s.sdkPort)
+	s.connMap[targetNodeEndpoint].LastUsage = time.Now()
+	return s.connMap[targetNodeEndpoint].Conn, nil
 }
 
 // driverGetVolume returns a volume for a given ID. This function skips
@@ -300,8 +301,89 @@ func (s *OsdCsiServer) addEncryptionInfoToLabels(labels, csiSecrets map[string]s
 // It will return an error if the server is already running.
 func (s *OsdCsiServer) Start() error {
 	return s.GrpcServer.Start(func(grpcServer *grpc.Server) {
+		go s.cleanupConnections()
+
 		csi.RegisterIdentityServer(grpcServer, s)
 		csi.RegisterControllerServer(grpcServer, s)
 		csi.RegisterNodeServer(grpcServer, s)
 	})
+}
+
+// Start is used to stop the server.
+func (s *OsdCsiServer) Stop() {
+	if s.stopCleanupCh != nil {
+		close(s.stopCleanupCh)
+	}
+	s.GrpcServer.Stop()
+}
+
+func (s *OsdCsiServer) cleanupConnections() {
+	s.stopCleanupCh = make(chan bool)
+	ticker := time.NewTicker(connCleanupInterval)
+
+	// Check every so often and delete/close connections
+	for {
+		select {
+		case <-s.stopCleanupCh:
+			ticker.Stop()
+			return
+
+		case _ = <-ticker.C:
+			ctx := correlation.WithCorrelationContext(context.Background(), correlation.ComponentCSIDriver)
+
+			// Anonymous function for using defer to unlock mutex
+			func() {
+				s.mu.Lock()
+				defer s.mu.Unlock()
+				clogger.Infof("Cleaning up open gRPC connections for CSI distributed provisioning")
+
+				// Clean all expired connections
+				numConnsClosed := 0
+				for ip, timedConn := range s.connMap {
+					expiryTime := timedConn.LastUsage.Add(connIdleConnLength)
+
+					// Connection has expired after 1hr of no usage.
+					// Close connection and remove from connMap
+					if expiryTime.Before(time.Now()) {
+						clogger.Infof("SDK gRPC connection to %s is has expired after %v minutes of no usage. Closing this connection", ip, connIdleConnLength.Minutes())
+						if err := timedConn.Conn.Close(); err != nil {
+							clogger.Errorf("failed to close connection to %s: %v", ip, timedConn.Conn)
+						}
+						delete(s.connMap, ip)
+						numConnsClosed++
+					}
+				}
+
+				// Get all nodes and cleanup conns for missing/deprovisioned nodes
+				nodesResp, err := s.cluster.Enumerate()
+				if err != nil {
+					clogger.Errorf("failed to get all nodes for connection cleanup: %v", err)
+					return
+				}
+				if len(nodesResp.Nodes) < 1 {
+					clogger.Errorf("no nodes available to cleanup: %v", err)
+					return
+				}
+				s.cleanupMissingNodeConnections(ctx, nodesResp.Nodes)
+
+				clogger.Infof("Cleaned up %v connections for CSI distributed provisioning. %v connections remaining", numConnsClosed, len(s.connMap))
+			}()
+		}
+	}
+}
+
+func (s *OsdCsiServer) cleanupMissingNodeConnections(ctx context.Context, nodes []*api.Node) {
+	nodesMap := make(map[string]bool)
+	for _, node := range nodes {
+		nodesMap[node.MgmtIp] = true
+	}
+	for ip, timedConn := range s.connMap {
+		if ok := nodesMap[ip]; !ok {
+			// If key in connmap is not in current nodes, close and remove it
+			if err := timedConn.Conn.Close(); err != nil {
+				clogger.WithContext(ctx).Errorf("failed to close conn to %s: %v", ip, err)
+			}
+			delete(s.connMap, ip)
+		}
+	}
 }

--- a/csi/csi_test.go
+++ b/csi/csi_test.go
@@ -206,6 +206,7 @@ func newTestServerWithConfig(t *testing.T, config *OsdCsiServerConfig) *testServ
 	config.Net = "tcp"
 	config.Address = "127.0.0.1:0"
 	config.SdkUds = tester.uds
+	config.SdkPort = tester.port
 	tester.server, err = NewOsdCsiServer(config)
 	assert.Nil(t, err)
 	err = tester.server.Start()

--- a/csi/csi_test.go
+++ b/csi/csi_test.go
@@ -241,6 +241,19 @@ func (s *testServer) setPorts() {
 	s.uds = fmt.Sprintf("/tmp/osd-csi-ut-%d.sock", port)
 }
 
+func (s *testServer) mockClusterEnumerateNode(_ *testing.T, nodeName string) {
+	s.MockCluster().EXPECT().
+		Enumerate().
+		Return(api.Cluster{
+			NodeId: nodeName,
+			Nodes: []*api.Node{{
+				Id:     "1",
+				MgmtIp: "[::]:",
+			}},
+		}, nil).
+		AnyTimes()
+}
+
 func (s *testServer) MockDriver() *mockdriver.MockVolumeDriver {
 	return s.m
 }

--- a/csi/csi_test.go
+++ b/csi/csi_test.go
@@ -248,7 +248,7 @@ func (s *testServer) mockClusterEnumerateNode(_ *testing.T, nodeName string) {
 			NodeId: nodeName,
 			Nodes: []*api.Node{{
 				Id:     "1",
-				MgmtIp: "[::]:",
+				MgmtIp: "[::]",
 			}},
 		}, nil).
 		AnyTimes()


### PR DESCRIPTION
Cherry pick of #2048 on release-9.4.

#2048: Add CSI VolumeCreate node round-robin

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.