### PR TITLE
Updates a log line in ClusterManager to help clarify tests

### DIFF
--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -264,7 +264,7 @@ func (c *ClusterManager) getNodeEntry(nodeID string, clustDBRef *cluster.Cluster
 
 	n, ok := c.nodeCache[nodeID]
 	if !ok {
-		return api.Node{}, errors.New("Unable to locate node with provided UUID.")
+		return api.Node{}, fmt.Errorf("Unable to locate node with provided UUID '%s'.", nodeID)
 	}
 
 	if n.Status == api.Status_STATUS_OFFLINE &&


### PR DESCRIPTION
**What this PR does / why we need it**:
Caught this log line in a torpedo test but wasn't able to figure out what it was calling. This will make it more obvious what is happening for debugging.

