### PR TITLE
PWX-23290: handle spec updates with stale config

### DIFF
--- a/api/server/sdk/volume_ops.go
+++ b/api/server/sdk/volume_ops.go
@@ -19,6 +19,7 @@ package sdk
 import (
 	"context"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -587,6 +588,78 @@ func (s *VolumeServer) EnumerateWithFilters(
 	}, nil
 }
 
+// mask all unmodified attributes of the spec before calling Set/Update
+func maskUnModified(spec *api.VolumeSpec, req *api.VolumeSpecUpdate) {
+	// spec has been updated fully for all attributes inclusive of requested attr.
+	// But it is possible for the current state to be stale and so requesting update with
+	// all attributes may have a side affect.
+	// For ex: a size update of the volume, could result in a ha-update
+	// So clear other attributes, so as not to cause side effect while applying
+	// the update.
+	// All state based conditionals are set only for requested attribs.
+	// boolean based state can still be stale, but the chances are low, because
+	// they are immediately handled within px, unlike HA updates which needs acknowledgement
+	// from px-storage to complete processing.
+
+	// ScanPolicy
+	if req.GetScanPolicy() == nil {
+		spec.ScanPolicy = nil
+	}
+
+	if req.GetSnapshotIntervalOpt() == nil {
+		spec.SnapshotInterval = math.MaxUint32
+	}
+
+	if req.GetSnapshotScheduleOpt() == nil {
+		spec.SnapshotSchedule = ""
+	}
+
+	// HA Level
+	if req.GetHaLevelOpt() == nil {
+		spec.HaLevel = 0
+	}
+
+	/*
+	 * immediately applied, hence never stale.
+	 * can carry part of the spec always safely.
+	 */
+	// if req.GetSizeOpt() == nil {
+	//   spec.Size = 0
+	// }
+
+	if req.GetCosOpt() == nil {
+		spec.Cos = api.CosType_NONE
+	}
+
+	if req.GetExportSpec() == nil {
+		spec.ExportSpec = nil
+	}
+
+	if req.GetMountOptSpec() == nil {
+		spec.MountOptions = nil
+	}
+
+	if req.GetSharedv4MountOptSpec() == nil {
+		spec.Sharedv4MountOptions = nil
+	}
+
+	if req.GetSharedv4ServiceSpec() == nil {
+		spec.Sharedv4ServiceSpec = nil
+	}
+
+	if req.GetSharedv4Spec() == nil {
+		spec.Sharedv4Spec = nil
+	}
+
+	if req.GetGroupOpt() == nil {
+		spec.Group = nil
+	}
+
+	if req.GetIoStrategy() == nil {
+		spec.IoStrategy = nil
+	}
+}
+
 // Update allows the caller to change values in the volume specification
 func (s *VolumeServer) Update(
 	ctx context.Context,
@@ -644,6 +717,11 @@ func (s *VolumeServer) Update(
 	if err != nil {
 		return nil, err
 	}
+
+	// avoid side effect while applying with stale config by masking
+	// other parts of the spec.
+	maskUnModified(updatedSpec, req.GetSpec())
+
 	// Send to driver
 	if err := s.driver(ctx).Set(req.GetVolumeId(), locator, updatedSpec); err != nil {
 		return nil, status.Errorf(codes.Internal, "Failed to update volume: %v", err)

--- a/api/server/sdk/volume_ops_test.go
+++ b/api/server/sdk/volume_ops_test.go
@@ -19,6 +19,7 @@ package sdk
 import (
 	"context"
 	"fmt"
+	"math"
 	"reflect"
 	"testing"
 
@@ -188,7 +189,7 @@ func TestSdkVolumeCreateCheckIdempotency(t *testing.T) {
 		EXPECT().
 		Inspect([]string{name}).
 		Return([]*api.Volume{
-			&api.Volume{
+			{
 				Id:     id,
 				Status: api.VolumeStatus_VOLUME_STATUS_UP,
 				Locator: &api.VolumeLocator{
@@ -352,7 +353,7 @@ func TestSdkVolumeDelete(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{},
+				{},
 			}, nil).
 			Times(1),
 
@@ -437,7 +438,7 @@ func TestSdkVolumeInspect(t *testing.T) {
 			VolumeIds: []string{id},
 		}, nil).
 		Return([]*api.Volume{
-			&api.Volume{
+			{
 				Id: id,
 			},
 		}, nil).
@@ -457,7 +458,7 @@ func TestSdkVolumeInspect(t *testing.T) {
 		EXPECT().
 		Inspect([]string{id}).
 		Return([]*api.Volume{
-			&api.Volume{
+			{
 				Id: id,
 			},
 		}, nil).
@@ -563,7 +564,7 @@ func TestSdkVolumeEnumerate(t *testing.T) {
 		EXPECT().
 		Enumerate(nil, nil).
 		Return([]*api.Volume{
-			&api.Volume{
+			{
 				Id: id,
 			},
 		}, nil).
@@ -599,7 +600,7 @@ func TestSdkVolumeEnumerateWithFilters(t *testing.T) {
 		EXPECT().
 		Enumerate(locator, nil).
 		Return([]*api.Volume{
-			&api.Volume{
+			{
 				Id: id,
 			},
 		}, nil).
@@ -642,11 +643,11 @@ func TestSdkVolumeUpdate(t *testing.T) {
 		Enumerate(&api.VolumeLocator{
 			VolumeIds: []string{id},
 		}, nil).
-		Return([]*api.Volume{&api.Volume{Spec: &api.VolumeSpec{}}}, nil).
+		Return([]*api.Volume{{Spec: &api.VolumeSpec{}}}, nil).
 		AnyTimes()
 	s.MockDriver().
 		EXPECT().
-		Set(id, &api.VolumeLocator{VolumeLabels: newlabels}, &api.VolumeSpec{}).
+		Set(id, &api.VolumeLocator{VolumeLabels: newlabels}, &api.VolumeSpec{SnapshotInterval: math.MaxUint32}).
 		Return(nil).
 		Times(1)
 
@@ -667,7 +668,7 @@ func TestSdkVolumeUpdate(t *testing.T) {
 
 	s.MockDriver().
 		EXPECT().
-		Set(id, nil, &api.VolumeSpec{Size: 1234}).
+		Set(id, nil, &api.VolumeSpec{Size: 1234, SnapshotInterval: math.MaxUint32}).
 		Return(nil).
 		Times(1)
 	_, err = c.Update(context.Background(), req)
@@ -689,7 +690,7 @@ func TestSdkVolumeUpdate(t *testing.T) {
 		Set(
 			id,
 			&api.VolumeLocator{VolumeLabels: newlabels},
-			&api.VolumeSpec{Size: 1234},
+			&api.VolumeSpec{Size: 1234, SnapshotInterval: math.MaxUint32},
 		).
 		Return(nil).
 		Times(1)
@@ -712,7 +713,7 @@ func TestSdkVolumeStats(t *testing.T) {
 			VolumeIds: []string{id},
 		}, nil).
 		Return([]*api.Volume{
-			&api.Volume{
+			{
 				Id: id,
 			},
 		}, nil).
@@ -779,7 +780,7 @@ func TestSdkVolumeCapacityUsage(t *testing.T) {
 			VolumeIds: []string{id},
 		}, nil).
 		Return([]*api.Volume{
-			&api.Volume{
+			{
 				Id: id,
 			},
 		}, nil).
@@ -822,7 +823,7 @@ func TestSdkVolumeCapacityUsageAbortedResult(t *testing.T) {
 			VolumeIds: []string{id},
 		}, nil).
 		Return([]*api.Volume{
-			&api.Volume{
+			{
 				Id: id,
 			},
 		}, nil).
@@ -867,7 +868,7 @@ func TestSdkVolumeCapacityUsageUnimplementedResult(t *testing.T) {
 			VolumeIds: []string{id},
 		}, nil).
 		Return([]*api.Volume{
-			&api.Volume{
+			{
 				Id: id,
 			},
 		}, nil).
@@ -1160,6 +1161,7 @@ func TestSdkCloneOwnership(t *testing.T) {
 				Ownership: &api.Ownership{
 					Owner: user2,
 				},
+				SnapshotInterval: math.MaxUint32,
 			}).
 			Return(nil).
 			Times(1),
@@ -1286,6 +1288,7 @@ func TestSdkCloneOwnership(t *testing.T) {
 				Ownership: &api.Ownership{
 					Owner: user2,
 				},
+				SnapshotInterval: math.MaxUint32,
 			}).
 			Return(nil).
 			Times(1),
@@ -1735,8 +1738,9 @@ func TestSdkVolumeUpdatePolicyOwnership(t *testing.T) {
 	volReq := &api.SdkVolumeCreateRequest{
 		Name: name,
 		Spec: &api.VolumeSpec{
-			Size:    size,
-			HaLevel: 1,
+			Size:             size,
+			HaLevel:          1,
+			SnapshotInterval: math.MaxUint32,
 		},
 	}
 
@@ -1750,8 +1754,9 @@ func TestSdkVolumeUpdatePolicyOwnership(t *testing.T) {
 		Shared:  volSpec.GetShared(),
 		HaLevel: volSpec.GetHaLevel(),
 		// since volume is created as per default policy
-		StoragePolicy: "testpolicyA",
-		Ownership:     owner,
+		StoragePolicy:    "testpolicyA",
+		Ownership:        owner,
+		SnapshotInterval: math.MaxUint32,
 	}
 
 	// Create response
@@ -1794,7 +1799,7 @@ func TestSdkVolumeUpdatePolicyOwnership(t *testing.T) {
 		Enumerate(&api.VolumeLocator{
 			VolumeIds: []string{id},
 		}, nil).
-		Return([]*api.Volume{&api.Volume{Spec: volPolSpec}}, nil).
+		Return([]*api.Volume{{Spec: volPolSpec}}, nil).
 		AnyTimes()
 	mv.
 		EXPECT().
@@ -1828,7 +1833,7 @@ func TestSdkInspectWithFilters(t *testing.T) {
 		EXPECT().
 		Enumerate(locator, nil).
 		Return([]*api.Volume{
-			&api.Volume{
+			{
 				Spec: &api.VolumeSpec{
 					Size: size,
 				},

--- a/api/server/sdk/volume_snapshot_test.go
+++ b/api/server/sdk/volume_snapshot_test.go
@@ -18,6 +18,7 @@ package sdk
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/libopenstorage/openstorage/api"
@@ -69,7 +70,7 @@ func TestSdkVolumeSnapshotCreate(t *testing.T) {
 			VolumeIds: []string{volid},
 		}, nil).
 		Return([]*api.Volume{
-			&api.Volume{
+			{
 				Id: volid,
 			},
 		}, nil).
@@ -151,7 +152,7 @@ func TestSdkVolumeSnapshotRestore(t *testing.T) {
 			VolumeIds: []string{volid},
 		}, nil).
 		Return([]*api.Volume{
-			&api.Volume{
+			{
 				Id: volid,
 			},
 		}, nil).
@@ -184,7 +185,7 @@ func TestSdkVolumeSnapshotEnumerate(t *testing.T) {
 		EXPECT().
 		SnapEnumerate(nil, nil).
 		Return([]*api.Volume{
-			&api.Volume{
+			{
 				Id: snapid,
 			},
 		}, nil).
@@ -212,7 +213,7 @@ func TestSdkVolumeSnapshotEnumerate(t *testing.T) {
 			VolumeIds: []string{volid},
 		}, nil).
 		Return([]*api.Volume{
-			&api.Volume{
+			{
 				Id: volid,
 			},
 		}, nil).
@@ -221,7 +222,7 @@ func TestSdkVolumeSnapshotEnumerate(t *testing.T) {
 		EXPECT().
 		SnapEnumerate([]string{volid}, nil).
 		Return([]*api.Volume{
-			&api.Volume{
+			{
 				Id: snapid,
 			},
 		}, nil).
@@ -258,7 +259,7 @@ func TestSdkVolumeSnapshotEnumerateWithFilters(t *testing.T) {
 			VolumeIds: []string{volid},
 		}, nil).
 		Return([]*api.Volume{
-			&api.Volume{
+			{
 				Id: volid,
 			},
 		}, nil).
@@ -267,7 +268,7 @@ func TestSdkVolumeSnapshotEnumerateWithFilters(t *testing.T) {
 		EXPECT().
 		SnapEnumerate([]string{volid}, labels).
 		Return([]*api.Volume{
-			&api.Volume{
+			{
 				Id: snapid,
 			},
 		}, nil).
@@ -301,7 +302,7 @@ func TestSdkVolumeSnapshotScheduleUpdate(t *testing.T) {
 		Enumerate(&api.VolumeLocator{
 			VolumeIds: []string{volid},
 		}, nil).
-		Return([]*api.Volume{&api.Volume{Spec: &api.VolumeSpec{}}}, nil).
+		Return([]*api.Volume{{Spec: &api.VolumeSpec{}}}, nil).
 		AnyTimes()
 	s.MockCluster().
 		EXPECT().
@@ -312,6 +313,7 @@ func TestSdkVolumeSnapshotScheduleUpdate(t *testing.T) {
 		EXPECT().
 		Set(volid, nil, &api.VolumeSpec{
 			SnapshotSchedule: "policy=mypolicy",
+			SnapshotInterval: math.MaxUint32,
 		}).
 		Return(nil).
 		Times(1)
@@ -340,7 +342,7 @@ func TestSdkVolumeSnapshotScheduleUpdateDelete(t *testing.T) {
 		Enumerate(&api.VolumeLocator{
 			VolumeIds: []string{volid},
 		}, nil).
-		Return([]*api.Volume{&api.Volume{Spec: &api.VolumeSpec{
+		Return([]*api.Volume{{Spec: &api.VolumeSpec{
 			SnapshotSchedule: "policy=mypolicy",
 		}}}, nil).
 		AnyTimes()
@@ -348,6 +350,7 @@ func TestSdkVolumeSnapshotScheduleUpdateDelete(t *testing.T) {
 		EXPECT().
 		Set(volid, nil, &api.VolumeSpec{
 			SnapshotSchedule: "",
+			SnapshotInterval: math.MaxUint32,
 		}).
 		Return(nil).
 		Times(1)

--- a/csi/controller.go
+++ b/csi/controller.go
@@ -188,9 +188,7 @@ func (s *OsdCsiServer) ValidateVolumeCapabilities(
 
 	// Log request
 	clogger.WithContext(ctx).Infof("csi.ValidateVolumeCapabilities of id %s "+
-		"capabilities %#v "+
-		id,
-		capabilities)
+		"capabilities %#v ", id, capabilities)
 
 	// Get grpc connection
 	conn, err := s.getConn()

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -19,6 +19,7 @@ package csi
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"testing"
 
 	"github.com/golang/protobuf/ptypes"
@@ -49,7 +50,7 @@ func containsCap(c csi.ControllerServiceCapability_RPC_Type, resp *csi.Controlle
 
 func getDefaultVolumeCapabilities(t *testing.T) []*csi.VolumeCapability {
 	return []*csi.VolumeCapability{
-		&csi.VolumeCapability{
+		{
 			AccessType: &csi.VolumeCapability_Mount{
 				Mount: &csi.VolumeCapability_MountVolume{
 					FsType: "ext4",
@@ -225,7 +226,7 @@ func TestControllerValidateVolumeCapabilitiesBadArguments(t *testing.T) {
 
 	// Miss id
 	req.VolumeCapabilities = []*csi.VolumeCapability{
-		&csi.VolumeCapability{},
+		{},
 	}
 	_, err = c.ValidateVolumeCapabilities(context.Background(), req)
 	assert.NotNil(t, err)
@@ -272,7 +273,7 @@ func TestControllerValidateVolumeInvalidId(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id: "bad volume id",
 				},
 			}, nil),
@@ -280,7 +281,7 @@ func TestControllerValidateVolumeInvalidId(t *testing.T) {
 
 	req := &csi.ValidateVolumeCapabilitiesRequest{
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{},
+			{},
 		},
 		VolumeId: id,
 		Secrets:  map[string]string{authsecrets.SecretTokenKey: systemUserToken},
@@ -335,7 +336,7 @@ func TestControllerValidateVolumeInvalidCapabilities(t *testing.T) {
 			VolumeIds: []string{id},
 		}, nil).
 		Return([]*api.Volume{
-			&api.Volume{
+			{
 				Id: id,
 			},
 		}, nil).
@@ -344,7 +345,7 @@ func TestControllerValidateVolumeInvalidCapabilities(t *testing.T) {
 	// Setup validate request
 	req := &csi.ValidateVolumeCapabilitiesRequest{
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{},
+			{},
 		},
 		VolumeId: id,
 		Secrets:  map[string]string{authsecrets.SecretTokenKey: systemUserToken},
@@ -382,7 +383,7 @@ func TestControllerValidateVolumeAccessModeSNWR(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id:       id,
 					Readonly: false,
 					Spec: &api.VolumeSpec{
@@ -398,7 +399,7 @@ func TestControllerValidateVolumeAccessModeSNWR(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id:       id,
 					Readonly: true,
 					Spec: &api.VolumeSpec{
@@ -414,7 +415,7 @@ func TestControllerValidateVolumeAccessModeSNWR(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id:       id,
 					Readonly: false,
 					Spec: &api.VolumeSpec{
@@ -430,7 +431,7 @@ func TestControllerValidateVolumeAccessModeSNWR(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id:       id,
 					Readonly: true,
 					Spec: &api.VolumeSpec{
@@ -443,7 +444,7 @@ func TestControllerValidateVolumeAccessModeSNWR(t *testing.T) {
 	// Setup request
 	req := &csi.ValidateVolumeCapabilitiesRequest{
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{
+			{
 				AccessType: &csi.VolumeCapability_Mount{
 					Mount: &csi.VolumeCapability_MountVolume{},
 				},
@@ -499,7 +500,7 @@ func TestControllerValidateVolumeAccessModeSNRO(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id:       id,
 					Readonly: false,
 					Spec: &api.VolumeSpec{
@@ -515,7 +516,7 @@ func TestControllerValidateVolumeAccessModeSNRO(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id:       id,
 					Readonly: true,
 					Spec: &api.VolumeSpec{
@@ -531,7 +532,7 @@ func TestControllerValidateVolumeAccessModeSNRO(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id:       id,
 					Readonly: false,
 					Spec: &api.VolumeSpec{
@@ -547,7 +548,7 @@ func TestControllerValidateVolumeAccessModeSNRO(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id:       id,
 					Readonly: true,
 					Spec: &api.VolumeSpec{
@@ -560,7 +561,7 @@ func TestControllerValidateVolumeAccessModeSNRO(t *testing.T) {
 	// Setup request
 	req := &csi.ValidateVolumeCapabilitiesRequest{
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{
+			{
 				AccessType: &csi.VolumeCapability_Mount{
 					Mount: &csi.VolumeCapability_MountVolume{},
 				},
@@ -616,7 +617,7 @@ func TestControllerValidateVolumeAccessModeMNRO(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id:       id,
 					Readonly: false,
 					Spec: &api.VolumeSpec{
@@ -632,7 +633,7 @@ func TestControllerValidateVolumeAccessModeMNRO(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id:       id,
 					Readonly: true,
 					Spec: &api.VolumeSpec{
@@ -648,7 +649,7 @@ func TestControllerValidateVolumeAccessModeMNRO(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id:       id,
 					Readonly: false,
 					Spec: &api.VolumeSpec{
@@ -664,7 +665,7 @@ func TestControllerValidateVolumeAccessModeMNRO(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id:       id,
 					Readonly: true,
 					Spec: &api.VolumeSpec{
@@ -677,7 +678,7 @@ func TestControllerValidateVolumeAccessModeMNRO(t *testing.T) {
 	// Setup request
 	req := &csi.ValidateVolumeCapabilitiesRequest{
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{
+			{
 				AccessType: &csi.VolumeCapability_Mount{
 					Mount: &csi.VolumeCapability_MountVolume{},
 				},
@@ -733,7 +734,7 @@ func TestControllerValidateVolumeAccessModeMNWR(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id:       id,
 					Readonly: false,
 					Spec: &api.VolumeSpec{
@@ -749,7 +750,7 @@ func TestControllerValidateVolumeAccessModeMNWR(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id:       id,
 					Readonly: true,
 					Spec: &api.VolumeSpec{
@@ -765,7 +766,7 @@ func TestControllerValidateVolumeAccessModeMNWR(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id:       id,
 					Readonly: false,
 					Spec: &api.VolumeSpec{
@@ -781,7 +782,7 @@ func TestControllerValidateVolumeAccessModeMNWR(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id:       id,
 					Readonly: true,
 					Spec: &api.VolumeSpec{
@@ -794,7 +795,7 @@ func TestControllerValidateVolumeAccessModeMNWR(t *testing.T) {
 	// Setup request
 	req := &csi.ValidateVolumeCapabilitiesRequest{
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{
+			{
 				AccessType: &csi.VolumeCapability_Mount{
 					Mount: &csi.VolumeCapability_MountVolume{},
 				},
@@ -842,7 +843,7 @@ func TestControllerValidateVolumeAccessModeUnknown(t *testing.T) {
 			VolumeIds: []string{id},
 		}, nil).
 		Return([]*api.Volume{
-			&api.Volume{
+			{
 				Id:       id,
 				Readonly: false,
 				Spec: &api.VolumeSpec{
@@ -855,7 +856,7 @@ func TestControllerValidateVolumeAccessModeUnknown(t *testing.T) {
 	// Setup request
 	req := &csi.ValidateVolumeCapabilitiesRequest{
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{
+			{
 				AccessType: &csi.VolumeCapability_Mount{
 					Mount: &csi.VolumeCapability_MountVolume{},
 				},
@@ -947,7 +948,7 @@ func TestControllerCreateVolumeFoundByVolumeFromNameConflict(t *testing.T) {
 				s.MockDriver().
 					EXPECT().
 					Enumerate(&api.VolumeLocator{Name: "size"}, nil).
-					Return([]*api.Volume{&api.Volume{
+					Return([]*api.Volume{{
 						Id: "size",
 						Locator: &api.VolumeLocator{
 							Name: "size",
@@ -970,7 +971,7 @@ func TestControllerCreateVolumeFoundByVolumeFromNameConflict(t *testing.T) {
 				s.MockDriver().
 					EXPECT().
 					Enumerate(&api.VolumeLocator{Name: "size"}, nil).
-					Return([]*api.Volume{&api.Volume{
+					Return([]*api.Volume{{
 						Id: "size",
 						Locator: &api.VolumeLocator{
 							Name: "size",
@@ -1008,7 +1009,7 @@ func TestControllerCreateVolumeNoCapacity(t *testing.T) {
 	req := &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{},
+			{},
 		},
 		Secrets: map[string]string{authsecrets.SecretTokenKey: systemUserToken},
 	}
@@ -1048,7 +1049,7 @@ func TestControllerCreateVolumeNoCapacity(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id: id,
 					Locator: &api.VolumeLocator{
 						Name: name,
@@ -1083,7 +1084,7 @@ func TestControllerCreateVolumeFoundByVolumeFromName(t *testing.T) {
 	req := &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{},
+			{},
 		},
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: size,
@@ -1103,7 +1104,7 @@ func TestControllerCreateVolumeFoundByVolumeFromName(t *testing.T) {
 			EXPECT().
 			Enumerate(&api.VolumeLocator{Name: name}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id: name,
 					Locator: &api.VolumeLocator{
 						Name: name,
@@ -1126,7 +1127,7 @@ func TestControllerCreateVolumeFoundByVolumeFromName(t *testing.T) {
 			EXPECT().
 			Enumerate(&api.VolumeLocator{Name: name}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id: name,
 					Locator: &api.VolumeLocator{
 						Name: name,
@@ -1144,7 +1145,7 @@ func TestControllerCreateVolumeFoundByVolumeFromName(t *testing.T) {
 			Enumerate(&api.VolumeLocator{
 				VolumeIds: []string{name},
 			}, nil).
-			Return([]*api.Volume{&api.Volume{
+			Return([]*api.Volume{{
 				Id: name,
 				Locator: &api.VolumeLocator{
 					Name: name,
@@ -1178,7 +1179,7 @@ func TestControllerCreateVolumeBadParameters(t *testing.T) {
 	req := &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{},
+			{},
 		},
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: size,
@@ -1210,7 +1211,7 @@ func TestControllerCreateVolumeBadParentId(t *testing.T) {
 	req := &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{},
+			{},
 		},
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: size,
@@ -1229,7 +1230,7 @@ func TestControllerCreateVolumeBadParentId(t *testing.T) {
 			Enumerate(&api.VolumeLocator{
 				VolumeIds: []string{parent},
 			}, nil).
-			Return([]*api.Volume{&api.Volume{Id: parent}}, nil).
+			Return([]*api.Volume{{Id: parent}}, nil).
 			Times(1),
 
 		// VolFromName (name)
@@ -1279,7 +1280,7 @@ func TestControllerCreateVolumeBadSnapshot(t *testing.T) {
 	req := &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{},
+			{},
 		},
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: size,
@@ -1298,7 +1299,7 @@ func TestControllerCreateVolumeBadSnapshot(t *testing.T) {
 			Enumerate(&api.VolumeLocator{
 				VolumeIds: []string{parent},
 			}, nil).
-			Return([]*api.Volume{&api.Volume{Id: parent}}, nil).
+			Return([]*api.Volume{{Id: parent}}, nil).
 			Times(1),
 
 		// VolFromName (name)
@@ -1318,7 +1319,7 @@ func TestControllerCreateVolumeBadSnapshot(t *testing.T) {
 		s.MockDriver().
 			EXPECT().
 			Inspect([]string{parent}).
-			Return([]*api.Volume{&api.Volume{Id: parent}}, nil).
+			Return([]*api.Volume{{Id: parent}}, nil).
 			Times(1),
 
 		// Return an error from snapshot
@@ -1355,7 +1356,7 @@ func TestControllerCreateVolumeWithSharedv4Volume(t *testing.T) {
 		req := &csi.CreateVolumeRequest{
 			Name: name,
 			VolumeCapabilities: []*csi.VolumeCapability{
-				&csi.VolumeCapability{
+				{
 					AccessMode: &csi.VolumeCapability_AccessMode{
 						Mode: mode,
 					},
@@ -1394,7 +1395,7 @@ func TestControllerCreateVolumeWithSharedv4Volume(t *testing.T) {
 					VolumeIds: []string{id},
 				}, nil).
 				Return([]*api.Volume{
-					&api.Volume{
+					{
 						Id: id,
 						Locator: &api.VolumeLocator{
 							Name: name,
@@ -1436,7 +1437,7 @@ func TestControllerCreateVolumeWithSharedVolume(t *testing.T) {
 		req := &csi.CreateVolumeRequest{
 			Name: name,
 			VolumeCapabilities: []*csi.VolumeCapability{
-				&csi.VolumeCapability{
+				{
 					AccessMode: &csi.VolumeCapability_AccessMode{
 						Mode: mode,
 					},
@@ -1478,7 +1479,7 @@ func TestControllerCreateVolumeWithSharedVolume(t *testing.T) {
 					VolumeIds: []string{id},
 				}, nil).
 				Return([]*api.Volume{
-					&api.Volume{
+					{
 						Id: id,
 						Locator: &api.VolumeLocator{
 							Name: name,
@@ -1515,7 +1516,7 @@ func TestControllerCreateVolumeFails(t *testing.T) {
 	req := &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{},
+			{},
 		},
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: size,
@@ -1564,7 +1565,7 @@ func TestControllerCreateVolumeNoNewVolumeInfo(t *testing.T) {
 	req := &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{},
+			{},
 		},
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: size,
@@ -1638,7 +1639,7 @@ func TestControllerCreateVolumeFailedRemoteConn(t *testing.T) {
 	req := &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{},
+			{},
 		},
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: size,
@@ -1673,7 +1674,7 @@ func TestControllerCreateVolumeFailedRemoteConn(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id: id,
 					Locator: &api.VolumeLocator{
 						Name:         name,
@@ -1716,7 +1717,7 @@ func TestControllerCreateVolume(t *testing.T) {
 	req := &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{},
+			{},
 		},
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: size,
@@ -1751,7 +1752,7 @@ func TestControllerCreateVolume(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id: id,
 					Locator: &api.VolumeLocator{
 						Name:         name,
@@ -1793,7 +1794,7 @@ func TestControllerCreateVolumeRoundUp(t *testing.T) {
 	req := &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{},
+			{},
 		},
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: size,
@@ -1837,7 +1838,7 @@ func TestControllerCreateVolumeRoundUp(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id: id,
 					Locator: &api.VolumeLocator{
 						Name:         name,
@@ -1874,7 +1875,7 @@ func TestControllerCreateVolumeFromSnapshot(t *testing.T) {
 	req := &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{},
+			{},
 		},
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: size,
@@ -1900,7 +1901,7 @@ func TestControllerCreateVolumeFromSnapshot(t *testing.T) {
 			Enumerate(&api.VolumeLocator{
 				VolumeIds: []string{mockParentID},
 			}, nil).
-			Return([]*api.Volume{&api.Volume{Id: mockParentID}}, nil).
+			Return([]*api.Volume{{Id: mockParentID}}, nil).
 			Times(1),
 
 		// VolFromName (name)
@@ -1921,7 +1922,7 @@ func TestControllerCreateVolumeFromSnapshot(t *testing.T) {
 			EXPECT().
 			Inspect(gomock.Any()).
 			Return(
-				[]*api.Volume{&api.Volume{
+				[]*api.Volume{{
 					Id: mockParentID,
 				}}, nil).
 			Times(1),
@@ -1938,7 +1939,7 @@ func TestControllerCreateVolumeFromSnapshot(t *testing.T) {
 				VolumeIds: []string{snapID},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id:     id,
 					Source: &api.Source{Parent: mockParentID},
 				},
@@ -1953,11 +1954,9 @@ func TestControllerCreateVolumeFromSnapshot(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Enumerate(&api.VolumeLocator{
-				VolumeIds: []string{snapID},
-			}, nil).
+			Enumerate(gomock.Any(), nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id:     id,
 					Source: &api.Source{Parent: mockParentID},
 				},
@@ -1988,7 +1987,7 @@ func TestControllerCreateVolumeSnapshotThroughParameters(t *testing.T) {
 	req := &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{},
+			{},
 		},
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: size,
@@ -2008,7 +2007,7 @@ func TestControllerCreateVolumeSnapshotThroughParameters(t *testing.T) {
 			Enumerate(&api.VolumeLocator{
 				VolumeIds: []string{mockParentID},
 			}, nil).
-			Return([]*api.Volume{&api.Volume{Id: mockParentID}}, nil).
+			Return([]*api.Volume{{Id: mockParentID}}, nil).
 			Times(1),
 
 		//VolFromName name
@@ -2029,7 +2028,7 @@ func TestControllerCreateVolumeSnapshotThroughParameters(t *testing.T) {
 			EXPECT().
 			Inspect([]string{mockParentID}).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id: mockParentID,
 				},
 			}, nil).
@@ -2048,11 +2047,9 @@ func TestControllerCreateVolumeSnapshotThroughParameters(t *testing.T) {
 		// check snap
 		s.MockDriver().
 			EXPECT().
-			Enumerate(&api.VolumeLocator{
-				VolumeIds: []string{id},
-			}, nil).
+			Enumerate(&api.VolumeLocator{VolumeIds: []string{id}}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id: id,
 					Locator: &api.VolumeLocator{
 						Name: name,
@@ -2070,11 +2067,9 @@ func TestControllerCreateVolumeSnapshotThroughParameters(t *testing.T) {
 		// update - inspect and set
 		s.MockDriver().
 			EXPECT().
-			Enumerate(&api.VolumeLocator{
-				VolumeIds: []string{id},
-			}, nil).
+			Enumerate(&api.VolumeLocator{VolumeIds: []string{id}}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id: id,
 					Locator: &api.VolumeLocator{
 						Name: name,
@@ -2096,11 +2091,9 @@ func TestControllerCreateVolumeSnapshotThroughParameters(t *testing.T) {
 		// final inspect
 		s.MockDriver().
 			EXPECT().
-			Enumerate(&api.VolumeLocator{
-				VolumeIds: []string{id},
-			}, nil).
+			Enumerate(&api.VolumeLocator{VolumeIds: []string{id}}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id: id,
 					Locator: &api.VolumeLocator{
 						Name: name,
@@ -2145,7 +2138,7 @@ func TestControllerCreateVolumeBlock(t *testing.T) {
 	req := &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{
+			{
 				AccessType: &csi.VolumeCapability_Block{
 					Block: &csi.VolumeCapability_BlockVolume{},
 				},
@@ -2180,11 +2173,9 @@ func TestControllerCreateVolumeBlock(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Enumerate(&api.VolumeLocator{
-				VolumeIds: []string{id},
-			}, nil).
+			Enumerate(&api.VolumeLocator{VolumeIds: []string{id}}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id: id,
 					Locator: &api.VolumeLocator{
 						Name:         name,
@@ -2225,12 +2216,12 @@ func TestControllerCreateVolumeBlockSharedInvalid(t *testing.T) {
 	req := &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{
+			{
 				AccessType: &csi.VolumeCapability_Block{
 					Block: &csi.VolumeCapability_BlockVolume{},
 				},
 			},
-			&csi.VolumeCapability{
+			{
 				AccessMode: &csi.VolumeCapability_AccessMode{
 					Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 				},
@@ -2263,7 +2254,7 @@ func TestControllerCreateVolumeWithoutTopology(t *testing.T) {
 	req := &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{},
+			{},
 		},
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: size,
@@ -2308,7 +2299,7 @@ func TestControllerCreateVolumeWithoutTopology(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id: id,
 					Locator: &api.VolumeLocator{
 						Name: name,
@@ -2334,7 +2325,7 @@ func TestControllerCreateVolumeWithoutTopology(t *testing.T) {
 	req = &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{},
+			{},
 		},
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: size,
@@ -2369,11 +2360,9 @@ func TestControllerCreateVolumeWithoutTopology(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Enumerate(&api.VolumeLocator{
-				VolumeIds: []string{id},
-			}, nil).
+			Enumerate(&api.VolumeLocator{VolumeIds: []string{id}}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id: id,
 					Locator: &api.VolumeLocator{
 						Name: name,
@@ -2411,7 +2400,7 @@ func TestControllerCreateVolumeWithTopology(t *testing.T) {
 	req := &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{},
+			{},
 		},
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: size,
@@ -2474,7 +2463,7 @@ func TestControllerCreateVolumeWithTopology(t *testing.T) {
 	req = &csi.CreateVolumeRequest{
 		Name: name,
 		VolumeCapabilities: []*csi.VolumeCapability{
-			&csi.VolumeCapability{},
+			{},
 		},
 		CapacityRange: &csi.CapacityRange{
 			RequiredBytes: size,
@@ -2557,11 +2546,9 @@ func TestControllerCreateVolumeWithTopology(t *testing.T) {
 
 		s.MockDriver().
 			EXPECT().
-			Enumerate(&api.VolumeLocator{
-				VolumeIds: []string{id},
-			}, nil).
+			Enumerate(&api.VolumeLocator{VolumeIds: []string{id}}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id: id,
 					Locator: &api.VolumeLocator{
 						Name: name,
@@ -2622,11 +2609,9 @@ func TestControllerDeleteVolumeError(t *testing.T) {
 	gomock.InOrder(
 		s.MockDriver().
 			EXPECT().
-			Enumerate(&api.VolumeLocator{
-				VolumeIds: []string{myid},
-			}, nil).
+			Enumerate(&api.VolumeLocator{VolumeIds: []string{myid}}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id: myid,
 				},
 			}, nil).
@@ -2665,9 +2650,7 @@ func TestControllerDeleteVolume(t *testing.T) {
 	// Now return no error, but empty list
 	s.MockDriver().
 		EXPECT().
-		Enumerate(&api.VolumeLocator{
-			VolumeIds: []string{myid},
-		}, nil).
+		Enumerate(&api.VolumeLocator{VolumeIds: []string{myid}}, nil).
 		Return([]*api.Volume{}, nil).
 		Times(1)
 
@@ -2678,11 +2661,9 @@ func TestControllerDeleteVolume(t *testing.T) {
 	gomock.InOrder(
 		s.MockDriver().
 			EXPECT().
-			Enumerate(&api.VolumeLocator{
-				VolumeIds: []string{myid},
-			}, nil).
+			Enumerate(&api.VolumeLocator{VolumeIds: []string{myid}}, nil).
 			Return([]*api.Volume{
-				&api.Volume{
+				{
 					Id: myid,
 				},
 			}, nil).
@@ -2757,15 +2738,14 @@ func TestControllerExpandVolume(t *testing.T) {
 			AnyTimes(),
 		s.MockDriver().
 			EXPECT().
-			Enumerate(&api.VolumeLocator{
-				VolumeIds: []string{myid},
-			}, nil).
+			Enumerate(&api.VolumeLocator{VolumeIds: []string{myid}}, nil).
 			Return([]*api.Volume{vol}, nil).
 			AnyTimes(),
 		s.MockDriver().
 			EXPECT().
 			Set(gomock.Any(), gomock.Any(), &api.VolumeSpec{
-				Size: 46 * units.GiB, // Round up from 45.5 to 46
+				Size:             46 * units.GiB, // Round up from 45.5 to 46
+				SnapshotInterval: math.MaxUint32,
 			}).
 			Return(nil).
 			Times(1),
@@ -2938,7 +2918,7 @@ func TestControllerCreateSnapshot(t *testing.T) {
 			Enumerate(&api.VolumeLocator{
 				VolumeIds: []string{volume},
 			}, nil).
-			Return([]*api.Volume{&api.Volume{Id: volume, Spec: &api.VolumeSpec{
+			Return([]*api.Volume{{Id: volume, Spec: &api.VolumeSpec{
 				Size: size,
 			}}}, nil).
 			Times(1),
@@ -3021,7 +3001,7 @@ func TestControllerDeleteSnapshot(t *testing.T) {
 				VolumeIds: []string{id},
 			}, nil).
 			Return([]*api.Volume{
-				&api.Volume{},
+				{},
 			}, nil).
 			Times(1),
 
@@ -3157,14 +3137,14 @@ func TestResolveSpecFromCSI(t *testing.T) {
 			name: "Should accept supported non-default FsType and Sharedv4",
 			req: &csi.CreateVolumeRequest{
 				VolumeCapabilities: []*csi.VolumeCapability{
-					&csi.VolumeCapability{
+					{
 						AccessType: &csi.VolumeCapability_Mount{
 							Mount: &csi.VolumeCapability_MountVolume{
 								FsType: "xfs",
 							},
 						},
 					},
-					&csi.VolumeCapability{
+					{
 						AccessMode: &csi.VolumeCapability_AccessMode{
 							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 						},
@@ -3182,14 +3162,14 @@ func TestResolveSpecFromCSI(t *testing.T) {
 			name: "Should override with the CSI parameter if both are provided",
 			req: &csi.CreateVolumeRequest{
 				VolumeCapabilities: []*csi.VolumeCapability{
-					&csi.VolumeCapability{
+					{
 						AccessType: &csi.VolumeCapability_Mount{
 							Mount: &csi.VolumeCapability_MountVolume{
 								FsType: "xfs",
 							},
 						},
 					},
-					&csi.VolumeCapability{
+					{
 						AccessMode: &csi.VolumeCapability_AccessMode{
 							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 						},
@@ -3211,14 +3191,14 @@ func TestResolveSpecFromCSI(t *testing.T) {
 			name: "Should accept shared instead of sharedv4 if explicitly provided already",
 			req: &csi.CreateVolumeRequest{
 				VolumeCapabilities: []*csi.VolumeCapability{
-					&csi.VolumeCapability{
+					{
 						AccessType: &csi.VolumeCapability_Mount{
 							Mount: &csi.VolumeCapability_MountVolume{
 								FsType: "ext4",
 							},
 						},
 					},
-					&csi.VolumeCapability{
+					{
 						AccessMode: &csi.VolumeCapability_AccessMode{
 							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 						},
@@ -3238,14 +3218,14 @@ func TestResolveSpecFromCSI(t *testing.T) {
 			name: "Should not accept bad FsType",
 			req: &csi.CreateVolumeRequest{
 				VolumeCapabilities: []*csi.VolumeCapability{
-					&csi.VolumeCapability{
+					{
 						AccessType: &csi.VolumeCapability_Mount{
 							Mount: &csi.VolumeCapability_MountVolume{
 								FsType: "badfs",
 							},
 						},
 					},
-					&csi.VolumeCapability{
+					{
 						AccessMode: &csi.VolumeCapability_AccessMode{
 							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 						},
@@ -3260,12 +3240,12 @@ func TestResolveSpecFromCSI(t *testing.T) {
 			name: "Should accept block volumes",
 			req: &csi.CreateVolumeRequest{
 				VolumeCapabilities: []*csi.VolumeCapability{
-					&csi.VolumeCapability{
+					{
 						AccessType: &csi.VolumeCapability_Block{
 							Block: &csi.VolumeCapability_BlockVolume{},
 						},
 					},
-					&csi.VolumeCapability{
+					{
 						AccessMode: &csi.VolumeCapability_AccessMode{
 							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 						},
@@ -3282,7 +3262,7 @@ func TestResolveSpecFromCSI(t *testing.T) {
 			name: "Should not set shared flag to true when using pure backends RWX",
 			req: &csi.CreateVolumeRequest{
 				VolumeCapabilities: []*csi.VolumeCapability{
-					&csi.VolumeCapability{
+					{
 						AccessMode: &csi.VolumeCapability_AccessMode{
 							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
 						},

--- a/volume/drivers/fake/fake.go
+++ b/volume/drivers/fake/fake.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 	"time"
 
@@ -337,7 +338,9 @@ func (d *driver) Set(volumeID string, locator *api.VolumeLocator, spec *api.Volu
 		v.Spec.Shared = spec.Shared
 		v.Spec.Sharedv4 = spec.Sharedv4
 		v.Spec.Journal = spec.Journal
-		v.Spec.SnapshotInterval = spec.SnapshotInterval
+		if spec.SnapshotInterval != math.MaxUint32 {
+			v.Spec.SnapshotInterval = spec.SnapshotInterval
+		}
 		v.Spec.IoProfile = spec.IoProfile
 		v.Spec.SnapshotSchedule = spec.SnapshotSchedule
 		v.Spec.Ownership = spec.Ownership


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Redo https://github.com/libopenstorage/openstorage/pull/2022 to fix the unit tests additionally.

When volume spec updates are requested, there is a spec reconciliation based on the current state of the volume.
This is done to validate policy settings.
For some volume update operations the spec gets updated only upon action from px-storage and may take time to complete action. Ex. HA Update on a volume needs action from px-storage before the HA level change gets reflected in spec.
So, if there is a subsequent volume update, it is possible for the reconciliation action part of update to pick stale config,
and the final action may be inconsistent after.

To avoid this, whenever volume update is applied, only pass the relevant section of the spec that needs update, mask
rest of the specs that have not been updated.

This window of stale config is open only for defered spec updated and long running actions to complete the update operations. Boolean based state are mostly instantaneous updates to the spec and does not seem to have this problem.

Which issue(s) this PR fixes (optional)
Closes # PWX-23290
https://portworx.atlassian.net/browse/PWX-23290

Special notes for your reviewer:
The changes have been tested in 2.10.0-ea branch where the issue was reported.
