### PR TITLE
[cherry-pick] Don't default to sharedv4/shared for RWX Volumes if proxy spec is set

### DIFF
--- a/csi/controller.go
+++ b/csi/controller.go
@@ -783,6 +783,11 @@ func resolveSharedSpec(spec *api.VolumeSpec, req *csi.CreateVolumeRequest) (*api
 		return spec, nil
 	}
 
+	// don't default to sharedv4/shared for RWX Volumes if proxy spec is set
+	if spec.ProxySpec != nil {
+		return spec, nil
+	}
+
 	var shared bool
 	for _, cap := range req.GetVolumeCapabilities() {
 		mode := cap.GetAccessMode().GetMode()

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -3299,7 +3299,8 @@ func TestResolveSpecFromCSI(t *testing.T) {
 			},
 
 			expectedSpec: &api.VolumeSpec{
-				Shared: false,
+				Shared:   false,
+				Sharedv4: false,
 				ProxySpec: &api.ProxySpec{
 					ProxyProtocol: api.ProxyProtocol_PROXY_PROTOCOL_NFS,
 				},

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -3281,6 +3281,30 @@ func TestResolveSpecFromCSI(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Should not set shared flag to true for RWX Volumes if proxy spec is set",
+			req: &csi.CreateVolumeRequest{
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+						},
+					},
+				},
+			},
+			existingSpec: &api.VolumeSpec{
+				ProxySpec: &api.ProxySpec{
+					ProxyProtocol: api.ProxyProtocol_PROXY_PROTOCOL_NFS,
+				},
+			},
+
+			expectedSpec: &api.VolumeSpec{
+				Shared: false,
+				ProxySpec: &api.ProxySpec{
+					ProxyProtocol: api.ProxyProtocol_PROXY_PROTOCOL_NFS,
+				},
+			},
+		},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
**What this PR does / why we need it**:  
Don't default to sharedv4/shared for RWX Volumes if proxy spec is set

**Which issue(s) this PR fixes** (optional)  
[PWX-33008](https://portworx.atlassian.net/browse/PWX-33008)

**Testing Notes**  
Add a proxy spec
RWX or a similar multi-node access mode the volume shouldn't default to sharedv4 if the proxy spec is defined



[PWX-33008]: https://portworx.atlassian.net/browse/PWX-33008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ