### PR TITLE
Using short hostname instead of FQDN hostnames to avoid custom DNS.

### DIFF
--- a/volume/drivers/pwx/connection.go
+++ b/volume/drivers/pwx/connection.go
@@ -125,7 +125,7 @@ func (cpb *ConnectionParamsBuilder) BuildClientsEndpoints() (string, string, err
 		return "", "", fmt.Errorf("failed to get k8s service specification: %v", err)
 	}
 
-	endpoint = fmt.Sprintf("%s.%s.svc.cluster.local", svc.Name, svc.Namespace)
+	endpoint = fmt.Sprintf("%s.%s.svc", svc.Name, svc.Namespace)
 
 	var restPort int
 	var restPortSecured int


### PR DESCRIPTION
Signed-Off-By: Diptiranjan
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:  
Some clusters may be configured with different DNS. 
It is better to give short hostnames than adding `cluster.local` as default for px service endpoint.

**Which issue(s) this PR fixes** (optional)  
Closes #
or
PWX-35059

**Testing Notes** 
Creating clusterpair with the above changes vendored in stork. 
➜  stork git: ✗ storkctl get clusterpair -n kube-system
NAME   STORAGE-STATUS   SCHEDULER-STATUS   CREATED
cp3    Ready            Ready              23 Jan 24 08:55 UTC

**Special notes for your reviewer**:  
Add any notes for the reviewer here.
