### PR TITLE
Only run "branch" job on master and release-x.y

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,3 +30,7 @@ notifications:
       - cnbu-controlplane@purestorage.com
     on_success: change
     on_failure: always
+branches:
+  only:
+    - master
+    - /^release-.*$/


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes the case where we were getting double travis jobs for every PR. There was a PR travis job and branch travis job.

The branch travis job will only run on master and release-x.y now.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

