### PR TITLE
Remove cred check from release-9.7

### DIFF
--- a/api/server/sdk/cloud_backup.go
+++ b/api/server/sdk/cloud_backup.go
@@ -50,7 +50,7 @@ func (s *CloudBackupServer) Create(
 	if len(req.GetVolumeId()) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "Must supply a volume id")
 	}
-	if len(req.GetCredentialId()) == 0 {
+	if !req.NearSyncMigrate && len(req.GetCredentialId()) == 0 {
 		credId, err = s.defaultCloudBackupCreds(ctx)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:
Nearsync migrate does not need credentials and so the cred check is also not needed.