### PR TITLE
PWX-26792 Fix Race condition in unmount

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -606,7 +606,6 @@ func (m *Mounter) Unmount(
 	}
 	info, ok := m.mounts[device]
 	if !ok {
-		m.Unlock()
 		logrus.Warnf("Unable to unmount device %q path %q: %v",
 			devPath, path, ErrEnoent.Error())
 		logrus.Infof("Found %v mounts in mounter's cache: ", len(m.mounts))
@@ -620,6 +619,7 @@ func (m *Mounter) Unmount(
 				logrus.Infof("\t Mountpath: %v Rootpath: %v", path.Path, path.Root)
 			}
 		}
+		m.Unlock()
 		return ErrEnoent
 	}
 	m.Unlock()

--- a/pkg/mount/mount_test.go
+++ b/pkg/mount/mount_test.go
@@ -38,15 +38,15 @@ func TestRawMounter(t *testing.T) {
 }
 
 func allTests(t *testing.T, source, dest string) {
-	// load(t, source, dest)
-	// mountTest(t, source, dest)
+	load(t, source, dest)
+	mountTest(t, source, dest)
 	mountTestParallel(t, source, dest)
-	// inspect(t, source, dest)
-	// reload(t, source, dest)
-	// hasMounts(t, source, dest)
-	// refcounts(t, source, dest)
-	// exists(t, source, dest)
-	// shutdown(t, source, dest)
+	inspect(t, source, dest)
+	reload(t, source, dest)
+	hasMounts(t, source, dest)
+	refcounts(t, source, dest)
+	exists(t, source, dest)
+	shutdown(t, source, dest)
 }
 
 func setupNFS(t *testing.T) {

--- a/pkg/mount/mount_test.go
+++ b/pkg/mount/mount_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sync"
 	"syscall"
 	"testing"
 
@@ -37,14 +38,15 @@ func TestRawMounter(t *testing.T) {
 }
 
 func allTests(t *testing.T, source, dest string) {
-	load(t, source, dest)
-	mountTest(t, source, dest)
-	inspect(t, source, dest)
-	reload(t, source, dest)
-	hasMounts(t, source, dest)
-	refcounts(t, source, dest)
-	exists(t, source, dest)
-	shutdown(t, source, dest)
+	// load(t, source, dest)
+	// mountTest(t, source, dest)
+	mountTestParallel(t, source, dest)
+	// inspect(t, source, dest)
+	// reload(t, source, dest)
+	// hasMounts(t, source, dest)
+	// refcounts(t, source, dest)
+	// exists(t, source, dest)
+	// shutdown(t, source, dest)
 }
 
 func setupNFS(t *testing.T) {
@@ -92,6 +94,42 @@ func mountTest(t *testing.T, source, dest string) {
 	require.NoError(t, err, "Failed in mount")
 	err = m.Unmount(source, dest, 0, 0, nil)
 	require.NoError(t, err, "Failed in unmount")
+}
+
+// mountTestParallel runs mount and unmount in parallel with serveral dirs
+// in addition, we trigger failed unmount to test race condition in the case
+// source directory is not found in the cache
+func mountTestParallel(t *testing.T, source, dest string) {
+	mountFunc := func(s, d string) {
+		err := m.Mount(0, s, d, "", syscall.MS_BIND, "", 0, nil)
+		require.NoError(t, err, "Failed in mount")
+	}
+	unmountFunc := func(s, d string) {
+		err := m.Unmount(s, d, 0, 0, nil)
+		require.NoError(t, err, "Failed in unmount")
+	}
+	unmountFailedFunc := func(s, d string) {
+		err := m.Unmount(s, d, 0, 0, nil)
+		require.Error(t, err, "Failed in unmount; expected an error")
+	}
+	numRuns := 200
+	var wg sync.WaitGroup
+	for i := 1; i < numRuns; i++ {
+		wg.Add(1)
+		s := fmt.Sprintf("%s_%d", source, i)
+		d := fmt.Sprintf("%s_%d", dest, i)
+		random_s := fmt.Sprintf("%s__%d", source, i)
+		cleandir(s)
+		cleandir(d)
+		go func() {
+			mountFunc(s, d)
+			unmountFunc(s, d)
+			unmountFailedFunc(random_s, d)
+			defer wg.Done()
+		}()
+	}
+	wg.Wait()
+
 }
 
 func inspect(t *testing.T, source, dest string) {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
We hit a race condition in unmount with concurrent iteration and write. This was due to unlocking too early before reading ends. This commit adds the fix and UT to verify.

**Which issue(s) this PR fixes** (optional)
JIRA: PWX-26792

**Special notes for your reviewer**:
- Testing: UT passed
- UT error without the fix when run:
`go test  github.com/libopenstorage/openstorage/pkg/mount/... `
```
fatal error: concurrent map iteration and map write

goroutine 153 [running]:
runtime.throw(0xb74a14, 0x26)
	/usr/local/go/src/runtime/panic.go:1116 +0x72 fp=0xc0001e7c78 sp=0xc0001e7c48 pc=0x4366f2
runtime.mapiternext(0xc0001e7e50)
	/usr/local/go/src/runtime/map.go:853 +0x552 fp=0xc0001e7cf8 sp=0xc0001e7c78 pc=0x411492
github.com/libopenstorage/openstorage/pkg/mount.(*Mounter).Unmount(0xc0001acb98, 0xc000594960, 0x1b, 0xc000594940, 0x1b, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/dahuang/go/src/github.com/libopenstorage/openstorage/pkg/mount/mount.go:613 +0xa07 fp=0xc0001e7ed0 sp=0xc0001e7cf8 pc=0x9b45e7
github.com/libopenstorage/openstorage/pkg/mount.mountTestParallel.func3(0xc000594960, 0x1b, 0xc000594940, 0x1b)
	/home/dahuang/go/src/github.com/libopenstorage/openstorage/pkg/mount/mount_test.go:111 +0x87 fp=0xc0001e7f48 sp=0xc0001e7ed0 pc=0x9bd8a7
github.com/libopenstorage/openstorage/pkg/mount.mountTestParallel.func4(0xc00051c310, 0xc000594920, 0x1a, 0xc000594940, 0x1b, 0xc00051c320, 0xc00051c330, 0xc000594960, 0x1b, 0xc000259e30)
	/home/dahuang/go/src/github.com/libopenstorage/openstorage/pkg/mount/mount_test.go:126 +0xc7 fp=0xc0001e7f90 sp=0xc0001e7f48 pc=0x9bd9f7
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1373 +0x1 fp=0xc0001e7f98 sp=0xc0001e7f90 pc=0x468841
created by github.com/libopenstorage/openstorage/pkg/mount.mountTestParallel
	/home/dahuang/go/src/github.com/libopenstorage/openstorage/pkg/mount/mount_test.go:123 +0x476

goroutine 1 [chan receive]:
........ lines skip ........
```

Signed-off-by: dahuang <dahuang@purestorage.com>
