### PR TITLE
PWX-26709: fix the intermittent failure in the unit test

### DIFF
--- a/pkg/sched/sched_test.go
+++ b/pkg/sched/sched_test.go
@@ -99,13 +99,13 @@ func TestMulti(t *testing.T) {
 		require.Equal(t, err, nil, "schedule multi")
 		taskIDs = append(taskIDs, taskID)
 	}
-	time.Sleep(3 * time.Second)
+	time.Sleep(3500 * time.Millisecond)
 
 	// all tasks should have been run once already
 	for i, tc := range tcs {
 		require.True(t, tc.count == 1, "count was %d for task %d", tc.count, i)
 	}
-	time.Sleep(17 * time.Second)
+	time.Sleep(16500 * time.Millisecond)
 
 	// Check counters for runOnce and periodic, cancel the runOnce tasks.
 	for i, tc := range tcs {


### PR DESCRIPTION
**What this PR does / why we need it**:

Need to sleep a bit longer to ensure that that tasks get chance to run.

This was the failure in travis build:

--- FAIL: TestMulti (3.00s)
	Error Trace:	sched_test.go:106
	Error:		Should be true
	Messages:	count was 0 for task 0

FAIL

Signed-off-by: Neelesh Thakur <neelesh.thakur@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->



**Which issue(s) this PR fixes** (optional)
PWX-26709

**Special notes for your reviewer**:

