### PR TITLE
PWX-24862: add more helpful error message for non-shared vol attach

### DIFF
--- a/volume/volume.go
+++ b/volume/volume.go
@@ -28,8 +28,11 @@ var (
 	ErrAttachedHostSpecNotFound = errors.New("Spec of the attached host is not found")
 	// ErrVolAttached returned when volume is in attached state
 	ErrVolAttached = errors.New("Volume is attached")
-	// ErrVolAttachedOnRemoteNode returned when volume is in attached on different node
-	ErrVolAttachedOnRemoteNode = errors.New("Volume is attached on another node")
+        // ErrVolAttachedOnRemoteNode returned when volume is attached on different node
+        ErrVolAttachedOnRemoteNode = errors.New("Volume is attached on another node")
+        // ErrNonSharedVolAttachedOnRemoteNode returned when a non-shared volume is attached on different node
+        ErrNonSharedVolAttachedOnRemoteNode = errors.New("Non-shared volume is already attached on another node." +
+                " Non-shared volumes can only be attached on one node at a time.")
 	// ErrVolAttachedScale returned when volume is attached and can be scaled
 	ErrVolAttachedScale = errors.New("Volume is attached on another node." +
 		" Increase scale factor to create more instances")


### PR DESCRIPTION
**What this PR does / why we need it**:
New error message makes it more obvious that the attach failure is because
the volume is not shared.

Signed-off-by: Neelesh Thakur <neelesh.thakur@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->



**Which issue(s) this PR fixes** (optional)
PWX-24862

**Special notes for your reviewer**:

