### PR TITLE
Merge pull request #2366 from libopenstorage/pwx-34315

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1309,6 +1309,9 @@ func (v *VolumeSpec) IsPureVolume() bool {
 	return v.GetProxySpec() != nil && v.GetProxySpec().IsPureBackend()
 }
 
+func (v *VolumeSpec) IsPureBlockVolume() bool {
+	return v.GetProxySpec() != nil && v.GetProxySpec().IsPureBlockBackend()
+}
 // GetCloneCreatorOwnership returns the appropriate ownership for the
 // new snapshot and if an update is required
 func (v *VolumeSpec) GetCloneCreatorOwnership(ctx context.Context) (*Ownership, bool) {
@@ -1441,6 +1444,14 @@ func ParseProxyEndpoint(proxyEndpoint string) (ProxyProtocol, string) {
 func (s *ProxySpec) IsPureBackend() bool {
 	return s.ProxyProtocol == ProxyProtocol_PROXY_PROTOCOL_PURE_BLOCK ||
 		s.ProxyProtocol == ProxyProtocol_PROXY_PROTOCOL_PURE_FILE
+}
+
+func (s *ProxySpec) IsPureBlockBackend() bool {
+	return s.ProxyProtocol == ProxyProtocol_PROXY_PROTOCOL_PURE_BLOCK
+}
+
+func (s *ProxySpec) IsPureFileBackend() bool {
+	return s.ProxyProtocol == ProxyProtocol_PROXY_PROTOCOL_PURE_FILE
 }
 
 func (s *ProxySpec) IsPureImport() bool {


### PR DESCRIPTION
PWX-34315: Add IsPureBlockVolume() interface

In Background thread that detects ReadOnly volumes, certain action needs to be taken for BlockVolumes(), exposing IsPureBlockVolume() as an api interface so that apt action can be taken.

PWX-34315

Brief of testing Notes:
With various combination of volumes continuously make the volumes go read-only and verify that apt pods are getting bounced.
