### PR TITLE
PWX-32899_pt4: K8s DNS fix

### DIFF
--- a/volume/drivers/pwx/connection.go
+++ b/volume/drivers/pwx/connection.go
@@ -125,7 +125,7 @@ func (cpb *ConnectionParamsBuilder) BuildClientsEndpoints() (string, string, err
 		return "", "", fmt.Errorf("failed to get k8s service specification: %v", err)
 	}
 
-	endpoint = fmt.Sprintf("%s.%s.svc.cluster.local", svc.Name, svc.Namespace)
+	endpoint = fmt.Sprintf("%s.%s", svc.Name, svc.Namespace)
 
 	var restPort int
 	var restPortSecured int

--- a/volume/drivers/pwx/connection_test.go
+++ b/volume/drivers/pwx/connection_test.go
@@ -206,8 +206,8 @@ func TestPortworx_buildClientsEndpoints_OK_WithDefaultNsAndService_TLS(t *testin
 	pxMgmtEndpoint, sdkEndpoint, err := paramsBuilder.BuildClientsEndpoints()
 	require.NoError(t, err, "should build endpoints when service and ns is not defined in env variables: %+v", err)
 
-	require.Equal(t, "https://portworx-service.kube-system.svc.cluster.local:9902", pxMgmtEndpoint)
-	require.Equal(t, "portworx-service.kube-system.svc.cluster.local:9999", sdkEndpoint)
+	require.Equal(t, "https://portworx-service.kube-system:9902", pxMgmtEndpoint)
+	require.Equal(t, "portworx-service.kube-system:9999", sdkEndpoint)
 }
 
 func TestPortworx_buildClientsEndpoints_OK_WithDefaultNsAndService_NO_TLS(t *testing.T) {
@@ -217,8 +217,8 @@ func TestPortworx_buildClientsEndpoints_OK_WithDefaultNsAndService_NO_TLS(t *tes
 	pxMgmtEndpoint, sdkEndpoint, err := paramsBuilder.BuildClientsEndpoints()
 	require.NoError(t, err)
 
-	require.Equal(t, "http://portworx-service.kube-system.svc.cluster.local:9901", pxMgmtEndpoint)
-	require.Equal(t, "portworx-service.kube-system.svc.cluster.local:9999", sdkEndpoint)
+	require.Equal(t, "http://portworx-service.kube-system:9901", pxMgmtEndpoint)
+	require.Equal(t, "portworx-service.kube-system:9999", sdkEndpoint)
 }
 
 func TestPortworx_buildClientsEndpoints_OK_WithNonDefaultNsAndService_NO_TLS(t *testing.T) {
@@ -233,8 +233,8 @@ func TestPortworx_buildClientsEndpoints_OK_WithNonDefaultNsAndService_NO_TLS(t *
 	pxMgmtEndpoint, sdkEndpoint, err := paramsBuilder.BuildClientsEndpoints()
 	require.NoError(t, err, "should build endpoints when service and ns is not defined in env variables: %+v", err)
 
-	require.Equal(t, "http://portworx-service.non-default-ns.svc.cluster.local:9901", pxMgmtEndpoint)
-	require.Equal(t, "portworx-service.non-default-ns.svc.cluster.local:9999", sdkEndpoint)
+	require.Equal(t, "http://portworx-service.non-default-ns:9901", pxMgmtEndpoint)
+	require.Equal(t, "portworx-service.non-default-ns:9999", sdkEndpoint)
 }
 
 func TestPortworx_buildClientsEndpoints_OK_WithNonDefaultNsAndService_TLS(t *testing.T) {
@@ -249,8 +249,8 @@ func TestPortworx_buildClientsEndpoints_OK_WithNonDefaultNsAndService_TLS(t *tes
 	pxMgmtEndpoint, sdkEndpoint, err := paramsBuilder.BuildClientsEndpoints()
 	require.NoError(t, err, "should build endpoints when service and ns is not defined in env varaibles: %+v", err)
 
-	require.Equal(t, "https://portworx-service.non-default-ns.svc.cluster.local:9902", pxMgmtEndpoint)
-	require.Equal(t, "portworx-service.non-default-ns.svc.cluster.local:9999", sdkEndpoint)
+	require.Equal(t, "https://portworx-service.non-default-ns:9902", pxMgmtEndpoint)
+	require.Equal(t, "portworx-service.non-default-ns:9999", sdkEndpoint)
 }
 
 func TestPortworx_buildClientsEndpoints_OK_WithStaticEndpointAndPorts_NO_TLS(t *testing.T) {
@@ -361,8 +361,8 @@ func TestPortworx_buildClientsEndpoints_OK_WithDefaultNsAndServiceWithEmptyStati
 	pxMgmtEndpoint, sdkEndpoint, err := paramsBuilder.BuildClientsEndpoints()
 	require.NoError(t, err, "should build endpoints when service and ns is not defined in env variables: %+v", err)
 
-	require.Equal(t, "http://portworx-service.kube-system.svc.cluster.local:9901", pxMgmtEndpoint)
-	require.Equal(t, "portworx-service.kube-system.svc.cluster.local:9999", sdkEndpoint)
+	require.Equal(t, "http://portworx-service.kube-system:9901", pxMgmtEndpoint)
+	require.Equal(t, "portworx-service.kube-system:9999", sdkEndpoint)
 }
 
 func TestPortworx_buildClientsEndpoints_OK_WithDefaultNsAndServiceWithEmptyStaticRestPort_TLS(t *testing.T) {
@@ -376,8 +376,8 @@ func TestPortworx_buildClientsEndpoints_OK_WithDefaultNsAndServiceWithEmptyStati
 	pxMgmtEndpoint, sdkEndpoint, err := paramsBuilder.BuildClientsEndpoints()
 	require.NoError(t, err, "should build endpoints when service and ns is not defined in env varaibles: %+v", err)
 
-	require.Equal(t, "https://portworx-service.kube-system.svc.cluster.local:9902", pxMgmtEndpoint)
-	require.Equal(t, "portworx-service.kube-system.svc.cluster.local:9999", sdkEndpoint)
+	require.Equal(t, "https://portworx-service.kube-system:9902", pxMgmtEndpoint)
+	require.Equal(t, "portworx-service.kube-system:9999", sdkEndpoint)
 }
 
 func TestPortworx_dialOptions_Error_WhenSecretDoesNotExist(t *testing.T) {


### PR DESCRIPTION

**What this PR does / why we need it**:  

Autopilot and Stork (which vendor in this library) should not assume that Kubernetes DNS is configured with default `.svc.cluster.local` domain

FIX:
* as a fix, we are modifying the hostnames to `<service>.<endpoint>` (and no `.svc.cluster.local` domain)
* instead, we will rely on the `/etc/resolv.conf` to provide the correct search `<dns-domain>` entry, so DNS resolution will still work correctly

**Which issue(s) this PR fixes** (optional)  
PWX-32899  (part 4)

See also:
* part 1: https://github.com/libopenstorage/operator/pull/1437
* part 2: https://github.com/libopenstorage/stork/pull/1629
* part 3: https://github.com/pure-px/autopilot/pull/250

**Testing Notes**  

Please check stork and autopilot PRs for manual tests results

**Special notes for your reviewer**:  

TODO: This PR change will need to be vendored into `stork` and `autopilot` projects