### PR TITLE
PWX-33647: Export parseInfoFile 

### DIFF
--- a/pkg/mount/consistent_read.go
+++ b/pkg/mount/consistent_read.go
@@ -65,7 +65,7 @@ func parseMountTable() ([]*mountinfo.Info, error) {
 		return nil, err
 	}
 
-	return parseInfoFile(bytes.NewReader(mountInfoBytes))
+	return ParseInfoFile(bytes.NewReader(mountInfoBytes))
 }
 
 // consistentRead repeatedly reads a file until it gets the same content twice.
@@ -91,7 +91,7 @@ func consistentRead(filename string, attempts int) ([]byte, error) {
 	return nil, fmt.Errorf("could not get consistent content of mount table after %d attempts", attempts)
 }
 
-func parseInfoFile(r io.Reader) ([]*mountinfo.Info, error) {
+func ParseInfoFile(r io.Reader) ([]*mountinfo.Info, error) {
 	var (
 		s   = bufio.NewScanner(r)
 		out = []*mountinfo.Info{}


### PR DESCRIPTION
… can parse mountinfo file using this function

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:  
There are multiple use cases, especially for testing, where we want to parseMountInfo() from a input buffer.

**Which issue(s) this PR fixes** (optional)  

PWX-33647


