### PR TITLE
PWX-26155: Setting default region for purefb in case of missing region.

### DIFF
--- a/api/server/sdk/bucket_ops.go
+++ b/api/server/sdk/bucket_ops.go
@@ -33,6 +33,13 @@ type BucketServer struct {
 	server serverAccessor
 }
 
+const (
+	// S3 Drive name
+	S3Driver = "S3Driver"
+	// PureDBDrive name
+	PureFBDriver = "PureFBDriver"
+)
+
 func (s *BucketServer) driver(ctx context.Context) bucket.BucketDriver {
 	return s.server.bucketDriver(ctx)
 }
@@ -53,7 +60,7 @@ func (s *BucketServer) Create(
 	}
 	region := req.GetRegion()
 	if len(region) == 0 {
-		if strings.Compare(s.driver(ctx).String(), "PureFBDriver") == 0 {
+		if strings.Compare(s.driver(ctx).String(), PureFBDriver) == 0 {
 			region = "default"
 		} else {
 			return nil, status.Error(
@@ -90,7 +97,7 @@ func (s *BucketServer) Delete(
 	}
 	region := req.GetRegion()
 	if len(region) == 0 {
-		if strings.Compare(s.driver(ctx).String(), "PureFBDriver") == 0 {
+		if strings.Compare(s.driver(ctx).String(), PureFBDriver) == 0 {
 			region = "default"
 		} else {
 			return nil, status.Error(

--- a/api/server/sdk/bucket_ops.go
+++ b/api/server/sdk/bucket_ops.go
@@ -19,6 +19,7 @@ package sdk
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	"github.com/libopenstorage/openstorage/api"
 	bucket "github.com/libopenstorage/openstorage/bucket"
@@ -52,9 +53,13 @@ func (s *BucketServer) Create(
 	}
 	region := req.GetRegion()
 	if len(region) == 0 {
-		return nil, status.Error(
-			codes.InvalidArgument,
-			"Must supply the region")
+		if strings.Compare(s.driver(ctx).String(), "PureFBDriver") == 0 {
+			region = "default"
+		} else {
+			return nil, status.Error(
+				codes.InvalidArgument,
+				"Must supply the region")
+		}
 	}
 	logrus.Infof("Create bucket request received for Bucket: %s, Region: %s", name, region)
 
@@ -85,9 +90,14 @@ func (s *BucketServer) Delete(
 	}
 	region := req.GetRegion()
 	if len(region) == 0 {
-		return nil, status.Error(
-			codes.InvalidArgument,
-			"Must supply the region")
+		if strings.Compare(s.driver(ctx).String(), "PureFBDriver") == 0 {
+			region = "default"
+		} else {
+			return nil, status.Error(
+				codes.InvalidArgument,
+				"Must supply the region")
+		}
+
 	}
 	logrus.Infof("Delete bucket request received for Bucket: %s", id)
 

--- a/api/server/sdk/bucket_ops_test.go
+++ b/api/server/sdk/bucket_ops_test.go
@@ -84,7 +84,7 @@ func TestBucketCreateSuccessRegionMissingPureFB(t *testing.T) {
 	s.MockBucketDriver().
 		EXPECT().
 		String().
-		Return("PureFBDriver").
+		Return(PureFBDriver).
 		Times(1)
 
 	// Create CreateBucket response

--- a/api/server/sdk/bucket_ops_test.go
+++ b/api/server/sdk/bucket_ops_test.go
@@ -63,6 +63,46 @@ func TestBucketCreateSuccess(t *testing.T) {
 	assert.Equal(t, resp.BucketId, testMockResp.BucketId)
 }
 
+func TestBucketCreateSuccessRegionMissingPureFB(t *testing.T) {
+	// Create server and client connection
+	s := newTestServer(t)
+	defer s.Stop()
+	time.Sleep(1 * time.Second)
+
+	name := "test_bucket"
+	req := &api.BucketCreateRequest{
+		Name:                      name,
+		AnonymousBucketAccessMode: api.AnonymousBucketAccessMode_Private,
+	}
+
+	id := "test_bucket_id"
+	testMockResp := &api.BucketCreateResponse{
+		BucketId: id,
+	}
+
+	// Return PureFBDriver drive string
+	s.MockBucketDriver().
+		EXPECT().
+		String().
+		Return("PureFBDriver").
+		Times(1)
+
+	// Create CreateBucket response
+	s.MockBucketDriver().
+		EXPECT().
+		CreateBucket(name, "default", "", api.AnonymousBucketAccessMode_Private).
+		Return(id, nil).
+		Times(1)
+	// Setup client
+	c := api.NewOpenStorageBucketClient(s.Conn())
+
+	// Get info
+	resp, err := c.Create(context.Background(), req)
+
+	assert.NoError(t, err)
+	assert.Equal(t, resp.BucketId, testMockResp.BucketId)
+}
+
 func TestBucketCreateRegionMissing(t *testing.T) {
 	// Create server and client connection
 	s := newTestServer(t)
@@ -74,12 +114,17 @@ func TestBucketCreateRegionMissing(t *testing.T) {
 		Name: name,
 	}
 
+	// Return Non PureFBDriver name as String() response
+	s.MockBucketDriver().
+		EXPECT().
+		String().
+		Return("S3Driver").
+		Times(1)
 	// Setup client
 	c := api.NewOpenStorageBucketClient(s.Conn())
 
 	// Get info
 	_, err := c.Create(context.Background(), req)
-
 	assert.Error(t, err)
 }
 
@@ -112,6 +157,41 @@ func TestBucketCreateFailure(t *testing.T) {
 	_, err := c.Create(context.Background(), req)
 
 	assert.Error(t, err)
+}
+
+func TestBucketDeleteSuccessRegionMissingPureFB(t *testing.T) {
+	// Create server and client connection
+	s := newTestServer(t)
+	defer s.Stop()
+	time.Sleep(1 * time.Second)
+
+	id := "test_bucket_id"
+	req := &api.BucketDeleteRequest{
+		BucketId:    id,
+		ClearBucket: true,
+	}
+
+	// Return PureFBDriver drive string
+	s.MockBucketDriver().
+		EXPECT().
+		String().
+		Return("PureFBDriver").
+		Times(1)
+
+	// Create DeleteBucket response
+	s.MockBucketDriver().
+		EXPECT().
+		DeleteBucket(id, "default", "", true).
+		Return(nil).
+		Times(1)
+
+	// Setup client
+	c := api.NewOpenStorageBucketClient(s.Conn())
+
+	// Get info
+	_, err := c.Delete(context.Background(), req)
+
+	assert.NoError(t, err)
 }
 
 func TestBucketDeleteSuccess(t *testing.T) {
@@ -184,6 +264,12 @@ func TestBucketDeleteFailureRegionMissing(t *testing.T) {
 		BucketId: id,
 	}
 
+	// Return Non PureFBDriver name as String() response
+	s.MockBucketDriver().
+		EXPECT().
+		String().
+		Return("S3Driver").
+		Times(1)
 	// Setup client
 	c := api.NewOpenStorageBucketClient(s.Conn())
 


### PR DESCRIPTION
Signed-off-by: Priyanshu Pandey <ppandey@purestorage.com>

**Which issue(s) this PR fixes** (optional)
Closes #PWX-26155

**Special notes for your reviewer**:
Pure FB doesn't require setting a region. We are using S3 compatible APIs which expect a region to be passed so passing a default region in create and delete bucket api calls to satisfy the region check.
