### PR TITLE
Automated cherry pick of #2262: Move ControllerGetVolume log to be Tracef

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -136,7 +136,7 @@ func (s *OsdCsiServer) ControllerGetVolume(
 	req *csi.ControllerGetVolumeRequest,
 ) (*csi.ControllerGetVolumeResponse, error) {
 
-	clogger.WithContext(ctx).Infof("ControllerGetVolume request received. VolumeID: %s", req.GetVolumeId())
+	clogger.WithContext(ctx).Tracef("ControllerGetVolume request received. VolumeID: %s", req.GetVolumeId())
 
 	vol, err := s.driverGetVolume(ctx, req.GetVolumeId())
 	if err != nil {


### PR DESCRIPTION
Cherry pick of #2262 on release-9.7.

#2262: Move ControllerGetVolume log to be Tracef

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.