### PR TITLE
Automated cherry pick of #2114: Return non-final NodePublishVolume codes and

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -188,7 +188,7 @@ func (s *OsdCsiServer) ValidateVolumeCapabilities(
 	conn, err := s.getConn()
 	if err != nil {
 		return nil, status.Errorf(
-			codes.Internal,
+			codes.Unavailable,
 			"Unable to connect to SDK server: %v", err)
 	}
 
@@ -530,7 +530,7 @@ func (s *OsdCsiServer) CreateVolume(
 		conn, err = s.getConn()
 		if err != nil {
 			return nil, status.Errorf(
-				codes.Internal,
+				codes.Unavailable,
 				"Unable to connect to SDK server: %v", err)
 		}
 	}
@@ -623,7 +623,7 @@ func (s *OsdCsiServer) DeleteVolume(
 	conn, err := s.getConn()
 	if err != nil {
 		return nil, status.Errorf(
-			codes.Internal,
+			codes.Unavailable,
 			"Unable to connect to SDK server: %v", err)
 	}
 
@@ -643,7 +643,7 @@ func (s *OsdCsiServer) DeleteVolume(
 			req.GetVolumeId(),
 			err.Error())
 		clogger.WithContext(ctx).Errorln(e)
-		return nil, status.Error(codes.Internal, e)
+		return nil, status.Error(codes.Aborted, e)
 	}
 
 	return &csi.DeleteVolumeResponse{}, nil
@@ -676,7 +676,7 @@ func (s *OsdCsiServer) ControllerExpandVolume(
 	conn, err := s.getConn()
 	if err != nil {
 		return nil, status.Errorf(
-			codes.Internal,
+			codes.Unavailable,
 			"Unable to connect to SDK server: %v", err)
 	}
 
@@ -846,7 +846,7 @@ func (s *OsdCsiServer) CreateSnapshot(
 	conn, err := s.getConn()
 	if err != nil {
 		return nil, status.Errorf(
-			codes.Internal,
+			codes.Unavailable,
 			"Unable to connect to SDK server: %v", err)
 	}
 
@@ -927,7 +927,7 @@ func (s *OsdCsiServer) DeleteSnapshot(
 	conn, err := s.getConn()
 	if err != nil {
 		return nil, status.Errorf(
-			codes.Internal,
+			codes.Unavailable,
 			"Unable to connect to SDK server: %v", err)
 	}
 
@@ -979,7 +979,7 @@ func (s *OsdCsiServer) listSingleSnapshot(
 	conn, err := s.getConn()
 	if err != nil {
 		return nil, status.Errorf(
-			codes.Internal,
+			codes.Unavailable,
 			"Unable to connect to SDK server: %v", err)
 	}
 
@@ -1046,7 +1046,7 @@ func (s *OsdCsiServer) listMultipleSnapshots(
 	conn, err := s.getConn()
 	if err != nil {
 		return nil, status.Errorf(
-			codes.Internal,
+			codes.Unavailable,
 			"Unable to connect to SDK server: %v", err)
 	}
 

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -2640,7 +2640,7 @@ func TestControllerDeleteVolumeError(t *testing.T) {
 	assert.NotNil(t, err)
 	serverError, ok := status.FromError(err)
 	assert.True(t, ok)
-	assert.Equal(t, serverError.Code(), codes.Internal)
+	assert.Equal(t, serverError.Code(), codes.Aborted)
 	assert.Contains(t, serverError.Message(), "Unable to delete")
 	assert.Contains(t, serverError.Message(), "MOCKERRORTEST")
 }

--- a/csi/node_test.go
+++ b/csi/node_test.go
@@ -377,7 +377,7 @@ func TestNodePublishVolumeFailedToAttach(t *testing.T) {
 	assert.NotNil(t, err)
 	serverError, ok := status.FromError(err)
 	assert.True(t, ok)
-	assert.Equal(t, serverError.Code(), codes.Internal)
+	assert.Equal(t, codes.Unavailable, serverError.Code())
 	assert.Contains(t, serverError.Message(), "Unable to attach volume")
 }
 
@@ -440,7 +440,7 @@ func TestNodePublishVolumeFailedMount(t *testing.T) {
 	assert.NotNil(t, err)
 	serverError, ok := status.FromError(err)
 	assert.True(t, ok)
-	assert.Equal(t, serverError.Code(), codes.Internal)
+	assert.Equal(t, codes.Unavailable, serverError.Code())
 	assert.Contains(t, serverError.Message(), "Unable to mount volume")
 }
 
@@ -971,7 +971,7 @@ func TestNodeUnpublishVolumeFailedDetach(t *testing.T) {
 	assert.NotNil(t, err)
 	serverError, ok := status.FromError(err)
 	assert.True(t, ok)
-	assert.Equal(t, serverError.Code(), codes.Internal)
+	assert.Equal(t, serverError.Code(), codes.Canceled)
 	assert.Contains(t, serverError.Message(), "Unable to detach volume")
 	assert.Contains(t, serverError.Message(), "DETACH ERROR")
 }


### PR DESCRIPTION
Cherry pick of #2114 on release-9.5.

#2114: Return non-final NodePublishVolume codes and

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.