### PR TITLE
PWX-26615: avoid scheduling duplicate mountpath removal tasks

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -702,6 +702,11 @@ func (m *Mounter) RemoveMountPath(mountPath string, opts map[string]string) erro
 			symlinkName := hex.EncodeToString(hasher.Sum(nil))
 			symlinkPath := path.Join(m.trashLocation, symlinkName)
 
+			if p, err := filepath.EvalSymlinks(symlinkPath); err == nil && p == mountPath {
+				// we already scheduled the removal for this mountPath
+				return nil
+			}
+
 			if err = os.Symlink(mountPath, symlinkPath); err != nil {
 				if !os.IsExist(err) {
 					logrus.Errorf("Error creating sym link %s => %s. Err: %v", symlinkPath, mountPath, err)


### PR DESCRIPTION
**What this PR does / why we need it**:

We delay the removal of mountPath by 30 seconds. CSI NodeUnpublishVolume()
call fails if the mountPath still exists and kubelet retries the same call
call in quick succession (before the back-off slows it down). This
causes us to add duplicate tasks for removing the same mountPath.

This patch detects that we already scheduled the mountPath reomoval and
skips adding a task again.

Signed-off-by: Neelesh Thakur <neelesh.thakur@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->



**Which issue(s) this PR fixes** (optional)
PWX-26615

**Special notes for your reviewer**:

