### PR TITLE
[CSI] Adjust error codes for snapshotting to be non-final

### DIFF
--- a/api/server/sdk/volume_ops.go
+++ b/api/server/sdk/volume_ops.go
@@ -168,8 +168,16 @@ func (s *VolumeServer) create(
 			Name: volName,
 		}, false)
 		if err != nil {
+			if err == kvdb.ErrNotFound {
+				return "", status.Errorf(
+					codes.Aborted,
+					"unable to create snapshot with parent ID %s: %v",
+					parent.GetId(),
+					err.Error())
+			}
+
 			return "", status.Errorf(
-				codes.Internal,
+				codes.Aborted,
 				"unable to create snapshot: %s",
 				err.Error())
 		}

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -1333,7 +1333,7 @@ func TestControllerCreateVolumeBadSnapshot(t *testing.T) {
 	assert.NotNil(t, err)
 	serverError, ok := status.FromError(err)
 	assert.True(t, ok)
-	assert.Equal(t, serverError.Code(), codes.Internal)
+	assert.Equal(t, serverError.Code(), codes.Aborted)
 	assert.Contains(t, serverError.Message(), "snapshoterr")
 }
 


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <ggriffiths@purestorage.com>
**What this PR does / why we need it**:
We were seeing some cases where snapshotting retries do not happen. 

This happens when an error is non-final:
https://github.com/kubernetes-csi/external-snapshotter/blob/v6.0.1/pkg/sidecar-controller/snapshot_controller.go#L656-L678

In addition, we were checking the SDK Server response to be `kvdb.ErrNotFound`, but the SDK server only returns grpc status errors. We need to check for codes.NotFound instead.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

