### PR TITLE
PWX-26782 Fix Race condition in unmount (#2116)

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -605,7 +605,6 @@ func (m *Mounter) Unmount(
 	}
 	info, ok := m.mounts[device]
 	if !ok {
-		m.Unlock()
 		logrus.Warnf("Unable to unmount device %q path %q: %v",
 			devPath, path, ErrEnoent.Error())
 		logrus.Infof("Found %v mounts in mounter's cache: ", len(m.mounts))
@@ -619,6 +618,7 @@ func (m *Mounter) Unmount(
 				logrus.Infof("\t Mountpath: %v Rootpath: %v", path.Path, path.Root)
 			}
 		}
+		m.Unlock()
 		return ErrEnoent
 	}
 	m.Unlock()


### PR DESCRIPTION
We hit a race condition in unmount with concurrent iteration and write. This was due to unlocking too early before reading ends. This commits adds the fix and UT to verify.

JIRA: PWX-26782

Testing: UT passed

Signed-off-by: dahuang <dahuang@purestorage.com>


