### PR TITLE
PWX-35601 Add length check before accessing in round robin

### DIFF
--- a/pkg/loadbalancer/roundrobin.go
+++ b/pkg/loadbalancer/roundrobin.go
@@ -142,9 +142,10 @@ func (rr *roundRobin) getTargetAndIncrement(filteredNodes []*api.Node, selfNodeI
 		targetNodeNumber int
 		isRemoteConn     bool
 	)
-	if rr.nextCreateNodeNumber != 0 {
-		targetNodeNumber = rr.nextCreateNodeNumber
+	if len(filteredNodes) == 0 {
+		return "", false
 	}
+	targetNodeNumber = rr.nextCreateNodeNumber % len(filteredNodes)
 	targetNode := filteredNodes[targetNodeNumber]
 	if targetNode.Id != selfNodeID {
 		// NodeID set on the cluster object is this node's ID.

--- a/pkg/loadbalancer/roundrobin.go
+++ b/pkg/loadbalancer/roundrobin.go
@@ -98,6 +98,9 @@ func (rr *roundRobin) GetRemoteNode() (string, bool, error) {
 	// Get target node info and set next round robbin node.
 	// nextNode is always lastNode + 1 mod (numOfNodes), to loop back to zero
 	targetNodeEndpoint, isRemoteConn := rr.getTargetAndIncrement(filteredNodes, selfNode.Id)
+	if targetNodeEndpoint == "" {
+		return "", false, errors.New("target node not found")
+	}
 
 	return targetNodeEndpoint, isRemoteConn, nil
 }

--- a/pkg/loadbalancer/roundrobin_test.go
+++ b/pkg/loadbalancer/roundrobin_test.go
@@ -94,12 +94,10 @@ func TestGetRemoteNodeWithDomains(t *testing.T) {
 	}
 }
 
-// TestGetTargetAndIncrementNullPointer tests the case when getTargetAndIncrement
-// causes null pointer. This happens when the round robin index is not checked against node array
-// length before accessing it.
-//
-// https://portworx.atlassian.net/browse/PWX-35601
-func TestGetTargetAndIncrementNullPointer(t *testing.T) {
+// TestGetTargetAndIncrementIndexOutOfBound tests the case when getTargetAndIncrement
+// causes index out of bound error. This happens when the round robin index is not
+// checked against node array length before accessing it.
+func TestGetTargetAndIncrementIndexOutOfBound(t *testing.T) {
 	filteredNodes := []*api.Node{
 		{
 			Id:     "1",

--- a/pkg/loadbalancer/roundrobin_test.go
+++ b/pkg/loadbalancer/roundrobin_test.go
@@ -93,3 +93,31 @@ func TestGetRemoteNodeWithDomains(t *testing.T) {
 		}
 	}
 }
+
+// TestGetTargetAndIncrementNullPointer tests the case when getTargetAndIncrement
+// causes null pointer. This happens when the round robin index is not checked against node array
+// length before accessing it.
+//
+// https://portworx.atlassian.net/browse/PWX-35601
+func TestGetTargetAndIncrementNullPointer(t *testing.T) {
+	filteredNodes := []*api.Node{
+		{
+			Id:     "1",
+			MgmtIp: "1",
+		},
+		{
+			Id:     "2",
+			MgmtIp: "2",
+		},
+	}
+	rr := &roundRobin{nextCreateNodeNumber: len(filteredNodes)}
+	endpoint, isRemote := rr.getTargetAndIncrement(filteredNodes, "")
+	require.True(t, isRemote, "isRemote is not as expected")
+	require.Equal(t, "1", endpoint, "target endpoint is not as expected")
+
+	filteredNodes = []*api.Node{}
+	rr.nextCreateNodeNumber = 0
+	endpoint, isRemote = rr.getTargetAndIncrement(filteredNodes, "")
+	require.False(t, isRemote, "isRemote is not as expected")
+	require.Equal(t, "", endpoint, "target endpoint is not as expected")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:  
This PR adds a few check before accessing the filteredNodes:
1. If the length is zero, we return empty string and false (isRemote)
2. Before accessing the array, we take a reminder of the currentIndex with the length of the array.

**Which issue(s) this PR fixes** (optional)  
PWX-35601

**Testing Notes**  
Added simple UT to check the function
