### PR TITLE
PWX-33879: Add support for RWOP access mode

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -101,6 +101,9 @@ func (s *OsdCsiServer) ControllerGetCapabilities(
 
 		// GetCapacity
 		csi.ControllerServiceCapability_RPC_GET_CAPACITY,
+
+		// SINGLE_NODE_MULTI_WRITER Capability for RWOP access mode
+		csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
 	}
 
 	var serviceCapabilities []*csi.ControllerServiceCapability

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -77,7 +77,7 @@ func TestControllerGetCapabilities(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 
-	assert.Len(t, resp.GetCapabilities(), 8)
+	assert.Len(t, resp.GetCapabilities(), 9)
 	assert.True(t, containsCap(csi.ControllerServiceCapability_RPC_GET_VOLUME, resp))
 	assert.True(t, containsCap(csi.ControllerServiceCapability_RPC_CLONE_VOLUME, resp))
 	assert.True(t, containsCap(csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME, resp))
@@ -86,6 +86,7 @@ func TestControllerGetCapabilities(t *testing.T) {
 	assert.True(t, containsCap(csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS, resp))
 	assert.True(t, containsCap(csi.ControllerServiceCapability_RPC_VOLUME_CONDITION, resp))
 	assert.True(t, containsCap(csi.ControllerServiceCapability_RPC_GET_CAPACITY, resp))
+	assert.True(t, containsCap(csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER, resp))
 
 	assert.False(t, containsCap(csi.ControllerServiceCapability_RPC_UNKNOWN, resp))
 }

--- a/csi/node.go
+++ b/csi/node.go
@@ -73,7 +73,6 @@ func (s *OsdCsiServer) NodeGetInfo(
 // target path on the node.
 //
 // TODO: Support READ ONLY Mounts
-//
 func (s *OsdCsiServer) NodePublishVolume(
 	ctx context.Context,
 	req *csi.NodePublishVolumeRequest,
@@ -297,6 +296,7 @@ func (s *OsdCsiServer) NodeGetCapabilities(
 		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
 		// Indicates that the Node service can report volume conditions.
 		csi.NodeServiceCapability_RPC_VOLUME_CONDITION,
+		csi.NodeServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
 	}
 
 	var serviceCapabilities []*csi.NodeServiceCapability

--- a/csi/node_test.go
+++ b/csi/node_test.go
@@ -1047,7 +1047,7 @@ func TestNodeGetCapabilities(t *testing.T) {
 		context.Background(),
 		&csi.NodeGetCapabilitiesRequest{})
 	assert.NoError(t, err)
-	assert.Len(t, r.GetCapabilities(), 2)
+	assert.Len(t, r.GetCapabilities(), 3)
 	assert.Equal(
 		t,
 		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
@@ -1056,6 +1056,10 @@ func TestNodeGetCapabilities(t *testing.T) {
 		t,
 		csi.NodeServiceCapability_RPC_VOLUME_CONDITION,
 		r.GetCapabilities()[1].GetRpc().GetType())
+	assert.Equal(
+		t,
+		csi.NodeServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
+		r.GetCapabilities()[2].GetRpc().GetType())
 }
 
 func TestNodeGetVolumeStats(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:  
Adds the required CSI capabilities for the RWOP access mode as defined in this blog:
https://kubernetes.io/blog/2023/04/20/read-write-once-pod-access-mode-beta/

**Which issue(s) this PR fixes** (optional)  
https://portworx.atlassian.net/browse/PWX-33879

**Testing Notes**  
TODO, will add before requesting review.

**Special notes for your reviewer**:  
n/a