### PR TITLE
feat: delete cloud backup handler

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -1161,7 +1161,8 @@ func (s *OsdCsiServer) deleteCloudBackup(
 	})
 	if err != nil {
 		if strings.HasSuffix(err.Error(), " not found") {
-			return nil, status.Errorf(codes.NotFound, err.Error())
+			clogger.WithContext(ctx).Errorln(err.Error())
+			return &csi.DeleteSnapshotResponse{}, nil
 		}
 		return nil, status.Errorf(codes.Aborted, "failed to delete cloud snapshot: %v", err)
 	}

--- a/csi/controller.go
+++ b/csi/controller.go
@@ -1155,7 +1155,7 @@ func (s *OsdCsiServer) deleteCloudBackup(
 	backupID := req.GetSnapshotId()
 
 	// Delete snapshot
-	resp, err := cloudBackupClient.Delete(ctx, &api.SdkCloudBackupDeleteRequest{
+	_, err = cloudBackupClient.Delete(ctx, &api.SdkCloudBackupDeleteRequest{
 		BackupId:     backupID,
 		CredentialId: credentialID,
 	})
@@ -1166,12 +1166,7 @@ func (s *OsdCsiServer) deleteCloudBackup(
 		}
 		return nil, status.Errorf(codes.Aborted, "failed to delete cloud snapshot: %v", err)
 	}
-
-	if resp != nil {
-		return &csi.DeleteSnapshotResponse{}, nil
-	}
-
-	return nil, status.Errorf(codes.Aborted, "unexpected error occured: %v", err)
+	return &csi.DeleteSnapshotResponse{}, nil
 }
 
 // ListSnapshots lists all snapshots in a cluster.

--- a/csi/controller.go
+++ b/csi/controller.go
@@ -22,13 +22,13 @@ import (
 	"math"
 	"reflect"
 	"sort"
-	"strings"
 
 	"github.com/portworx/kvdb"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/libopenstorage/openstorage/api"
+	"github.com/libopenstorage/openstorage/api/server/sdk"
 	"github.com/libopenstorage/openstorage/pkg/grpcutil"
 	"github.com/libopenstorage/openstorage/pkg/units"
 	"github.com/libopenstorage/openstorage/pkg/util"
@@ -1159,11 +1159,9 @@ func (s *OsdCsiServer) deleteCloudBackup(
 		BackupId:     backupID,
 		CredentialId: credentialID,
 	})
-	if err != nil {
-		if strings.HasSuffix(err.Error(), " not found") {
-			clogger.WithContext(ctx).Errorln(err.Error())
-			return &csi.DeleteSnapshotResponse{}, nil
-		}
+	// NOTE: Currently, the Delete API call has no implementation that returns
+	//  a not found gRPC error with the status code.
+	if err != nil && !sdk.IsErrorNotFound(err) {
 		return nil, status.Errorf(codes.Aborted, "failed to delete cloud snapshot: %v", err)
 	}
 	return &csi.DeleteSnapshotResponse{}, nil

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -3653,20 +3653,6 @@ func TestOsdCsiServer_DeleteCloudSnapshot(t *testing.T) {
 			true,
 		},
 		{
-			"volume id not found while deleting",
-			"delete-notfound",
-			"valid-cred",
-			nil,
-			true,
-		},
-		{
-			"unexpected error",
-			"unexpected-error",
-			"valid-cred",
-			&csi.DeleteSnapshotResponse{},
-			true,
-		},
-		{
 			"deletion completes without any error",
 			"ok",
 			"valid-cred",

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -3642,8 +3642,8 @@ func TestOsdCsiServer_DeleteCloudSnapshot(t *testing.T) {
 			"fail snapshot delete",
 			"not-found-error",
 			"valid-cred",
-			nil,
-			true,
+			&csi.DeleteSnapshotResponse{},
+			false,
 		},
 		{
 			"fail snapshot delete",

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/libopenstorage/openstorage/api"
-	api_err "github.com/libopenstorage/openstorage/api/errors"
 	"github.com/libopenstorage/openstorage/api/mock"
 	"github.com/libopenstorage/openstorage/api/spec"
 	authsecrets "github.com/libopenstorage/openstorage/pkg/auth/secrets"
@@ -3573,12 +3572,10 @@ func TestOsdCsiServer_DeleteCloudSnapshot(t *testing.T) {
 
 	ctx := context.Background()
 
-	mockErr := errors.New("MOCK ERROR")
+	mockErrMsg := "MOCK ERROR"
+	mockErr := status.Error(codes.Internal, mockErrMsg)
 
-	notFoundErr := &api_err.ErrNotFound{
-		Type: "CloudBackup",
-		ID:   "not-found-error",
-	}
+	notFoundErr := status.Error(codes.NotFound, mockErrMsg)
 
 	mockRoundRobinBalancer := mockLoadBalancer.NewMockBalancer(ctrl)
 	// nil, false, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
Delete snapshots created for cloud backup

the deletion would require passing in the credential id in the secrets parameter along with the cloud backup id as the snapshot id
