### PR TITLE
Revert "Cherry/rebuild cache volume wait err"

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -30,8 +30,6 @@ func NewClient(host, version, userAgent string) (*Client, error) {
 		return nil, fmt.Errorf("Unable to parse provided url: %v", host)
 	}
 	c := &Client{
-		host:        host,
-		tlsConfig:   nil,
 		base:        baseURL,
 		version:     version,
 		httpClient:  hClient,
@@ -39,8 +37,6 @@ func NewClient(host, version, userAgent string) (*Client, error) {
 		accesstoken: "",
 		userAgent:   fmt.Sprintf("%v/%v", userAgent, version),
 	}
-	c.transport = hClient.Transport
-	hClient.Transport = c
 	return c, nil
 }
 
@@ -59,8 +55,6 @@ func NewAuthClient(host, version, authstring, accesstoken, userAgent string) (*C
 		return nil, fmt.Errorf("Unable to parse provided url: %v", host)
 	}
 	c := &Client{
-		host:        host,
-		tlsConfig:   nil,
 		base:        baseURL,
 		version:     version,
 		httpClient:  hClient,
@@ -68,8 +62,6 @@ func NewAuthClient(host, version, authstring, accesstoken, userAgent string) (*C
 		accesstoken: accesstoken,
 		userAgent:   fmt.Sprintf("%v/%v", userAgent, version),
 	}
-	c.transport = hClient.Transport
-	hClient.Transport = c
 	return c, nil
 }
 
@@ -87,9 +79,6 @@ func GetUnixServerPath(socketName string, paths ...string) string {
 // Client is an HTTP REST wrapper. Use one of Get/Post/Put/Delete to get a request
 // object.
 type Client struct {
-	host        string
-	tlsConfig   *tls.Config
-	transport   http.RoundTripper
 	base        *url.URL
 	version     string
 	httpClient  *http.Client
@@ -103,16 +92,9 @@ func (c *Client) BaseURL() string {
 }
 
 func (c *Client) SetTLS(tlsConfig *tls.Config) {
-	transport := &http.Transport{TLSClientConfig: c.tlsConfig}
-
-	// re-assign transport layer defaults
-	c.tlsConfig = tlsConfig
-	c.transport = transport
-
 	c.httpClient = &http.Client{
-		Transport: c,
+		Transport: &http.Transport{TLSClientConfig: tlsConfig},
 	}
-
 }
 
 // Versions send a request at the /versions REST endpoint.
@@ -129,8 +111,7 @@ func (c *Client) Get() *Request {
 
 // Post returns a Request object setup for POST call.
 func (c *Client) Post() *Request {
-	r := NewRequest(c.httpClient, c.base, http.MethodPost, c.version, c.authstring, c.userAgent)
-	return r
+	return NewRequest(c.httpClient, c.base, http.MethodPost, c.version, c.authstring, c.userAgent)
 }
 
 // Put returns a Request object setup for PUT call.
@@ -155,41 +136,6 @@ func unix2HTTP(u *url.URL) {
 		u.Host = "unix.sock"
 		u.Path = ""
 	}
-}
-
-// shouldRoundTripRetry
-func (c *Client) shouldRoundTripRetry(res *http.Response, err error) bool {
-	if http.ErrHandlerTimeout == err || res == nil {
-		return true
-	}
-	return res.StatusCode == http.StatusRequestTimeout ||
-		res.StatusCode == http.StatusGatewayTimeout
-}
-
-// RoundTrip
-// When creating the http client we cache the client against the host without any expiration
-// when picking the client from cache for any further request
-// The cached client resolves the IP that was assigned to the node prior to DHCP update
-// A custom round tripper in the transport layer which can invalidate the cache and
-// build a new http client in case of a timeout.
-// Rebuilding the cache on timeout and retrying will resolve the new IP for that host.
-func (c *Client) RoundTrip(req *http.Request) (res *http.Response, err error) {
-	res, err = c.transport.RoundTrip(req)
-
-	if c.shouldRoundTripRetry(res, err) {
-		retireHTTPClient(c.host)
-		c.httpClient = getHTTPClient(c.host)
-		if c.tlsConfig != nil {
-			c.SetTLS(c.tlsConfig)
-		} else {
-			c.transport = c.httpClient.Transport
-			c.httpClient.Transport = c
-		}
-
-		res, err = c.transport.RoundTrip(req)
-	}
-
-	return
 }
 
 func newHTTPClient(
@@ -218,14 +164,6 @@ func newHTTPClient(
 	}
 
 	return &http.Client{Transport: httpTransport, Timeout: responseTimeout}
-}
-
-func retireHTTPClient(host string) {
-	cacheLock.Lock()
-	defer cacheLock.Unlock()
-	if _, ok := httpCache[host]; ok {
-		delete(httpCache, host)
-	}
 }
 
 func getHTTPClient(host string) *http.Client {

--- a/api/server/sdk/volume_ops.go
+++ b/api/server/sdk/volume_ops.go
@@ -63,11 +63,6 @@ func (s *VolumeServer) waitForVolumeReady(ctx context.Context, id string) (*api.
 				return false, nil
 			}
 
-			// The volume has entered a state of that might not recover from hence the status might be down and will be in pending state forever.
-			if v.GetStatus() == api.VolumeStatus_VOLUME_STATUS_DOWN && v.GetState() != api.VolumeState_VOLUME_STATE_PENDING {
-				return false, status.Errorf(codes.Internal, "Volume id %s got created but due to Internal issues is in Down State. The Volume creation needs to be retried.", v.GetId())
-			}
-
 			// Continue waiting
 			return true, nil
 		})


### PR DESCRIPTION
Reverts libopenstorage/openstorage#2386

The roundtripper does needs to have a back off, it can go into recursion and exhaust stack limit very quickly before the transport can restablish itself.