### PR TITLE
PWX-30083: Optional way to purge alerts

### DIFF
--- a/alerts/alerts.go
+++ b/alerts/alerts.go
@@ -53,6 +53,8 @@ type Manager interface {
 	SetRules(rules ...Rule)
 	// DeleteRules deletes rules
 	DeleteRules(rules ...Rule)
+	// Purge alerts.
+	Purge() error
 }
 
 // FilterDeleter defines a list and delete interface on alerts.
@@ -68,7 +70,7 @@ type FilterDeleter interface {
 }
 
 func newManager(options ...Option) (*manager, error) {
-	m := &manager{rules: make(map[string]Rule), ttl: HalfDay}
+	m := &manager{rules: make(map[string]Rule), ttl: HalfDay, useTtl: false}
 	for _, option := range options {
 		switch option.GetType() {
 		case ttlOption:
@@ -77,6 +79,12 @@ func newManager(options ...Option) (*manager, error) {
 				return nil, typeAssertionError
 			}
 			m.ttl = v
+		case useTtlOption:
+			v, ok := option.GetValue().(bool)
+			if !ok {
+				return nil, typeAssertionError
+			}
+			m.useTtl = v
 		}
 	}
 	return m, nil
@@ -86,6 +94,7 @@ func newManager(options ...Option) (*manager, error) {
 type manager struct {
 	rules map[string]Rule
 	ttl   uint64
+	useTtl bool
 	sync.Mutex
 }
 
@@ -129,13 +138,15 @@ func (m *manager) Raise(alert *api.Alert) error {
 	// kvdb will delete the object once ttl elapses.
 	if alert.Cleared {
 		// if the alert is marked Cleared, it is pushed to kvdb with a ttlOption of half day
-		_, err := kvdb.Instance().Put(key, alert, m.ttl)
-		return err
-	} else {
-		// otherwise use the ttl value embedded in the alert object
-		_, err := kvdb.Instance().Put(key, alert, alert.Ttl)
-		return err
+		alert.Ttl = m.ttl;
 	}
+	// otherwise use the ttl value embedded in the alert object
+	ttl := alert.Ttl
+	if (!m.useTtl) {
+		ttl = 0
+	}
+	_, err := kvdb.Instance().Put(key, alert, ttl)
+	return err
 }
 
 // Enumerate takes a variadic list of filters that are first analyzed to see if one filter
@@ -246,6 +257,29 @@ func (m *manager) Filter(alerts []*api.Alert, filters ...Filter) ([]*api.Alert, 
 	}
 
 	return alerts, nil
+}
+
+func (m *manager) Purge() error {
+	if (m.useTtl) {
+		return nil
+	}
+	if kvdb.Instance() != nil {
+		kvps, err := enumerate(kvdb.Instance(), kvdbKey)
+		if err == nil {
+			for _, kvp := range kvps {
+				alert := new(api.Alert)
+				if err := json.Unmarshal(kvp.Value, alert); err != nil {
+					continue
+				}
+				curtime := (int64)(time.Now().Unix())
+				if (curtime - alert.Timestamp.GetSeconds()) > (int64)(alert.Ttl) {
+					//Alert has lived its ttl. Time to delete it.
+					kvdb.Instance().Delete(kvp.Key)
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func (m *manager) Delete(filters ...Filter) error {

--- a/alerts/alerts_test.go
+++ b/alerts/alerts_test.go
@@ -1054,7 +1054,7 @@ func TestManager_SetRules_EventRaise_ActionClear(t *testing.T) {
 	}
 
 	// create a ttl value of 5 seconds
-	manager, err := NewManager(NewTTLOption(1))
+	manager, err := NewManager(NewTTLOption(1), NewUSETTLOption(true))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/alerts/api.go
+++ b/alerts/api.go
@@ -23,6 +23,11 @@ func NewTTLOption(ttl uint64) Option {
 	return &option{optionType: ttlOption, value: ttl}
 }
 
+// UseTtl decides whether we use ttl or a purge method for alert lifecycle
+func NewUSETTLOption(useTtl bool) Option {
+	return &option{optionType: useTtlOption, value: useTtl}
+}
+
 // NewTimeSpanOption provides an option to be used in filter definition.
 // Filters that take options, apply options only during matching alerts.
 func NewTimeSpanOption(start, stop time.Time) Option {

--- a/alerts/opt.go
+++ b/alerts/opt.go
@@ -27,6 +27,8 @@ const (
 	// the resource id. Such option is useful for creating efficient filters that fetch efficiently
 	// from kvdb and apply filtering after fetching.
 	resourceIdOption
+	// Option to use ttl or not
+	useTtlOption
 )
 
 // Option defines what is an option.


### PR DESCRIPTION
PWX-30083: In openstorage either use an option to use ttl to purge alerts or let the alert publisher purge the alerts. Default to the publisher purging the alerts.
