### PR TITLE
fix: throw error if volume is down state and with pending status, it might not recover

### DIFF
--- a/api/server/sdk/volume_ops.go
+++ b/api/server/sdk/volume_ops.go
@@ -65,7 +65,7 @@ func (s *VolumeServer) waitForVolumeReady(ctx context.Context, id string) (*api.
 
 			// The volume has entered a state of that might not recover from hence the status might be down and will be in pending state forever.
 			if v.GetStatus() == api.VolumeStatus_VOLUME_STATUS_DOWN && v.GetState() != api.VolumeState_VOLUME_STATE_PENDING {
-				return false, status.Errorf(codes.Internal, "Volume id %s got created but is in down state, please recreate the PVC", v.GetId())
+				return false, status.Errorf(codes.Internal, "Volume id %s got created but due to Internal issues is in Down State. The Volume creation needs to be retried.", v.GetId())
 			}
 
 			// Continue waiting

--- a/api/server/sdk/volume_ops.go
+++ b/api/server/sdk/volume_ops.go
@@ -63,6 +63,11 @@ func (s *VolumeServer) waitForVolumeReady(ctx context.Context, id string) (*api.
 				return false, nil
 			}
 
+			// The volume has entered a state of that might not recover from hence the status might be down and will be in pending state forever.
+			if v.GetStatus() == api.VolumeStatus_VOLUME_STATUS_DOWN && v.GetState() != api.VolumeState_VOLUME_STATE_PENDING {
+				return false, status.Errorf(codes.Internal, "Volume id %s got created but is in down state, please recreate the PVC", v.GetId())
+			}
+
 			// Continue waiting
 			return true, nil
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:  
In case the underlying storage driver fails to create the volume and puts it in down state and keep it pending forever due to kvdb miss, it could also be that it is unable to rollback too since the kvdb is down.
the check added helps us break out of that loop.

**Which issue(s) this PR fixes** (optional)  
[PWX-35130](https://portworx.atlassian.net/browse/PWX-35130)

**Testing Notes**  
While creating a volume if the kvdb is unavailable and the volume enters a down state
CSI should throw an error


[PWX-35130]: https://portworx.atlassian.net/browse/PWX-35130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ