### PR TITLE
CSI: Cleanup failed snapshot and re-create on next retry

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -912,16 +912,18 @@ func (s *OsdCsiServer) CreateSnapshot(
 		if req.GetSourceVolumeId() != v.GetSource().GetParent() {
 			return nil, status.Error(codes.AlreadyExists, "Requested snapshot already exists for another source volume id")
 		}
-
-		return &csi.CreateSnapshotResponse{
-			Snapshot: &csi.Snapshot{
-				SizeBytes:      int64(v.GetSpec().GetSize()),
-				SnapshotId:     v.GetId(),
-				SourceVolumeId: v.GetSource().GetParent(),
-				CreationTime:   v.GetCtime(),
-				ReadyToUse:     isSnapshotReady(v),
-			},
-		}, nil
+		readyToUse := isSnapshotReady(v)
+		if readyToUse {
+			return &csi.CreateSnapshotResponse{
+				Snapshot: &csi.Snapshot{
+					SizeBytes:      int64(v.GetSpec().GetSize()),
+					SnapshotId:     v.GetId(),
+					SourceVolumeId: v.GetSource().GetParent(),
+					CreationTime:   v.GetCtime(),
+					ReadyToUse:     readyToUse,
+				},
+			}, nil
+		}
 	}
 
 	// Get any labels passed in by the CO
@@ -944,13 +946,30 @@ func (s *OsdCsiServer) CreateSnapshot(
 			// https://github.com/kubernetes-csi/external-snapshotter/blob/v6.0.1/pkg/sidecar-controller/snapshot_controller.go#L656-L678
 			return nil, status.Errorf(codes.Aborted, "Volume id %s not found: %v", req.GetSourceVolumeId(), err)
 		}
-		return nil, status.Errorf(codes.Internal, "Failed to create snapshot: %v", err)
+
+		// Check if snapshot has been created but is in error state
+		snapInfo, errFindFailed := util.VolumeFromIdSdk(ctx, volumes, req.GetName())
+		if errFindFailed == nil && !isSnapshotReady(snapInfo) {
+
+			// If snapshot was created but has errors, cleanup and re-create it on the next iteration.
+			_, errCleanupSnap := volumes.Delete(ctx, &api.SdkVolumeDeleteRequest{
+				VolumeId: snapInfo.Id,
+			})
+			if errCleanupSnap != nil {
+				return nil, status.Errorf(codes.Aborted, "Snapshot create failed and unable to delete failed snapshot %s: %v",
+					snapInfo.Id,
+					errCleanupSnap)
+			}
+			logrus.Infof("cleaned up failed snapshot %v in order to retry snapshot create", snapInfo.Id)
+		}
+
+		return nil, status.Errorf(codes.Aborted, "Failed to create snapshot: %v", err)
 	}
 	snapshotID := snapResp.SnapshotId
 
 	snapInfo, err := util.VolumeFromIdSdk(ctx, volumes, snapshotID)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "Failed to get information about the snapshot: %v", err)
+		return nil, status.Errorf(codes.Aborted, "Failed to get information about the snapshot: %v", err)
 	}
 
 	return &csi.CreateSnapshotResponse{

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -2862,6 +2862,7 @@ func TestControllerCreateSnapshotIdempotent(t *testing.T) {
 		Spec: &api.VolumeSpec{
 			Size: uint64(size),
 		},
+		Status: api.VolumeStatus_VOLUME_STATUS_UP,
 	}
 
 	// Snapshot already exists


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleanup failed snapshot and re-create on next retry

**Special notes for your reviewer**:
Reproduced the issue, and received the below alert for a failed snapshot create.
```
VOLUME	SnapshotCreateFailure		985152750896393125			ALARM		1	Feb 17 07:08:39 UTC 2023	Feb 17 07:08:39 UTC 2023	Volume (Id: 985152750896393125 Name: snapshot-9a69ca8d-fc5c-4591-80e2-b2ce3bd48d8f Source: 1027903614514639842) snapshot failed with error: All nodes which store the volume data are not online or data is not yet fully replicated on all replicas. Snapshot will automatically complete when volume is ready.	
```

However, the CSI driver cleaned up this failed snapshot and re-create it. The test then passed.
```
Ran 4 of 7227 Specs in 133.751 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 7223 Skipped

```

Previously, this would result in a test failure:
```
[root@torpedo-tp-nextpx-op-csi-e2e-460-2 /]# /opt/pwx/bin/pxctl alerts show | grep SnapshotCreateFailure
VOLUME	SnapshotCreateFailure		697143149459174097			ALARM		1	Feb 17 02:44:53 UTC 2023	Feb 17 02:44:53 UTC 2023	Volume (Id: 697143149459174097 Name: snapshot-04230195-be88-4064-893e-eb50c5c23c73 Source: 633915026553598074) snapshot failed with error: All nodes which store the volume data are not online or data is not yet fully replicated on all replicas. Snapshot will automatically complete when volume is ready.		
VOLUME	SnapshotCreateFailure		357923254567354870			ALARM		1	Feb 17 04:50:39 UTC 2023	Feb 17 04:50:39 UTC 2023	Volume (Id: 357923254567354870 Name: snapshot-5c58ccea-32c4-46a5-8d37-43829c919468 Source: 142250729840541413) snapshot failed with error: All nodes which store the volume data are not online or data is not yet fully replicated on all replicas. Snapshot will automatically complete when volume is ready.		
VOLUME	SnapshotCreateFailure		285377165156618971			ALARM		1	Feb 17 05:10:31 UTC 2023	Feb 17 05:10:31 UTC 2023	Volume (Id: 285377165156618971 Name: snapshot-edc06f60-3cd6-45e6-b18a-272d0d14f2ee Source: 1059369973295762962) snapshot failed with error: All nodes which store the volume data are not online or data is not yet fully replicated on all replicas. Snapshot will automatically complete when volume is ready.	
VOLUME	SnapshotCreateFailure		497223356895187970			ALARM		1	Feb 17 05:45:18 UTC 2023	Feb 17 05:45:18 UTC 2023	Volume (Id: 497223356895187970 Name: snapshot-7005579c-b681-41e2-8540-23835bc82878 Source: 933150842651034314) snapshot failed with error: All nodes which store the volume data are not online or data is not yet fully replicated on all replicas. Snapshot will automatically complete when volume is ready.		
VOLUME	SnapshotCreateFailure		985152750896393125			ALARM		1	Feb 17 07:08:39 UTC 2023	Feb 17 07:08:39 UTC 2023	Volume (Id: 985152750896393125 Name: snapshot-9a69ca8d-fc5c-4591-80e2-b2ce3bd48d8f Source: 1027903614514639842) snapshot failed with error: All nodes which store the volume data are not online or data is not yet fully replicated on all replicas. Snapshot will automatically complete when volume is ready.	
```

Before my fix, the above alerts resulted in a failed test.