### PR TITLE
PWX-24720: Changed mounter to use regex instead of prefix

### DIFF
--- a/api/flexvolume/flexvolume.go
+++ b/api/flexvolume/flexvolume.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"net"
+	"regexp"
 
 	"google.golang.org/grpc"
 
@@ -95,7 +96,7 @@ func (c *flexVolumeClient) Mount(targetMountDir string, mountDevice string,
 		return err
 	}
 	// Update the deviceDriverMap
-	mountManager, err := mount.New(mount.DeviceMount, nil, []string{""}, nil, []string{}, "")
+	mountManager, err := mount.New(mount.DeviceMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, "")
 	if err != nil {
 		logrus.Infof("Could not read mountpoints from /proc/self/mountinfo. Device - Driver mapping not saved!")
 		return nil
@@ -110,7 +111,7 @@ func (c *flexVolumeClient) Mount(targetMountDir string, mountDevice string,
 
 func (c *flexVolumeClient) Unmount(mountDir string, options map[string]string) error {
 	// Get the mountDevice from mount manager
-	mountManager, err := mount.New(mount.DeviceMount, nil, []string{""}, nil, []string{}, "")
+	mountManager, err := mount.New(mount.DeviceMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, "")
 	if err != nil {
 		return ErrNoMountInfo
 	}

--- a/pkg/mount/custom_mount.go
+++ b/pkg/mount/custom_mount.go
@@ -1,9 +1,13 @@
 package mount
 
-import "github.com/libopenstorage/openstorage/pkg/keylock"
+import (
+	"regexp"
+
+	"github.com/libopenstorage/openstorage/pkg/keylock"
+)
 
 // CustomLoad defines the mounter.Load callback function for customer mounters
-type CustomLoad func([]string, DeviceMap, PathMap) error
+type CustomLoad func([]*regexp.Regexp, DeviceMap, PathMap) error
 
 // CustomReload defines the mounter.Reload callback function for customer mounters
 type CustomReload func(string, DeviceMap, PathMap) error
@@ -20,7 +24,7 @@ type CustomMounterHandler struct {
 
 // NewCustomMounter returns a new CustomMounter
 func NewCustomMounter(
-	devPrefixes []string,
+	devRegexes []*regexp.Regexp,
 	mountImpl MountImpl,
 	customMounter CustomMounter,
 	allowedDirs []string,
@@ -38,7 +42,7 @@ func NewCustomMounter(
 	cl, cr := customMounter()
 	m.cl = cl
 	m.cr = cr
-	err := m.Load(devPrefixes)
+	err := m.Load(devRegexes)
 	if err != nil {
 		return nil, err
 	}
@@ -46,8 +50,8 @@ func NewCustomMounter(
 }
 
 // Load mount table
-func (c *CustomMounterHandler) Load(devPrefixes []string) error {
-	return c.cl(devPrefixes, c.mounts, c.paths)
+func (c *CustomMounterHandler) Load(devRegexes []*regexp.Regexp) error {
+	return c.cl(devRegexes, c.mounts, c.paths)
 }
 
 // Reload mount table for a device

--- a/pkg/mount/deleted_mount.go
+++ b/pkg/mount/deleted_mount.go
@@ -4,6 +4,7 @@ package mount
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -25,7 +26,7 @@ func NewDeletedMounter(
 	mountImpl MountImpl,
 ) (*deletedMounter, error) {
 
-	devMounter, err := NewDeviceMounter([]string{"/dev/"}, mountImpl, nil, "")
+	devMounter, err := NewDeviceMounter([]*regexp.Regexp{regexp.MustCompile("/dev/")}, mountImpl, nil, "")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mount/device_test.go
+++ b/pkg/mount/device_test.go
@@ -2,6 +2,7 @@ package mount
 
 import (
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/docker/docker/pkg/mount"
@@ -65,7 +66,7 @@ func TestBasicDeviceMounter(t *testing.T) {
 	orderedDevices := []string{device1}
 	orderedPaths := []string{mountPath1}
 
-	dm, err := New(DeviceMount, nil, []string{osdDevicePrefix}, nil, []string{}, "")
+	dm, err := New(DeviceMount, nil, []*regexp.Regexp{regexp.MustCompile(osdDevicePrefix)}, nil, []string{}, "")
 	require.NoError(t, err, "Unexpected error on mount.New")
 
 	// Inspect
@@ -105,7 +106,7 @@ func TestBasicDeviceMounterWithMultipleMounts(t *testing.T) {
 	orderedDevices := []string{device1, device1}
 	orderedPaths := []string{mountPath1, mountPath2}
 
-	dm, err := New(DeviceMount, nil, []string{osdDevicePrefix}, nil, []string{}, "")
+	dm, err := New(DeviceMount, nil, []*regexp.Regexp{regexp.MustCompile(osdDevicePrefix)}, nil, []string{}, "")
 	require.NoError(t, err, "Unexpected error on mount.New")
 
 	// Inspect

--- a/pkg/mount/mount_test.go
+++ b/pkg/mount/mount_test.go
@@ -3,6 +3,7 @@ package mount
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"syscall"
 	"testing"
 
@@ -48,7 +49,7 @@ func allTests(t *testing.T, source, dest string) {
 
 func setupNFS(t *testing.T) {
 	var err error
-	m, err = New(NFSMount, nil, []string{""}, nil, []string{}, trashLocation)
+	m, err = New(NFSMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, trashLocation)
 	if err != nil {
 		t.Fatalf("Failed to setup test %v", err)
 	}
@@ -58,7 +59,7 @@ func setupNFS(t *testing.T) {
 
 func setupBindMounter(t *testing.T) {
 	var err error
-	m, err = New(BindMount, nil, []string{""}, nil, []string{}, trashLocation)
+	m, err = New(BindMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, trashLocation)
 	if err != nil {
 		t.Fatalf("Failed to setup test %v", err)
 	}
@@ -68,7 +69,7 @@ func setupBindMounter(t *testing.T) {
 
 func setupRawMounter(t *testing.T) {
 	var err error
-	m, err = New(RawMount, nil, []string{""}, nil, []string{}, trashLocation)
+	m, err = New(RawMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, trashLocation)
 	if err != nil {
 		t.Fatalf("Failed to setup test %v", err)
 	}
@@ -83,7 +84,7 @@ func cleandir(dir string) {
 }
 
 func load(t *testing.T, source, dest string) {
-	require.NoError(t, m.Load([]string{""}), "Failed in load")
+	require.NoError(t, m.Load([]*regexp.Regexp{regexp.MustCompile("")}), "Failed in load")
 }
 
 func mountTest(t *testing.T, source, dest string) {

--- a/pkg/mount/nfs.go
+++ b/pkg/mount/nfs.go
@@ -19,14 +19,14 @@ const (
 
 // nfsMounter implements Manager and keeps track of active mounts for volume drivers.
 type nfsMounter struct {
-	servers []string
+	servers []*regexp.Regexp
 	Mounter
 }
 
 // NewnfsMounter returns a Mounter specific to parse NFS mounts. This can work
 // VFS also if 'servers' is nil. Use NFSAllServers if the destination server
 // is unknown.
-func NewNFSMounter(servers []string,
+func NewNFSMounter(servers []*regexp.Regexp,
 	mountImpl MountImpl,
 	allowedDirs []string,
 ) (Manager, error) {
@@ -40,7 +40,7 @@ func NewNFSMounter(servers []string,
 			kl:          keylock.New(),
 		},
 	}
-	err := m.Load([]string{""})
+	err := m.Load([]*regexp.Regexp{}) // Input value is not used, can be anything
 	if err != nil {
 		return nil, err
 	}
@@ -49,7 +49,7 @@ func NewNFSMounter(servers []string,
 
 // Reload reloads the mount table for the specified source/
 func (m *nfsMounter) Reload(source string) error {
-	newNFSm, err := NewNFSMounter([]string{NFSAllServers},
+	newNFSm, err := NewNFSMounter([]*regexp.Regexp{regexp.MustCompile(NFSAllServers)},
 		m.mountImpl,
 		m.Mounter.allowedDirs,
 	)
@@ -69,7 +69,8 @@ func (m *nfsMounter) Reload(source string) error {
 //serverExists utility function to test if a server is part of driver config
 func (m *nfsMounter) serverExists(server string) bool {
 	for _, v := range m.servers {
-		if v == server || v == NFSAllServers {
+		vStr := v.String()
+		if vStr == server || vStr == NFSAllServers {
 			return true
 		}
 	}
@@ -95,7 +96,7 @@ func (m *nfsMounter) normalizeSource(info *mount.Info, host string) {
 }
 
 // Load mount table
-func (m *nfsMounter) Load(source []string) error {
+func (m *nfsMounter) Load(source []*regexp.Regexp) error {
 	info, err := GetMounts()
 	if err != nil {
 		return err

--- a/volume/drivers/nfs/nfs.go
+++ b/volume/drivers/nfs/nfs.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"regexp"
 	"strconv"
 	"syscall"
 	"time"
@@ -70,9 +71,13 @@ func Init(params map[string]string) (volume.VolumeDriver, error) {
 	//support more than one server using CSV
 	//TB-FIXME: modify driver params flow to support map[string]struct/array
 	servers := strings.Split(server, ",")
+	serverRegexes := make([]*regexp.Regexp, len(servers))
+	for i := range servers {
+		serverRegexes[i] = regexp.MustCompile(regexp.QuoteMeta(servers[i]))
+	}
 
 	// Create a mount manager for this NFS server. Blank sever is OK.
-	mounter, err := mount.New(mount.NFSMount, nil, servers, nil, []string{}, "")
+	mounter, err := mount.New(mount.NFSMount, nil, serverRegexes, nil, []string{}, "")
 	if err != nil {
 		logrus.Warnf("Failed to create mount manager for server: %v (%v)", server, err)
 		return nil, err


### PR DESCRIPTION
Signed-Off-By: Adam Krpan <akrpan@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
As part of enabling NVMe FlashArray drives, we now have to handle a different format of path as well which is not just a prefix. We specifically need to search for the pattern `/dev/mapper/*24a937` (note the asterisk in the middle). The easiest way I could think of doing this is to change from a string prefix to just passing in regexes instead. That way we can still specify prefixes by using the regex "start" character, but also get more complex cases.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Tests to run:
- [x] Validate that this works with Pure DA volumes
- [x] Validate that this works with normal PX volumes
- [x] Validate that this works with NFS proxy volumes
- [x] Validate that this works with sharedv4 volumes
