### PR TITLE
PWX-35451-pt2: NFS-proxy volumes fix

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1324,6 +1324,11 @@ func (v *VolumeSpec) IsPureBlockVolume() bool {
 	return v.GetProxySpec() != nil && v.GetProxySpec().IsPureBlockBackend()
 }
 
+// IsNFSProxyVolume returns true if this is a nfs reflection volume
+func (v *VolumeSpec) IsNFSProxyVolume() bool {
+	return v.GetProxySpec() != nil && v.GetProxySpec().NfsSpec != nil
+}
+
 // GetCloneCreatorOwnership returns the appropriate ownership for the
 // new snapshot and if an update is required
 func (v *VolumeSpec) GetCloneCreatorOwnership(ctx context.Context) (*Ownership, bool) {


### PR DESCRIPTION
* adding `VolumeSpec.IsNFSProxyVolume()`

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:  

Adding a convenient method to query if a volume is a NFS-proxy volume.

**Which issue(s) this PR fixes** (optional)  

PWX-35451 - part2


**Testing Notes**  

Tested together w/ https://github.com/portworx/porx/pull/12814 PR


**Special notes for your reviewer**:  
-
