### PR TITLE
PWX-34326: CSI - fix GetPluginInfo version for CSI

### DIFF
--- a/csi/identity.go
+++ b/csi/identity.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	// CSI 1.4 compatible
-	csiDriverVersion = "1.4.0"
+	// CSI 1.7 compatible
+	csiDriverVersion = "1.7.0"
 
 	// https://tools.ietf.org/html/rfc1035#section-2.3.1
 	csiDriverNameFormat = "%s.openstorage.org"


### PR DESCRIPTION
**What this PR does / why we need it**:  
Nomad shows this version in the CLI output, so we need to have the correct version exposed here via GetPluginInfo

**Which issue(s) this PR fixes** (optional)  
PWX-34326

**Testing Notes**  
Not needed

**Special notes for your reviewer**:  
n/a
