### PR TITLE
Allow round-robin load balancing of requests for SDK APIs.

### DIFF
--- a/api/server/sdk/sdk_test.go
+++ b/api/server/sdk/sdk_test.go
@@ -42,6 +42,7 @@ import (
 	mockcluster "github.com/libopenstorage/openstorage/cluster/mock"
 	"github.com/libopenstorage/openstorage/config"
 	"github.com/libopenstorage/openstorage/pkg/grpcserver"
+	"github.com/libopenstorage/openstorage/pkg/loadbalancer"
 	policy "github.com/libopenstorage/openstorage/pkg/storagepolicy"
 	"github.com/libopenstorage/openstorage/volume"
 	volumedrivers "github.com/libopenstorage/openstorage/volume/drivers"
@@ -141,6 +142,7 @@ func newTestServer(t *testing.T) *testServer {
 				KeyFile:  "test_certs/server.key",
 			},
 		},
+		RoundRobinBalancer: loadbalancer.NewNullBalancer(),
 	})
 
 	assert.Nil(t, err)

--- a/api/server/sdk/server.go
+++ b/api/server/sdk/server.go
@@ -263,9 +263,6 @@ func New(config *ServerConfig) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	// For the SDK server listening on ports set the grpc balancer
-	// to the provided round robin balancer
-	netServer.grpcBalancer = config.RoundRobinBalancer
 
 	// Create a gRPC server on a unix domain socket
 	udsConfig := *config
@@ -275,9 +272,6 @@ func New(config *ServerConfig) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	// For the SDK server listening on unix domain sockets, set the grpc balancer
-	// to the null balancer since we don't to forward requests received on it.
-	udsServer.grpcBalancer = loadbalancer.NewNullBalancer()
 
 	// Create REST Gateway and connect it to the unix domain socket server
 	restGateway, err := newSdkRestGateway(config, udsServer)
@@ -467,6 +461,8 @@ func newSdkGrpcServer(config *ServerConfig) (*sdkGrpcServer, error) {
 
 	s.roleServer = config.Security.Role
 	s.policyServer = config.StoragePolicy
+	// For the SDK server set the grpc balancer to the provided round robin balancer
+	s.grpcBalancer = config.RoundRobinBalancer
 
 	return s, nil
 }
@@ -581,17 +577,6 @@ func (s *sdkGrpcServer) Start() error {
 	}
 
 	return nil
-}
-
-// Stop is used to stop the sdkGrpcServer as well as stop
-// any other routines it runs as part of it.
-func (s *sdkGrpcServer) Stop() {
-	if s.grpcBalancer != nil {
-		s.grpcBalancer.Stop()
-	}
-	if s.GrpcServer != nil {
-		s.GrpcServer.Stop()
-	}
 }
 
 func (s *sdkGrpcServer) registerPrometheusMetrics(grpcServer *grpc.Server) {

--- a/api/server/sdk/server.go
+++ b/api/server/sdk/server.go
@@ -36,6 +36,7 @@ import (
 	"github.com/libopenstorage/openstorage/pkg/auth"
 	"github.com/libopenstorage/openstorage/pkg/correlation"
 	"github.com/libopenstorage/openstorage/pkg/grpcserver"
+	"github.com/libopenstorage/openstorage/pkg/loadbalancer"
 	"github.com/libopenstorage/openstorage/pkg/role"
 	policy "github.com/libopenstorage/openstorage/pkg/storagepolicy"
 	"github.com/libopenstorage/openstorage/volume"
@@ -113,6 +114,8 @@ type ServerConfig struct {
 	AlertsFilterDeleter alerts.FilterDeleter
 	// StoragePolicy Manager
 	StoragePolicy policy.PolicyManager
+	// gRPC round robin load balancer
+	RoundRobinBalancer loadbalancer.Balancer
 	// Security configuration
 	Security *SecurityConfig
 	// ServerExtensions allows you to extend the SDK gRPC server
@@ -153,6 +156,7 @@ type serverAccessor interface {
 	cluster() cluster.Cluster
 	driver(ctx context.Context) volume.VolumeDriver
 	bucketDriver(ctx context.Context) bucket.BucketDriver
+	balancer() loadbalancer.Balancer
 	auditLogWriter() io.Writer
 	port() string
 }
@@ -173,6 +177,9 @@ type sdkGrpcServer struct {
 	log             *logrus.Entry
 	auditLogOutput  io.Writer
 	accessLogOutput io.Writer
+
+	// gRPC request balancer
+	grpcBalancer loadbalancer.Balancer
 
 	// Interface implementations
 	clusterHandler       cluster.Cluster
@@ -256,6 +263,9 @@ func New(config *ServerConfig) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
+	// For the SDK server listening on ports set the grpc balancer
+	// to the provided round robin balancer
+	netServer.grpcBalancer = config.RoundRobinBalancer
 
 	// Create a gRPC server on a unix domain socket
 	udsConfig := *config
@@ -265,6 +275,9 @@ func New(config *ServerConfig) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
+	// For the SDK server listening on unix domain sockets, set the grpc balancer
+	// to the null balancer since we don't to forward requests received on it.
+	udsServer.grpcBalancer = loadbalancer.NewNullBalancer()
 
 	// Create REST Gateway and connect it to the unix domain socket server
 	restGateway, err := newSdkRestGateway(config, udsServer)
@@ -360,7 +373,7 @@ func newSdkGrpcServer(config *ServerConfig) (*sdkGrpcServer, error) {
 	}
 
 	// Setup authentication
-	for issuer, _ := range config.Security.Authenticators {
+	for issuer := range config.Security.Authenticators {
 		log.Infof("Authentication enabled for issuer: %s", issuer)
 
 		// Check the necessary security config options are set
@@ -570,6 +583,17 @@ func (s *sdkGrpcServer) Start() error {
 	return nil
 }
 
+// Stop is used to stop the sdkGrpcServer as well as stop
+// any other routines it runs as part of it.
+func (s *sdkGrpcServer) Stop() {
+	if s.grpcBalancer != nil {
+		s.grpcBalancer.Stop()
+	}
+	if s.GrpcServer != nil {
+		s.GrpcServer.Stop()
+	}
+}
+
 func (s *sdkGrpcServer) registerPrometheusMetrics(grpcServer *grpc.Server) {
 	// Register the gRPCs and enable latency historgram
 	grpc_prometheus.Register(grpcServer)
@@ -641,6 +665,10 @@ func (s *sdkGrpcServer) bucketDriver(ctx context.Context) bucket.BucketDriver {
 
 func (s *sdkGrpcServer) cluster() cluster.Cluster {
 	return s.clusterHandler
+}
+
+func (s *sdkGrpcServer) balancer() loadbalancer.Balancer {
+	return s.grpcBalancer
 }
 
 func (s *sdkGrpcServer) alert() alerts.FilterDeleter {

--- a/api/server/sdk/server_interceptors.go
+++ b/api/server/sdk/server_interceptors.go
@@ -41,6 +41,11 @@ const (
 	// key as the location of the raw token coming from the standard REST
 	// header: Authorization: bearer <adaf0sdfsd...token>
 	ContextMetadataTokenKey = "bearer"
+
+	// ContextRoundRobinTerminateKey is a key used to set on the context
+	// to indicate the request needs to be terminated at the receiving node
+	// and should not be forwarded to another node.
+	ContextRoundRobinTerminateKey = "round-robin-terminate"
 )
 
 // This interceptor provides a way to lock out any unary calls while we adjust the server

--- a/api/server/sdk/volume.go
+++ b/api/server/sdk/volume.go
@@ -23,6 +23,7 @@ import (
 	"github.com/libopenstorage/openstorage/api/spec"
 	"github.com/libopenstorage/openstorage/cluster"
 	"github.com/libopenstorage/openstorage/pkg/auth"
+	"github.com/libopenstorage/openstorage/pkg/loadbalancer"
 	"github.com/libopenstorage/openstorage/volume"
 
 	"google.golang.org/grpc/codes"
@@ -43,6 +44,10 @@ func (s *VolumeServer) cluster() cluster.Cluster {
 
 func (s *VolumeServer) driver(ctx context.Context) volume.VolumeDriver {
 	return s.server.driver(ctx)
+}
+
+func (s *VolumeServer) balancer() loadbalancer.Balancer {
+	return s.server.balancer()
 }
 
 func (s *VolumeServer) auditLog(ctx context.Context, method, format string, a ...interface{}) {

--- a/api/server/sdk/volume_migrate.go
+++ b/api/server/sdk/volume_migrate.go
@@ -38,7 +38,7 @@ func (s *VolumeServer) Start(
 
 	md, _ := metadata.FromIncomingContext(ctx)
 	ctxMetadata := md.Get(ContextRoundRobinTerminateKey)
-	if len(ctxMetadata) == 0 || ctxMetadata[0] == "true" {
+	if len(ctxMetadata) == 0 || ctxMetadata[0] != "true" {
 		// Context metadata key was not found OR termination of the request was not set.
 		// Forward the request to some other node and set the context metadata so that
 		// the request is terminated at the receiving node.

--- a/api/server/testutils_test.go
+++ b/api/server/testutils_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/libopenstorage/openstorage/pkg/auth"
 	sdkauth "github.com/libopenstorage/openstorage/pkg/auth"
 	"github.com/libopenstorage/openstorage/pkg/grpcserver"
+	"github.com/libopenstorage/openstorage/pkg/loadbalancer"
 	"github.com/libopenstorage/openstorage/pkg/role"
 	"github.com/libopenstorage/openstorage/pkg/storagepolicy"
 	"github.com/libopenstorage/openstorage/volume"
@@ -116,7 +117,7 @@ func (s *testServer) DisableGuestAccess() error {
 		Role: &api.SdkRole{
 			Name: "system.guest",
 			Rules: []*api.SdkRule{
-				&api.SdkRule{
+				{
 					Services: []string{"!*"},
 					Apis:     []string{"!*"},
 				},
@@ -236,15 +237,16 @@ func newTestServerSdkNoAuth(t *testing.T) *testServer {
 
 	os.Remove(testSdkSock)
 	tester.sdk, err = sdk.New(&sdk.ServerConfig{
-		DriverName:    "fake",
-		Net:           "tcp",
-		Address:       ":" + tester.port,
-		RestPort:      tester.gwport,
-		StoragePolicy: stp,
-		Cluster:       tester.c,
-		Socket:        testSdkSock,
-		AccessOutput:  ioutil.Discard,
-		AuditOutput:   ioutil.Discard,
+		DriverName:         "fake",
+		Net:                "tcp",
+		Address:            ":" + tester.port,
+		RestPort:           tester.gwport,
+		StoragePolicy:      stp,
+		Cluster:            tester.c,
+		Socket:             testSdkSock,
+		AccessOutput:       ioutil.Discard,
+		AuditOutput:        ioutil.Discard,
+		RoundRobinBalancer: loadbalancer.NewNullBalancer(),
 	})
 	assert.Nil(t, err)
 	err = tester.sdk.Start()
@@ -307,15 +309,16 @@ func newTestServerSdk(t *testing.T) *testServer {
 	})
 	assert.NoError(t, err)
 	tester.sdk, err = sdk.New(&sdk.ServerConfig{
-		DriverName:    "fake",
-		Net:           "tcp",
-		Address:       ":" + tester.port,
-		RestPort:      tester.gwport,
-		Cluster:       tester.c,
-		Socket:        testSdkSock,
-		StoragePolicy: stp,
-		AccessOutput:  ioutil.Discard,
-		AuditOutput:   ioutil.Discard,
+		DriverName:         "fake",
+		Net:                "tcp",
+		Address:            ":" + tester.port,
+		RestPort:           tester.gwport,
+		Cluster:            tester.c,
+		Socket:             testSdkSock,
+		StoragePolicy:      stp,
+		AccessOutput:       ioutil.Discard,
+		AuditOutput:        ioutil.Discard,
+		RoundRobinBalancer: loadbalancer.NewNullBalancer(),
 		Security: &sdk.SecurityConfig{
 			Role: rm,
 			Authenticators: map[string]auth.Authenticator{

--- a/cmd/osd/main.go
+++ b/cmd/osd/main.go
@@ -7,18 +7,18 @@
 // This document represents the API documentaton of Openstorage, for the GO client please visit:
 // https://github.com/libopenstorage/openstorage
 //
-//     Schemes: http, https
-//     Host: localhost
-//     BasePath: /v1
-//     Version: 2.0.0
-//     License: APACHE2 https://opensource.org/licenses/Apache-2.0
-//     Contact: https://github.com/libopenstorage/openstorage
+//	Schemes: http, https
+//	Host: localhost
+//	BasePath: /v1
+//	Version: 2.0.0
+//	License: APACHE2 https://opensource.org/licenses/Apache-2.0
+//	Contact: https://github.com/libopenstorage/openstorage
 //
-//     Consumes:
-//     - application/json
+//	Consumes:
+//	- application/json
 //
-//     Produces:
-//     - application/json
+//	Produces:
+//	- application/json
 //
 // swagger:meta
 package main
@@ -33,6 +33,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -55,7 +56,9 @@ import (
 	"github.com/libopenstorage/openstorage/objectstore"
 	"github.com/libopenstorage/openstorage/pkg/auth"
 	"github.com/libopenstorage/openstorage/pkg/auth/systemtoken"
+	"github.com/libopenstorage/openstorage/pkg/loadbalancer"
 	"github.com/libopenstorage/openstorage/pkg/role"
+	"github.com/libopenstorage/openstorage/pkg/sched"
 	policy "github.com/libopenstorage/openstorage/pkg/storagepolicy"
 	"github.com/libopenstorage/openstorage/schedpolicy"
 	"github.com/libopenstorage/openstorage/volume"
@@ -489,14 +492,23 @@ func start(c *cli.Context) error {
 			return fmt.Errorf("Unable to find cluster instance: %v", err)
 		}
 		sdkPort := c.String("sdkport")
+		// Initialize the scheduler
+		sched.Init(time.Second)
+
+		roundRobinBalancer, err := loadbalancer.NewRoundRobinBalancer(cm, sdkPort)
+		if err != nil {
+			return fmt.Errorf("Unable to get round robin balancer: %v", err)
+		}
+
 		csiServer, err := csi.NewOsdCsiServer(&csi.OsdCsiServerConfig{
-			Net:           "unix",
-			Address:       csisock,
-			DriverName:    d,
-			Cluster:       cm,
-			SdkUds:        sdksocket,
-			SdkPort:       sdkPort,
-			CsiDriverName: c.String("csidrivername"),
+			Net:                "unix",
+			Address:            csisock,
+			DriverName:         d,
+			Cluster:            cm,
+			SdkUds:             sdksocket,
+			SdkPort:            sdkPort,
+			CsiDriverName:      c.String("csidrivername"),
+			RoundRobinBalancer: roundRobinBalancer,
 		})
 		if err != nil {
 			return fmt.Errorf("Failed to create CSI server for driver %s: %v", d, err)

--- a/csi/csi.go
+++ b/csi/csi.go
@@ -17,16 +17,14 @@ limitations under the License.
 package csi
 
 import (
-	"errors"
 	"fmt"
-	"sort"
 	"sync"
-	"time"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/libopenstorage/openstorage/api"
 	"github.com/libopenstorage/openstorage/csi/sched/k8s"
 	"github.com/libopenstorage/openstorage/pkg/correlation"
+	"github.com/libopenstorage/openstorage/pkg/loadbalancer"
 	"github.com/libopenstorage/openstorage/pkg/options"
 	"github.com/portworx/kvdb"
 	"github.com/sirupsen/logrus"
@@ -49,11 +47,6 @@ var (
 	clogger *logrus.Logger
 )
 
-const (
-	connCleanupInterval = 15 * time.Minute
-	connIdleConnLength  = 30 * time.Minute
-)
-
 func init() {
 	clogger = correlation.NewPackageLogger(correlation.ComponentCSIDriver)
 }
@@ -61,13 +54,14 @@ func init() {
 // OsdCsiServerConfig provides the configuration to the
 // the gRPC CSI server created by NewOsdCsiServer()
 type OsdCsiServerConfig struct {
-	Net           string
-	Address       string
-	DriverName    string
-	Cluster       cluster.Cluster
-	SdkUds        string
-	SdkPort       string
-	SchedulerName string
+	Net                string
+	Address            string
+	DriverName         string
+	Cluster            cluster.Cluster
+	RoundRobinBalancer loadbalancer.Balancer
+	SdkUds             string
+	SdkPort            string
+	SchedulerName      string
 
 	// Name to be reported back to the CO. If not provided,
 	// the name will be in the format of <driver>.openstorage.org
@@ -78,12 +72,6 @@ type OsdCsiServerConfig struct {
 	EnableInlineVolumes bool
 }
 
-// TimedSDKConn represents a gRPC connection and the last time it was used
-type TimedSDKConn struct {
-	Conn      *grpc.ClientConn
-	LastUsage time.Time
-}
-
 // OsdCsiServer is a OSD CSI compliant server which
 // proxies CSI requests for a single specific driver
 type OsdCsiServer struct {
@@ -92,18 +80,16 @@ type OsdCsiServer struct {
 	csi.IdentityServer
 
 	*grpcserver.GrpcServer
-	specHandler          spec.SpecHandler
-	driver               volume.VolumeDriver
-	cluster              cluster.Cluster
-	sdkUds               string
-	sdkPort              string
-	conn                 *grpc.ClientConn
-	connMap              map[string]*TimedSDKConn
-	nextCreateNodeNumber int
-	mu                   sync.Mutex
-	csiDriverName        string
-	allowInlineVolumes   bool
-	stopCleanupCh        chan bool
+	specHandler        spec.SpecHandler
+	driver             volume.VolumeDriver
+	cluster            cluster.Cluster
+	sdkUds             string
+	sdkPort            string
+	conn               *grpc.ClientConn
+	mu                 sync.Mutex
+	csiDriverName      string
+	allowInlineVolumes bool
+	roundRobinBalancer loadbalancer.Balancer
 }
 
 // NewOsdCsiServer creates a gRPC CSI complient server on the
@@ -169,6 +155,7 @@ func NewOsdCsiServer(config *OsdCsiServerConfig) (grpcserver.Server, error) {
 		sdkPort:            config.SdkPort,
 		csiDriverName:      config.CsiDriverName,
 		allowInlineVolumes: config.EnableInlineVolumes,
+		roundRobinBalancer: config.RoundRobinBalancer,
 	}, nil
 }
 
@@ -196,56 +183,8 @@ func (s *OsdCsiServer) getRemoteConn(ctx context.Context) (*grpc.ClientConn, err
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// Get all nodes and sort them
-	nodesResp, err := s.cluster.Enumerate()
-	if err != nil {
-		return nil, err
-	}
-	if len(nodesResp.Nodes) < 1 {
-		return nil, errors.New("cluster nodes for remote connection not found")
-	}
-	sort.Slice(nodesResp.Nodes, func(i, j int) bool {
-		return nodesResp.Nodes[i].Id < nodesResp.Nodes[j].Id
-	})
-
-	// Clean up connections for missing nodes
-	s.cleanupMissingNodeConnections(ctx, nodesResp.Nodes)
-
-	// Get target node info and set next round robbin node.
-	// nextNode is always lastNode + 1 mod (numOfNodes), to loop back to zero
-	var targetNodeNumber int
-	if s.nextCreateNodeNumber != 0 {
-		targetNodeNumber = s.nextCreateNodeNumber
-	}
-	targetNodeEndpoint := nodesResp.Nodes[targetNodeNumber].MgmtIp
-	s.nextCreateNodeNumber = (targetNodeNumber + 1) % len(nodesResp.Nodes)
-
-	// Get conn for this node, otherwise create new conn
-	if len(s.connMap) == 0 {
-		s.connMap = make(map[string]*TimedSDKConn)
-	}
-	if s.connMap[targetNodeEndpoint] == nil {
-		var err error
-		clogger.WithContext(ctx).Infof("Round-robin connecting to node %v - %s:%s", targetNodeNumber, targetNodeEndpoint, s.sdkPort)
-		remoteConn, err := grpcserver.ConnectWithTimeout(
-			fmt.Sprintf("%s:%s", targetNodeEndpoint, s.sdkPort),
-			[]grpc.DialOption{
-				grpc.WithInsecure(),
-				grpc.WithUnaryInterceptor(correlation.ContextUnaryClientInterceptor),
-			}, 10*time.Second)
-		if err != nil {
-			return nil, err
-		}
-
-		s.connMap[targetNodeEndpoint] = &TimedSDKConn{
-			Conn: remoteConn,
-		}
-	}
-
-	// Keep track of when this conn was last accessed
-	clogger.WithContext(ctx).Infof("Using remote connection to SDK node %v - %s:%s", targetNodeNumber, targetNodeEndpoint, s.sdkPort)
-	s.connMap[targetNodeEndpoint].LastUsage = time.Now()
-	return s.connMap[targetNodeEndpoint].Conn, nil
+	remoteConn, _, err := s.roundRobinBalancer.GetRemoteNodeConnection(ctx)
+	return remoteConn, err
 }
 
 // driverGetVolume returns a volume for a given ID. This function skips
@@ -315,8 +254,6 @@ func (s *OsdCsiServer) addEncryptionInfoToLabels(labels, csiSecrets map[string]s
 // It will return an error if the server is already running.
 func (s *OsdCsiServer) Start() error {
 	return s.GrpcServer.Start(func(grpcServer *grpc.Server) {
-		go s.cleanupConnections()
-
 		csi.RegisterIdentityServer(grpcServer, s)
 		csi.RegisterControllerServer(grpcServer, s)
 		csi.RegisterNodeServer(grpcServer, s)
@@ -325,83 +262,7 @@ func (s *OsdCsiServer) Start() error {
 
 // Start is used to stop the server.
 func (s *OsdCsiServer) Stop() {
-	if s.stopCleanupCh != nil {
-		close(s.stopCleanupCh)
-	}
 	s.GrpcServer.Stop()
-}
-
-func (s *OsdCsiServer) cleanupConnections() {
-	s.stopCleanupCh = make(chan bool)
-	ticker := time.NewTicker(connCleanupInterval)
-
-	// Check every so often and delete/close connections
-	for {
-		select {
-		case <-s.stopCleanupCh:
-			ticker.Stop()
-			return
-
-		case _ = <-ticker.C:
-			ctx := correlation.WithCorrelationContext(context.Background(), correlation.ComponentCSIDriver)
-
-			// Anonymous function for using defer to unlock mutex
-			func() {
-				s.mu.Lock()
-				defer s.mu.Unlock()
-				clogger.Tracef("Cleaning up open gRPC connections for CSI distributed provisioning")
-
-				// Clean all expired connections
-				numConnsClosed := 0
-				for ip, timedConn := range s.connMap {
-					expiryTime := timedConn.LastUsage.Add(connIdleConnLength)
-
-					// Connection has expired after 1hr of no usage.
-					// Close connection and remove from connMap
-					if expiryTime.Before(time.Now()) {
-						clogger.Infof("SDK gRPC connection to %s is has expired after %v minutes of no usage. Closing this connection", ip, connIdleConnLength.Minutes())
-						if err := timedConn.Conn.Close(); err != nil {
-							clogger.Errorf("failed to close connection to %s: %v", ip, timedConn.Conn)
-						}
-						delete(s.connMap, ip)
-						numConnsClosed++
-					}
-				}
-
-				// Get all nodes and cleanup conns for missing/deprovisioned nodes
-				nodesResp, err := s.cluster.Enumerate()
-				if err != nil {
-					clogger.Errorf("failed to get all nodes for connection cleanup: %v", err)
-					return
-				}
-				if len(nodesResp.Nodes) < 1 {
-					clogger.Errorf("no nodes available to cleanup: %v", err)
-					return
-				}
-				s.cleanupMissingNodeConnections(ctx, nodesResp.Nodes)
-
-				if numConnsClosed > 0 {
-					clogger.Infof("Cleaned up %v connections for CSI distributed provisioning. %v connections remaining", numConnsClosed, len(s.connMap))
-				}
-			}()
-		}
-	}
-}
-
-func (s *OsdCsiServer) cleanupMissingNodeConnections(ctx context.Context, nodes []*api.Node) {
-	nodesMap := make(map[string]bool)
-	for _, node := range nodes {
-		nodesMap[node.MgmtIp] = true
-	}
-	for ip, timedConn := range s.connMap {
-		if ok := nodesMap[ip]; !ok {
-			// If key in connmap is not in current nodes, close and remove it
-			if err := timedConn.Conn.Close(); err != nil {
-				clogger.WithContext(ctx).Errorf("failed to close conn to %s: %v", ip, err)
-			}
-			delete(s.connMap, ip)
-		}
-	}
 }
 
 // adjustFinalErrors adjusts certain gRPC status to make CSI callers

--- a/csi/csi_test.go
+++ b/csi/csi_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/libopenstorage/openstorage/config"
 	"github.com/libopenstorage/openstorage/pkg/auth"
 	"github.com/libopenstorage/openstorage/pkg/grpcserver"
+	"github.com/libopenstorage/openstorage/pkg/loadbalancer"
 	"github.com/libopenstorage/openstorage/pkg/options"
 	"github.com/libopenstorage/openstorage/pkg/role"
 	"github.com/libopenstorage/openstorage/pkg/storagepolicy"
@@ -152,6 +153,7 @@ func newTestServerWithConfig(t *testing.T, config *OsdCsiServerConfig) *testServ
 	if config.Cluster == nil {
 		config.Cluster = tester.c
 	}
+	config.RoundRobinBalancer = loadbalancer.NewNullBalancer()
 
 	setupMockDriver(tester, t)
 

--- a/pkg/correlation/context.go
+++ b/pkg/correlation/context.go
@@ -41,10 +41,11 @@ const (
 	// ContextOriginKey represents the key for the correlation origin
 	ContextOriginKey = "correlation-context-origin"
 
-	ComponentUnknown   = Component("unknown")
-	ComponentCSIDriver = Component("csi-driver")
-	ComponentSDK       = Component("sdk-server")
-	ComponentAuth      = Component("openstorage/pkg/auth")
+	ComponentUnknown            = Component("unknown")
+	ComponentCSIDriver          = Component("csi-driver")
+	ComponentSDK                = Component("sdk-server")
+	ComponentRoundRobinBalancer = Component("round-robin-balancer")
+	ComponentAuth               = Component("openstorage/pkg/auth")
 )
 
 // RequestContext represents the context for a given a request.

--- a/pkg/loadbalancer/balancer.go
+++ b/pkg/loadbalancer/balancer.go
@@ -16,9 +16,6 @@ type Balancer interface {
 	// The boolean return argument is set to false if the connection is created
 	// to the local node.
 	GetRemoteNodeConnection(ctx context.Context) (*grpc.ClientConn, bool, error)
-
-	// Stop stops the balancer
-	Stop()
 }
 
 type nullBalancer struct{}
@@ -31,5 +28,3 @@ func NewNullBalancer() Balancer {
 func (n *nullBalancer) GetRemoteNodeConnection(ctx context.Context) (*grpc.ClientConn, bool, error) {
 	return nil, false, fmt.Errorf("remote connections not supported")
 }
-
-func (n *nullBalancer) Stop() {}

--- a/pkg/loadbalancer/balancer.go
+++ b/pkg/loadbalancer/balancer.go
@@ -1,0 +1,35 @@
+package loadbalancer
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/grpc"
+)
+
+// Balancer provides APIs to load balance a gRPC connection over a given
+// cluster.
+type Balancer interface {
+	// GetRemoteNodeConnection returns a gRPC client connection to a node
+	// in the cluster using a round-robin algorithm. The API will return
+	// an error if it fails to create a connection to a node in the cluster.
+	// The boolean return argument is set to false if the connection is created
+	// to the local node.
+	GetRemoteNodeConnection(ctx context.Context) (*grpc.ClientConn, bool, error)
+
+	// Stop stops the balancer
+	Stop()
+}
+
+type nullBalancer struct{}
+
+// NewNullBalancer is the no-op implementation of the Balancer interface
+func NewNullBalancer() Balancer {
+	return &nullBalancer{}
+}
+
+func (n *nullBalancer) GetRemoteNodeConnection(ctx context.Context) (*grpc.ClientConn, bool, error) {
+	return nil, false, fmt.Errorf("remote connections not supported")
+}
+
+func (n *nullBalancer) Stop() {}

--- a/pkg/loadbalancer/roundrobin.go
+++ b/pkg/loadbalancer/roundrobin.go
@@ -1,0 +1,215 @@
+package loadbalancer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/libopenstorage/openstorage/api"
+	"github.com/libopenstorage/openstorage/cluster"
+	"github.com/libopenstorage/openstorage/pkg/correlation"
+	"github.com/libopenstorage/openstorage/pkg/grpcserver"
+	"github.com/libopenstorage/openstorage/pkg/sched"
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc"
+)
+
+// TimedSDKConn represents a gRPC connection and the last time it was used
+type TimedSDKConn struct {
+	Conn      *grpc.ClientConn
+	LastUsage time.Time
+}
+
+type roundRobin struct {
+	cluster              cluster.Cluster
+	connMap              map[string]*TimedSDKConn
+	nextCreateNodeNumber int
+	mu                   sync.Mutex
+	stopCleanupCh        chan bool
+	grpcServerPort       string
+}
+
+var (
+	rrlogger *logrus.Logger
+)
+
+const (
+	connCleanupInterval = 15 * time.Minute
+	connIdleConnLength  = 30 * time.Minute
+)
+
+// NewRoundRobinBalancer returns an implementation of the RoundRobin interface
+// for getting a remote grpc client connection to one of the nodes in the cluster.
+func NewRoundRobinBalancer(
+	cluster cluster.Cluster,
+	grpcServerPort string,
+) (Balancer, error) {
+	if cluster == nil {
+		return nil, fmt.Errorf("cluster cannot be nil")
+	}
+	rr := &roundRobin{cluster: cluster, grpcServerPort: grpcServerPort}
+	if sched.Instance() == nil {
+		return nil, fmt.Errorf("sched instance is not initialized")
+	}
+	if _, err := sched.Instance().Schedule(
+		func(interval sched.Interval) { rr.cleanupConnections() },
+		sched.Periodic(connCleanupInterval),
+		time.Now().Add(connCleanupInterval),
+		false,
+	); err != nil {
+		return nil, fmt.Errorf("failed to schedule round robin cleanup routine: %v", err)
+	}
+	return rr, nil
+}
+
+func (rr *roundRobin) GetRemoteNodeConnection(ctx context.Context) (*grpc.ClientConn, bool, error) {
+	rr.mu.Lock()
+	defer rr.mu.Unlock()
+
+	// Get all nodes and sort them
+	cluster, err := rr.cluster.Enumerate()
+	if err != nil {
+		return nil, false, err
+	}
+	if len(cluster.Nodes) < 1 {
+		return nil, false, errors.New("cluster nodes for remote connection not found")
+	}
+	sort.Slice(cluster.Nodes, func(i, j int) bool {
+		return cluster.Nodes[i].Id < cluster.Nodes[j].Id
+	})
+
+	// Clean up connections for missing nodes
+	rr.cleanupMissingNodeConnections(ctx, cluster.Nodes)
+
+	// Get target node info and set next round robbin node.
+	// nextNode is always lastNode + 1 mod (numOfNodes), to loop back to zero
+	var (
+		targetNodeNumber int
+		isRemoteConn     bool
+	)
+	if rr.nextCreateNodeNumber != 0 {
+		targetNodeNumber = rr.nextCreateNodeNumber
+	}
+	targetNode := cluster.Nodes[targetNodeNumber]
+	if targetNode.Id != cluster.NodeId {
+		// NodeID set on the cluster object is this node's ID.
+		// Target NodeID does not match with our NodeID, so this will be a remote connection.
+		isRemoteConn = true
+	}
+	targetNodeEndpoint := targetNode.MgmtIp
+	rr.nextCreateNodeNumber = (targetNodeNumber + 1) % len(cluster.Nodes)
+
+	// Get conn for this node, otherwise create new conn
+	if len(rr.connMap) == 0 {
+		rr.connMap = make(map[string]*TimedSDKConn)
+	}
+	if rr.connMap[targetNodeEndpoint] == nil {
+		var err error
+		rrlogger.WithContext(ctx).Infof("Round-robin connecting to node %v - %s:%s", targetNodeNumber, targetNodeEndpoint, rr.grpcServerPort)
+		remoteConn, err := grpcserver.ConnectWithTimeout(
+			fmt.Sprintf("%s:%s", targetNodeEndpoint, rr.grpcServerPort),
+			[]grpc.DialOption{
+				grpc.WithInsecure(),
+				grpc.WithUnaryInterceptor(correlation.ContextUnaryClientInterceptor),
+			}, 10*time.Second)
+		if err != nil {
+			return nil, isRemoteConn, err
+		}
+
+		rr.connMap[targetNodeEndpoint] = &TimedSDKConn{
+			Conn: remoteConn,
+		}
+	}
+
+	// Keep track of when this conn was last accessed
+	rrlogger.WithContext(ctx).Infof("Using remote connection to SDK node %v - %s:%s", targetNodeNumber, targetNodeEndpoint, rr.grpcServerPort)
+	rr.connMap[targetNodeEndpoint].LastUsage = time.Now()
+	return rr.connMap[targetNodeEndpoint].Conn, isRemoteConn, nil
+
+}
+
+func (rr *roundRobin) cleanupMissingNodeConnections(ctx context.Context, nodes []*api.Node) {
+	nodesMap := make(map[string]bool)
+	for _, node := range nodes {
+		nodesMap[node.MgmtIp] = true
+	}
+	for ip, timedConn := range rr.connMap {
+		if ok := nodesMap[ip]; !ok {
+			// If key in connmap is not in current nodes, close and remove it
+			if err := timedConn.Conn.Close(); err != nil {
+				rrlogger.WithContext(ctx).Errorf("failed to close conn to %s: %v", ip, err)
+			}
+			delete(rr.connMap, ip)
+		}
+	}
+}
+
+func (rr *roundRobin) cleanupConnections() {
+	rr.stopCleanupCh = make(chan bool)
+	ticker := time.NewTicker(connCleanupInterval)
+
+	// Check every so often and delete/close connections
+	for {
+		select {
+		case <-rr.stopCleanupCh:
+			ticker.Stop()
+			return
+
+		case _ = <-ticker.C:
+			ctx := correlation.WithCorrelationContext(context.Background(), correlation.ComponentRoundRobinBalancer)
+
+			// Anonymous function for using defer to unlock mutex
+			func() {
+				rr.mu.Lock()
+				defer rr.mu.Unlock()
+				rrlogger.Tracef("Cleaning up open gRPC connections for CSI distributed provisioning")
+
+				// Clean all expired connections
+				numConnsClosed := 0
+				for ip, timedConn := range rr.connMap {
+					expiryTime := timedConn.LastUsage.Add(connIdleConnLength)
+
+					// Connection has expired after 1hr of no usage.
+					// Close connection and remove from connMap
+					if expiryTime.Before(time.Now()) {
+						rrlogger.Infof("SDK gRPC connection to %s is has expired after %v minutes of no usage. Closing this connection", ip, connIdleConnLength.Minutes())
+						if err := timedConn.Conn.Close(); err != nil {
+							rrlogger.Errorf("failed to close connection to %s: %v", ip, timedConn.Conn)
+						}
+						delete(rr.connMap, ip)
+						numConnsClosed++
+					}
+				}
+
+				// Get all nodes and cleanup conns for missing/deprovisioned nodes
+				nodesResp, err := rr.cluster.Enumerate()
+				if err != nil {
+					rrlogger.Errorf("failed to get all nodes for connection cleanup: %v", err)
+					return
+				}
+				if len(nodesResp.Nodes) < 1 {
+					rrlogger.Errorf("no nodes available to cleanup: %v", err)
+					return
+				}
+				rr.cleanupMissingNodeConnections(ctx, nodesResp.Nodes)
+
+				if numConnsClosed > 0 {
+					rrlogger.Infof("Cleaned up %v connections for CSI distributed provisioning. %v connections remaining", numConnsClosed, len(rr.connMap))
+				}
+			}()
+		}
+	}
+}
+
+func (rr *roundRobin) Stop() {
+	if rr.stopCleanupCh != nil {
+		close(rr.stopCleanupCh)
+	}
+}
+
+func init() {
+	rrlogger = correlation.NewPackageLogger(correlation.ComponentRoundRobinBalancer)
+}


### PR DESCRIPTION

**What this PR does / why we need it**:
- Move the current round-robin logic used by the CSI driver into a separate package.
- Currently only the VolumeMigrate's Start() API uses the round-robin load balancing functionality.
- Modify the CSI code to use the new round robin package.

The round robin package provides a GetRemoteNodeConnection() API
 - The API returns:
   - a gRPC client connection object.
   - a boolean value indicating whether the connection is to a remote node. It is set to false if the round robin node chosen is the current node itself.
   - an error which is returned when the API fails to create a gRPC connection.


**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Eventually we could bake the round-robin balancer into the gRPC interceptor itself and allow each registered API to choose whether they want the round-robin functionality
