### PR TITLE
PWX-26915-pt1: Auto-TLS support

### DIFF
--- a/volume/drivers/pwx/connection.go
+++ b/volume/drivers/pwx/connection.go
@@ -9,11 +9,10 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/libopenstorage/openstorage/pkg/grpcserver"
 	"github.com/portworx/sched-ops/k8s/core"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
-
-	"github.com/libopenstorage/openstorage/pkg/grpcserver"
 )
 
 // ConnectionParamsBuilder contains dependencies needed for building Dial options and endpoints
@@ -125,7 +124,7 @@ func (cpb *ConnectionParamsBuilder) BuildClientsEndpoints() (string, string, err
 		return "", "", fmt.Errorf("failed to get k8s service specification: %v", err)
 	}
 
-	endpoint = fmt.Sprintf("%s.%s", svc.Name, svc.Namespace)
+	endpoint = fmt.Sprintf("%s.%s.svc.cluster.local", svc.Name, svc.Namespace)
 
 	var restPort int
 	var restPortSecured int
@@ -223,6 +222,17 @@ func (cpb *ConnectionParamsBuilder) BuildDialOps() ([]grpc.DialOption, error) {
 	rootCA, err := cpb.getCaCertBytes()
 	if err != nil {
 		return nil, err
+	}
+
+	// add Kubernetes CA, if available
+	if k8sCA, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"); err == nil && len(k8sCA) > 0 {
+		logrus.Infof("Found Kubernetes CA, adding into gRPC dial options")
+		if len(rootCA) <= 0 {
+			rootCA = k8sCA
+		} else {
+			rootCA = append(rootCA, '\n')
+			rootCA = append(rootCA, k8sCA...)
+		}
 	}
 
 	tlsDialOptions, err := grpcserver.GetTlsDialOptions(rootCA)

--- a/volume/drivers/pwx/connection.go
+++ b/volume/drivers/pwx/connection.go
@@ -1,6 +1,7 @@
 package pwx
 
 import (
+	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -230,6 +231,7 @@ func (cpb *ConnectionParamsBuilder) BuildDialOps() ([]grpc.DialOption, error) {
 		if len(rootCA) <= 0 {
 			rootCA = k8sCA
 		} else {
+			rootCA = bytes.Trim(rootCA, "\r\n")
 			rootCA = append(rootCA, '\n')
 			rootCA = append(rootCA, k8sCA...)
 		}


### PR DESCRIPTION
* expand to "full" service names when using Kuberenetes DNS for service discovery
* adding Kuberenetes CA for gRPC dial-opts when SSL enabled

Signed-off-by: Zoran Rajic <zrajic@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

These changes are a part of the "auromatic SSL/TLS setup" effort

* change to "full" service names when using Kuberenetes DNS for discovery
  - required since the SSL certs are registered to FULL K8s dns-name `portworx-service.kube-system.svc.cluster.local`
  - using short `portworx-service.kube-system` dns-alias will result in SSL-validation errors
* adding Kuberenetes CA for gRPC dial-opts when SSL enabled
  - required since PX certs will be signed by K8s CA

**Which issue(s) this PR fixes** (optional)
Closes #  PWX-26915 (part 1)

**Special notes for your reviewer**:

