### PR TITLE
[PWX-34442] Update Error message, remove labels

### DIFF
--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/libopenstorage/openstorage/api"
-	"github.com/libopenstorage/openstorage/pkg/parser"
 )
 
 var (
@@ -56,7 +55,7 @@ func (e *ErrStoragePoolResizeInProgress) Error() string {
 	if e.Pool.LastOperation != nil {
 		op := e.Pool.LastOperation
 		if op.Type == api.SdkStoragePool_OPERATION_RESIZE {
-			errMsg = fmt.Sprintf("%s %s %s", errMsg, op.Msg, parser.LabelsToString(op.Params))
+			errMsg = fmt.Sprintf("%s %s %s", errMsg, op.Msg)
 		}
 	}
 

--- a/api/errors/errors.go
+++ b/api/errors/errors.go
@@ -55,7 +55,7 @@ func (e *ErrStoragePoolResizeInProgress) Error() string {
 	if e.Pool.LastOperation != nil {
 		op := e.Pool.LastOperation
 		if op.Type == api.SdkStoragePool_OPERATION_RESIZE {
-			errMsg = fmt.Sprintf("%s %s %s", errMsg, op.Msg)
+			errMsg = fmt.Sprintf("%s %s", errMsg, op.Msg)
 		}
 	}
 


### PR DESCRIPTION
Update Error message, remove labels

PWX-34442

Testing Done:- 
Before

```
# pxctl sv pool show
PX drive configuration:
Pool ID: 0
	Type:  PX-StoreV2
	UUID:  d948cae8-7077-4848-8530-5679e834ba07
	IO Priority:  HIGH
	Labels:  topology.portworx.io/node=422dcdcd-8b61-0a89-117d-867c72edefbe,kubernetes.io/hostname=rkinhalkar-59-2,topology.portworx.io/datacenter=CNBU,medium=STORAGE_MEDIUM_SSD,kubernetes.io/arch=amd64,kubernetes.io/os=linux,topology.portworx.io/hypervisor=HostSystem-host-35113,beta.kubernetes.io/os=linux,iopriority=HIGH,beta.kubernetes.io/arch=amd64
	Size: 186 GiB
	Status: In Maintenance
	Error Description: Pool or Node is in Maintenance mode
	Has metadata:  No
	Drives:
	0: /dev/sdf, Total size 200 GiB, Online
	1: /dev/sdh, Total size 200 GiB, Online
	LastOperation  OPERATION_RESIZE
		Status:  OPERATION_IN_PROGRESS
		Message: drive add is in progress: Rebalance in progress: 2.0%

	Cache Drives:
	No Cache drives found in this pool
Metadata Device:
	1: /dev/sdg, STORAGE_MEDIUM_SSD


pxctl sv pool expand -u d948cae8-7077-4848-8530-5679e834ba07 -s 500 -o resize-disk
Request to expand pool: d948cae8-7077-4848-8530-5679e834ba07 to size: 500 using operation: resize-disk
service pool expand: resize for pool d948cae8-7077-4848-8530-5679e834ba07 is already in progress. drive add is in progress: Rebalance in progress: 4.5%
 newSize=400,resizeType=RESIZE_TYPE_ADD_DISK,skipWaitForCleanVolumes=false
```

After

```
# pxctl sv pool show
PX drive configuration:
Pool ID: 0
	Type:  PX-StoreV2
	UUID:  64ca0812-4a4a-4cca-896e-3623dd56f6c9
	IO Priority:  HIGH
	Labels:  topology.portworx.io/datacenter=CNBU,beta.kubernetes.io/arch=amd64,kubernetes.io/hostname=rkinhalkar-59-2,topology.portworx.io/node=422dcdcd-8b61-0a89-117d-867c72edefbe,medium=STORAGE_MEDIUM_SSD,iopriority=HIGH,kubernetes.io/os=linux,topology.portworx.io/hypervisor=HostSystem-host-35113,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64
	Size: 186 GiB
	Status: In Maintenance
	Error Description: Pool or Node is in Maintenance mode
	Has metadata:  No
	Drives:
	1: /dev/sdk, Total size 200 GiB, Online
	0: /dev/sdi, Total size 200 GiB, Online
	LastOperation  OPERATION_RESIZE
		Status:  OPERATION_IN_PROGRESS
		Message: drive add is in progress: Rebalance in progress: 15.4%

	Cache Drives:
	No Cache drives found in this pool
Metadata Device:
	1: /dev/sdj, STORAGE_MEDIUM_SSD

# pxctl sv pool expand -u 64ca0812-4a4a-4cca-896e-3623dd56f6c9 -s 500 -o resize-disk
Request to expand pool: 64ca0812-4a4a-4cca-896e-3623dd56f6c9 to size: 500 using operation: resize-disk
service pool expand: resize for pool 64ca0812-4a4a-4cca-896e-3623dd56f6c9 is already in progress. drive add is in progress: Rebalance in progress: 15.4%
```