### PR TITLE
Bump CSI version to 1.7

### DIFF
--- a/csi/csi.go
+++ b/csi/csi.go
@@ -137,7 +137,7 @@ func NewOsdCsiServer(config *OsdCsiServerConfig) (grpcserver.Server, error) {
 
 	// Create server
 	gServer, err := grpcserver.New(&grpcserver.GrpcServerConfig{
-		Name:    "CSI 1.6",
+		Name:    "CSI 1.7",
 		Net:     config.Net,
 		Address: config.Address,
 		Opts:    opts,


### PR DESCRIPTION
Dependabot already updated this, but we need to bump the text

Signed-off-by: Grant Griffiths <ggriffiths@purestorage.com>
**What this PR does / why we need it**:
Bumps the CSI spec text to 1.7 for PX 2.13.0

Dependabot already updated the dependency. This handles the server text.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

