### PR TITLE
release-9.6: Add CSI standard pvc name/namespace and csi filter

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -50,6 +50,10 @@ const (
 	intreePvcNameKey      = "pvc"
 	intreePvcNamespaceKey = "namespace"
 
+	// CSI keys for PVC metadata
+	csiPVCNameKey      = "csi.storage.k8s.io/pvc/name"
+	csiPVCNamespaceKey = "csi.storage.k8s.io/pvc/namespace"
+
 	volumeCapabilityMessageMultinodeVolume    = "Volume is a multinode volume"
 	volumeCapabilityMessageNotMultinodeVolume = "Volume is not a multinode volume"
 	volumeCapabilityMessageReadOnlyVolume     = "Volume is read only"
@@ -342,6 +346,12 @@ func getPVCMetadata(params map[string]string) (map[string]string, error) {
 	metadata, err = addJsonMapToMetadata(params[osdPvcLabelsKey], metadata)
 	if err != nil {
 		return nil, err
+	}
+	if pvcName, ok := params[csiPVCNameKey]; ok {
+		metadata[intreePvcNameKey] = pvcName
+	}
+	if pvcNamespace, ok := params[csiPVCNamespaceKey]; ok {
+		metadata[intreePvcNamespaceKey] = pvcNamespace
 	}
 
 	return metadata, nil

--- a/csi/controller.go
+++ b/csi/controller.go
@@ -51,6 +51,7 @@ const (
 	intreePvcNamespaceKey = "namespace"
 
 	// CSI keys for PVC metadata
+	csiPVNameKey       = "csi.storage.k8s.io/pv/name"
 	csiPVCNameKey      = "csi.storage.k8s.io/pvc/name"
 	csiPVCNamespaceKey = "csi.storage.k8s.io/pvc/namespace"
 
@@ -362,6 +363,9 @@ func cleanupVolumeLabels(labels map[string]string) map[string]string {
 	delete(labels, osdPvcNamespaceKey)
 	delete(labels, osdPvcAnnotationsKey)
 	delete(labels, osdPvcLabelsKey)
+	delete(labels, csiPVNameKey)
+	delete(labels, csiPVCNameKey)
+	delete(labels, csiPVCNamespaceKey)
 
 	return labels
 }

--- a/csi/csi.go
+++ b/csi/csi.go
@@ -25,6 +25,7 @@ import (
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/libopenstorage/openstorage/api"
+	"github.com/libopenstorage/openstorage/csi/sched/k8s"
 	"github.com/libopenstorage/openstorage/pkg/correlation"
 	"github.com/libopenstorage/openstorage/pkg/options"
 	"github.com/portworx/kvdb"
@@ -60,12 +61,13 @@ func init() {
 // OsdCsiServerConfig provides the configuration to the
 // the gRPC CSI server created by NewOsdCsiServer()
 type OsdCsiServerConfig struct {
-	Net        string
-	Address    string
-	DriverName string
-	Cluster    cluster.Cluster
-	SdkUds     string
-	SdkPort    string
+	Net           string
+	Address       string
+	DriverName    string
+	Cluster       cluster.Cluster
+	SdkUds        string
+	SdkPort       string
+	SchedulerName string
 
 	// Name to be reported back to the CO. If not provided,
 	// the name will be in the format of <driver>.openstorage.org
@@ -125,15 +127,27 @@ func NewOsdCsiServer(config *OsdCsiServerConfig) (grpcserver.Server, error) {
 		return nil, fmt.Errorf("Unable to get driver %s info: %s", config.DriverName, err.Error())
 	}
 
-	// Add correlation interceptor
+	// create correlation interceptor
+	var unaryInterceptors []grpc.UnaryServerInterceptor
 	correlationInterceptor := correlation.ContextInterceptor{
 		Origin: correlation.ComponentCSIDriver,
 	}
 	opts := make([]grpc.ServerOption, 0)
-	opts = append(opts, grpc.UnaryInterceptor(
-		grpc_middleware.ChainUnaryServer(
-			correlationInterceptor.ContextUnaryServerInterceptor,
-		)))
+	unaryInterceptors = append(unaryInterceptors, correlationInterceptor.ContextUnaryServerInterceptor)
+
+	// create scheduler interceptor
+	switch config.SchedulerName {
+	case "kubernetes":
+		logrus.Infof("CSI K8s filter being added for %s scheduler", config.SchedulerName)
+		ki := k8s.NewInterceptor()
+		unaryInterceptors = append(unaryInterceptors, ki.SchedUnaryInterceptor)
+
+	default:
+		logrus.Infof("No CSI filter being added for %s scheduler", config.SchedulerName)
+	}
+
+	// Add interceptors
+	opts = append(opts, grpc.UnaryInterceptor(grpc_middleware.ChainUnaryServer(unaryInterceptors...)))
 
 	// Create server
 	gServer, err := grpcserver.New(&grpcserver.GrpcServerConfig{

--- a/csi/sched/filter.go
+++ b/csi/sched/filter.go
@@ -1,0 +1,9 @@
+package sched
+
+import (
+	csi "github.com/container-storage-interface/spec/lib/go/csi"
+)
+
+type Filter interface {
+	PreVolumeCreate(req *csi.CreateVolumeRequest) (*csi.CreateVolumeRequest, error)
+}

--- a/csi/sched/interceptor.go
+++ b/csi/sched/interceptor.go
@@ -1,0 +1,48 @@
+package sched
+
+import (
+	"context"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// FilterInterceptor is a wrapper for the filter
+// to be used an interceptor
+type FilterInterceptor struct {
+	Filter
+}
+
+// SchedUnaryInterceptor calls the filter function based on the req
+func (fi *FilterInterceptor) SchedUnaryInterceptor(
+	ctx context.Context,
+	req interface{},
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+) (interface{}, error) {
+	var err error
+
+	switch req.(type) {
+	case *csi.CreateVolumeRequest:
+		csiReq := req.(*csi.CreateVolumeRequest)
+		req, err = fi.Filter.PreVolumeCreate(csiReq)
+		if err != nil {
+			logrus.WithContext(ctx).Errorf("CSI pre-create filter failed: %v", err)
+
+			// Return an aborted code to retry from the csi-provisioner.
+			// We cannot ignore this error or else a volume will be created w/
+			// incorrect locator.VolumeLabels.
+			return nil, status.Error(codes.Aborted, "pre-create filter failed: %v")
+		} else {
+			logrus.WithContext(ctx).Tracef("K8s-CSI filter: Filter applied successfully for request %T", req)
+		}
+	default:
+		logrus.WithContext(ctx).Tracef("K8s-CSI filter: Ignoring filter for this request: %T", req)
+	}
+
+	return handler(ctx, req)
+}

--- a/csi/sched/k8s/k8s.go
+++ b/csi/sched/k8s/k8s.go
@@ -1,0 +1,84 @@
+package k8s
+
+import (
+	"fmt"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/libopenstorage/openstorage/csi/sched"
+	"github.com/portworx/sched-ops/k8s/core"
+	v1 "k8s.io/api/core/v1"
+)
+
+const (
+	// Openstorage specific parameters
+	osdParameterPrefix   = "csi.openstorage.org/"
+	osdPvcNameKey        = osdParameterPrefix + "pvc-name"
+	osdPvcNamespaceKey   = osdParameterPrefix + "pvc-namespace"
+	osdPvcAnnotationsKey = osdParameterPrefix + "pvc-annotations"
+	osdPvcLabelsKey      = osdParameterPrefix + "pvc-labels"
+
+	// CSI keys for PVC metadata
+	csiPVCNameKey      = "csi.storage.k8s.io/pvc/name"
+	csiPVCNamespaceKey = "csi.storage.k8s.io/pvc/namespace"
+)
+
+type k8s struct{}
+
+// PreVolumeCreate takes a CSI request and modifies it for k8s scheduler
+func (k *k8s) PreVolumeCreate(req *csi.CreateVolumeRequest) (*csi.CreateVolumeRequest, error) {
+	var err error
+
+	// Get PVC
+	pvcName, ok := req.Parameters[csiPVCNameKey]
+	if !ok {
+		return nil, fmt.Errorf("CSI PVC Name/Namespace not provided to this request")
+	}
+	pvcNamespace, ok := req.Parameters[csiPVCNamespaceKey]
+	if !ok {
+		return nil, fmt.Errorf("CSI PVC Name/Namespace not provided to this request")
+	}
+	pvc, err := core.Instance().GetPersistentVolumeClaim(pvcName, pvcNamespace)
+	if err != nil {
+		return nil, err
+	}
+
+	// add pvc name, namespace, annotations and labels in the parameters
+	req.Parameters, err = addPVCMetadataParams(req.Parameters, pvc)
+	if err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// NewInterceptor returns a interceptor wrapper around the k8s implementation
+func NewInterceptor() sched.FilterInterceptor {
+	return sched.FilterInterceptor{
+		Filter: &k8s{},
+	}
+}
+
+func addPVCMetadataParams(params map[string]string, pvc *v1.PersistentVolumeClaim) (map[string]string, error) {
+	if pvc.Labels == nil {
+		pvc.Labels = make(map[string]string)
+	}
+	if pvc.Annotations == nil {
+		pvc.Annotations = make(map[string]string)
+	}
+	if params == nil {
+		params = make(map[string]string)
+	}
+
+	// add all annotations to labels. Annotations take precedence, so we will overwrite
+	// labels with annotations if they have overlapping keys.
+	for k, v := range pvc.Annotations {
+		pvc.Labels[k] = v
+	}
+	for k, v := range pvc.Labels {
+		params[k] = v
+	}
+	params[osdPvcNameKey] = pvc.Name
+	params[osdPvcNamespaceKey] = pvc.Namespace
+
+	return params, nil
+}


### PR DESCRIPTION
Cherry pick of #2039 on release-9.6.

#2039: Add CSI standard pvc name/namespace

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.