### PR TITLE
PWX-26406-pt1: Optimizing NodeUnpublishVolume

### DIFF
--- a/csi/node.go
+++ b/csi/node.go
@@ -233,7 +233,7 @@ func (s *OsdCsiServer) NodeUnpublishVolume(
 	}
 
 	// Get volume information
-	vols, err := s.driver.Inspect([]string{req.GetVolumeId()})
+	vols, err := s.driver.Enumerate(&api.VolumeLocator{VolumeIds: []string{req.GetVolumeId()}}, nil)
 	if err != nil || len(vols) < 1 {
 		if err == kvdb.ErrNotFound {
 			clogger.WithContext(ctx).Infof("Volume %s was deleted or cannot be found: %s", req.GetVolumeId(), err.Error())

--- a/csi/node_test.go
+++ b/csi/node_test.go
@@ -839,7 +839,7 @@ func TestNodeUnpublishVolumeVolumeNotFound(t *testing.T) {
 		// Getting volume information
 		s.MockDriver().
 			EXPECT().
-			Inspect([]string{name}).
+			Enumerate(&api.VolumeLocator{VolumeIds: []string{name}}, nil).
 			Return(nil, fmt.Errorf("not found")).
 			Times(1),
 	)
@@ -871,7 +871,7 @@ func TestNodeUnpublishVolumeFailedToUnmount(t *testing.T) {
 	gomock.InOrder(
 		s.MockDriver().
 			EXPECT().
-			Inspect([]string{name}).
+			Enumerate(&api.VolumeLocator{VolumeIds: []string{name}}, nil).
 			Return([]*api.Volume{
 				&api.Volume{
 					Id: name,
@@ -928,7 +928,7 @@ func TestNodeUnpublishVolumeFailedDetach(t *testing.T) {
 	gomock.InOrder(
 		s.MockDriver().
 			EXPECT().
-			Inspect([]string{name}).
+			Enumerate(&api.VolumeLocator{VolumeIds: []string{name}}, nil).
 			Return([]*api.Volume{
 				&api.Volume{
 					Id: name,
@@ -990,7 +990,7 @@ func TestNodeUnpublishVolumeUnmount(t *testing.T) {
 	gomock.InOrder(
 		s.MockDriver().
 			EXPECT().
-			Inspect([]string{name}).
+			Enumerate(&api.VolumeLocator{VolumeIds: []string{name}}, nil).
 			Return([]*api.Volume{
 				&api.Volume{
 					Id: name,


### PR DESCRIPTION
* replacing "deep volume inspect" with cheaper equivalent "volume enumerate" call

Signed-off-by: Zoran Rajic <zrajic@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
The `NodeUnpublishVolume()` was using the "expensive" volume-inspect call, just to determine if the volume already existed, so that a different error can be displayed.

As a fix, we're using a "close equivalent" volume-enumerate call, which returns the volume-data from the cache, and avoids "deep volume inspect".  The returned data-structures are identical, also the lower-level function that gets called, is the same between the "volume-inspect" and "volume-enumerate" (except with "deep=true/false" parameter difference).

**Which issue(s) this PR fixes** (optional)
Closes # PWX-26406

**Special notes for your reviewer**:

