### PR TITLE
PWX-27439-pt1 Pass trashlocation in NFS mount

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package mount
@@ -702,9 +703,9 @@ func (m *Mounter) RemoveMountPath(mountPath string, opts map[string]string) erro
 			hasher.Write([]byte(mountPath))
 			symlinkName := hex.EncodeToString(hasher.Sum(nil))
 			symlinkPath := path.Join(m.trashLocation, symlinkName)
-
 			if p, err := filepath.EvalSymlinks(symlinkPath); err == nil && p == mountPath {
 				// we already scheduled the removal for this mountPath
+				logrus.Infof("RemoveMountPath is called where symlink still exists on: %v", symlinkPath)
 				return nil
 			}
 
@@ -716,6 +717,7 @@ func (m *Mounter) RemoveMountPath(mountPath string, opts map[string]string) erro
 
 			if _, err = sched.Instance().Schedule(
 				func(sched.Interval) {
+					logrus.Infof("[RemoveMountPath] Scheduled removing mount path %v ", mountPath)
 					if err = m.removeMountPath(mountPath); err != nil {
 						return
 					}
@@ -748,6 +750,7 @@ func (m *Mounter) EmptyTrashDir() error {
 	if _, err := sched.Instance().Schedule(
 		func(sched.Interval) {
 			for _, file := range files {
+				logrus.Infof("[EmptyTrashDir] Scheduled removing file %v in trash location %v", file.Name(), m.trashLocation)
 				e := m.removeSoftlinkAndTarget(path.Join(m.trashLocation, file.Name()))
 				if e != nil {
 					logrus.Errorf("failed to remove link: %s. Err: %v", path.Join(m.trashLocation, file.Name()), e)
@@ -817,7 +820,7 @@ func New(
 	case DeviceMount:
 		return NewDeviceMounter(identifiers, mountImpl, allowedDirs, trashLocation)
 	case NFSMount:
-		return NewNFSMounter(identifiers, mountImpl, allowedDirs)
+		return NewNFSMounter(identifiers, mountImpl, allowedDirs, trashLocation)
 	case BindMount:
 		return NewBindMounter(identifiers, mountImpl, allowedDirs, trashLocation)
 	case CustomMount:

--- a/pkg/mount/nfs.go
+++ b/pkg/mount/nfs.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package mount
@@ -29,15 +30,17 @@ type nfsMounter struct {
 func NewNFSMounter(servers []*regexp.Regexp,
 	mountImpl MountImpl,
 	allowedDirs []string,
+	trashLocation string,
 ) (Manager, error) {
 	m := &nfsMounter{
 		servers: servers,
 		Mounter: Mounter{
-			mountImpl:   mountImpl,
-			mounts:      make(DeviceMap),
-			paths:       make(PathMap),
-			allowedDirs: allowedDirs,
-			kl:          keylock.New(),
+			mountImpl:     mountImpl,
+			mounts:        make(DeviceMap),
+			paths:         make(PathMap),
+			allowedDirs:   allowedDirs,
+			kl:            keylock.New(),
+			trashLocation: trashLocation,
 		},
 	}
 	err := m.Load([]*regexp.Regexp{}) // Input value is not used, can be anything
@@ -52,6 +55,7 @@ func (m *nfsMounter) Reload(source string) error {
 	newNFSm, err := NewNFSMounter([]*regexp.Regexp{regexp.MustCompile(NFSAllServers)},
 		m.mountImpl,
 		m.Mounter.allowedDirs,
+		m.trashLocation,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION



Signed-off-by: dahuang <dahuang@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Previously, mount path was never removed because scheduled task was cancelled when PX is down. And NFS mount does not pass on the trashlocation for symlink removal. This commit adds the parameter and more logging for when removal happens.

**Which issue(s) this PR fixes** (optional)
PWX-27439

**Special notes for your reviewer**:
There will be a second part of related to the ticket on the porx side, to pass the trashlocation down from the mounter.New()
