### PR TITLE
PWX-33647: Export parseInfoFile, For external users. (#2357)

### DIFF
--- a/pkg/mount/consistent_read.go
+++ b/pkg/mount/consistent_read.go
@@ -65,7 +65,7 @@ func parseMountTable() ([]*mountinfo.Info, error) {
 		return nil, err
 	}
 
-	return parseInfoFile(bytes.NewReader(mountInfoBytes))
+	return ParseInfoFile(bytes.NewReader(mountInfoBytes))
 }
 
 // consistentRead repeatedly reads a file until it gets the same content twice.
@@ -91,7 +91,7 @@ func consistentRead(filename string, attempts int) ([]byte, error) {
 	return nil, fmt.Errorf("could not get consistent content of mount table after %d attempts", attempts)
 }
 
-func parseInfoFile(r io.Reader) ([]*mountinfo.Info, error) {
+func ParseInfoFile(r io.Reader) ([]*mountinfo.Info, error) {
 	var (
 		s   = bufio.NewScanner(r)
 		out = []*mountinfo.Info{}


### PR DESCRIPTION
**What this PR does / why we need it**:  
This PR exposes ParseInfoFile as external function.
This can be used for users wanting to use private files for parsing mountinfo (useful for test cases).
PWX-33647

Manually tested ParseInfoFile() functionality using in memory buffers as file.
