### PR TITLE
Adds a missing method that slipped into Porx directly

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1373,6 +1373,22 @@ func (s *ProxySpec) IsPureImport() bool {
 	return (s.PureBlockSpec != nil && s.PureBlockSpec.FullVolName != "") || (s.PureFileSpec != nil && s.PureFileSpec.FullVolName != "")
 }
 
+func (s *ProxySpec) GetPureFullVolumeName() string {
+	if !s.IsPureImport() {
+		return ""
+	}
+
+	if s.PureBlockSpec != nil {
+		return s.PureBlockSpec.FullVolName
+	}
+
+	if s.PureFileSpec != nil {
+		return s.PureFileSpec.FullVolName
+	}
+
+	return ""
+}
+
 // GetAllEnumInfo returns an EnumInfo for every proto enum
 func GetAllEnumInfo() []protoimpl.EnumInfo {
 	return file_api_api_proto_enumTypes


### PR DESCRIPTION
**What this PR does / why we need it**:
@pureneelesh noticed this when updating openstorage vendor and this method wasn't in release-9.5 (or master it turns out). Commit where it slipped into Porx is https://github.com/portworx/porx/commit/b8e78101443467105baf1f0414d33e8c7780b825#diff-e295365d6e35f64e39d4b464c205784290d3cc8346f9bfa447f98e6402203f08

