### PR TITLE
PWX-32881: [CSI] Add CSI socket auto-recover when deleted

### DIFF
--- a/csi/csi_test.go
+++ b/csi/csi_test.go
@@ -52,9 +52,10 @@ import (
 )
 
 const (
-	mockDriverName   = "mock"
-	testSharedSecret = "mysecret"
-	fakeWithSched    = "fake-sched"
+	mockDriverName     = "mock"
+	testSharedSecret   = "mysecret"
+	fakeWithSched      = "fake-sched"
+	testSocketLocation = "/tmp/csi-ut.sock"
 )
 
 var (
@@ -141,6 +142,15 @@ func newTestServer(t *testing.T) *testServer {
 	})
 }
 
+func newUDSTestServer(t *testing.T) *testServer {
+	os.Remove(testSocketLocation)
+	return newTestServerWithConfig(t, &OsdCsiServerConfig{
+		DriverName: mockDriverName,
+		Address:    testSocketLocation,
+		Net:        "unix",
+	})
+}
+
 func newTestServerWithConfig(t *testing.T, config *OsdCsiServerConfig) *testServer {
 	tester := &testServer{}
 	tester.setPorts()
@@ -205,8 +215,13 @@ func newTestServerWithConfig(t *testing.T, config *OsdCsiServerConfig) *testServ
 	})
 
 	// Setup CSI simple driver
-	config.Net = "tcp"
-	config.Address = "127.0.0.1:0"
+	// Allow for net and address to be overwritten
+	if config.Net == "" {
+		config.Net = "tcp"
+	}
+	if config.Address == "" {
+		config.Address = "127.0.0.1:0"
+	}
 	config.SdkUds = tester.uds
 	config.SdkPort = tester.port
 	tester.server, err = NewOsdCsiServer(config)
@@ -445,4 +460,35 @@ func TestCSIServerStartContextInterceptor(t *testing.T) {
 
 	expectedInfoLog = "csi-driver"
 	assert.Contains(t, logStr, expectedInfoLog)
+}
+
+func TestCSISocketAutoRecover(t *testing.T) {
+	csiSocketCheckInterval = 1 * time.Second
+
+	// Start server and wait for socket to be up and running
+	s := newUDSTestServer(t)
+	assert.True(t, s.Server().IsRunning())
+	defer func() {
+		s.Stop()
+	}()
+	assert.Eventually(t, s.server.IsRunning, 30*time.Second, time.Second)
+	assert.Eventually(t, func() bool {
+		_, err := os.Stat(testSocketLocation)
+		return err == nil
+	}, 30*time.Second, time.Second)
+	_, err := os.Stat(testSocketLocation)
+	assert.NoError(t, err, "UDS should exist after startup")
+
+	// Delete socket and wait for it to be gone
+	err = os.Remove(testSocketLocation)
+	assert.NoError(t, err)
+
+	// Wait for auto-recover
+	assert.Eventually(t, func() bool {
+		_, err := os.Stat(testSocketLocation)
+		return err == nil
+	}, 30*time.Second, time.Second)
+	assert.True(t, s.server.IsRunning(), "Server should be running after autorecover")
+	_, err = os.Stat(testSocketLocation)
+	assert.NoError(t, err, "UDS should exist after autorecover")
 }

--- a/pkg/grpcserver/grpcserver.go
+++ b/pkg/grpcserver/grpcserver.go
@@ -153,6 +153,11 @@ func (s *GrpcServer) IsRunning() bool {
 	return s.running
 }
 
+// Listener returns the listener used for this gRPC server
+func (s *GrpcServer) Listener() net.Listener {
+	return s.listener
+}
+
 func (s *GrpcServer) goServe(started chan<- bool) {
 	s.wg.Add(1)
 	go func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Add CSI socket auto-recover when deleted.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
* I first investigated using `fsnotify`, but it added a lot of complexity and seemed overkill. It was also unreliable compared to checking periodically.
* This only takes care of the CSI Driver socket at `/var/lib/kubelet/plugins/pxd.portworx.com/csi.sock`. There is another UDS created by the kubelet registration system for registering the CSI node. That is at `/var/lib/kubelet/plugins_registry/pxd.portworx.com-reg.sock`. A PX Pod restart is required to get that to re-register. Looking into how that can be automated too. This PR only fixes the issue of having to restart portworx to get the CSI Driver socket re-created.

**Test Results:**

_Delete socket on server:_
```
[root@ggriffiths-k8s1-node1 pxd.portworx.com]# rm -rf csi.sock
```

_CSI Server restarted:_
```
@ggriffiths-k8s1-node1 portworx[32494]: time="2023-08-12T00:23:21Z" level=info msg="csi.NodePublishVolume request received. VolumeID: 327234080797915498, TargetPath: /var/lib/kubelet/pods/dbc4f54c-e31c-43e9-bcb2-1966ff2ac44f/volumes/kubernetes.io~csi/pvc-824951cd-ca92-414e-9b7d-b3d3ca8b97a3/mount" component=csi-driver correlation-id=cb2f0116-2ea6-42d9-b824-3a6e52b6de53 origin=csi-driver
@ggriffiths-k8s1-node1 portworx[32494]: time="2023-08-12T00:23:30Z" level=info msg="Detected CSI socket deleted at path /var/lib/kubelet/plugins/pxd.portworx.com/csi.sock. Stopping CSI server" file="csi.go:337" component=openstorage/csi
@ggriffiths-k8s1-node1 portworx[32494]: time="2023-08-12T00:23:30Z" level=info msg="CSI K8s filter being added for kubernetes scheduler" file="csi.go:299" component=openstorage/csi
@ggriffiths-k8s1-node1 portworx[32494]: time="2023-08-12T00:23:30Z" level=info msg="Restarting CSI gRPC server at /var/lib/kubelet/plugins/pxd.portworx.com/csi.sock" file="csi.go:348" component=openstorage/csi
@ggriffiths-k8s1-node1 portworx[32494]: time="2023-08-12T00:23:30Z" level=info msg="CSI 1.7 gRPC Server ready on /var/lib/kubelet/plugins/pxd.portworx.com/csi.sock" file="grpcserver.go:119" component=openstorage/pkg/grpcserver
```

_socket re-created_
```
[root@ggriffiths-k8s1-node1 pxd.portworx.com]# ls
csi.sock
```