### PR TITLE
PWX-35277: copy auth token to the outgoing gRPC metadata

### DIFF
--- a/api/server/sdk/volume_migrate.go
+++ b/api/server/sdk/volume_migrate.go
@@ -27,6 +27,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+const (
+	authorizationKey = "authorization"
+)
+
 // Start a volume migration
 func (s *VolumeServer) Start(
 	ctx context.Context,
@@ -43,6 +47,11 @@ func (s *VolumeServer) Start(
 		// Forward the request to some other node and set the context metadata so that
 		// the request is terminated at the receiving node.
 		rctx := metadata.AppendToOutgoingContext(ctx, ContextRoundRobinTerminateKey, "true")
+		// append auth
+		auth := md.Get(authorizationKey)
+		if len(auth) > 0 {
+			rctx = metadata.AppendToOutgoingContext(rctx, authorizationKey, auth[0])
+		}
 		remoteConn, remote, err := s.balancer().GetRemoteNodeConnection(rctx)
 		if err == nil && remote {
 			return api.NewOpenStorageMigrateClient(remoteConn).Start(rctx, req)


### PR DESCRIPTION
**What this PR does / why we need it**:  
Need to explicitly copy the auth token to the outgoing gRPC metadata when forwarding the request to another node.

**Which issue(s) this PR fixes** (optional)  
PWX-35277

**Testing Notes**  
Thanks @diptiranjanpx for validating the fix on his cluster that was exhibiting the problem.

**Special notes for your reviewer**:  

