### PR TITLE
PWX-33631: Remove global lock on getRemoteConn

### DIFF
--- a/csi/csi.go
+++ b/csi/csi.go
@@ -159,9 +159,6 @@ func (s *OsdCsiServer) getConn() (*grpc.ClientConn, error) {
 }
 
 func (s *OsdCsiServer) getRemoteConn(ctx context.Context) (*grpc.ClientConn, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	remoteConn, _, err := s.roundRobinBalancer.GetRemoteNodeConnection(ctx)
 	return remoteConn, err
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove global lock on getRemoteConn

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

