### PR TITLE
PWX-27439 release 9.5

### DIFF
--- a/pkg/mount/nfs.go
+++ b/pkg/mount/nfs.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package mount
@@ -29,15 +30,17 @@ type nfsMounter struct {
 func NewNFSMounter(servers []string,
 	mountImpl MountImpl,
 	allowedDirs []string,
+	trashLocation string,
 ) (Manager, error) {
 	m := &nfsMounter{
 		servers: servers,
 		Mounter: Mounter{
-			mountImpl:   mountImpl,
-			mounts:      make(DeviceMap),
-			paths:       make(PathMap),
-			allowedDirs: allowedDirs,
-			kl:          keylock.New(),
+			mountImpl:     mountImpl,
+			mounts:        make(DeviceMap),
+			paths:         make(PathMap),
+			allowedDirs:   allowedDirs,
+			kl:            keylock.New(),
+			trashLocation: trashLocation,
 		},
 	}
 	err := m.Load([]string{""})
@@ -52,6 +55,7 @@ func (m *nfsMounter) Reload(source string) error {
 	newNFSm, err := NewNFSMounter([]string{NFSAllServers},
 		m.mountImpl,
 		m.Mounter.allowedDirs,
+		m.trashLocation,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
Previously, mount path was never removed because scheduled task was cancelled when PX is down. And NFS mount does not pass on the trashlocation for symlink removal. This commit adds the parameter and more logging for when removal happens.

Testing: local testing

JIRA: PWX-27439

Signed-off-by: dahuang <dahuang@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

