### PR TITLE
add check for shared volumes in getVolumeStats

### DIFF
--- a/csi/node.go
+++ b/csi/node.go
@@ -365,7 +365,8 @@ func (s *OsdCsiServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetV
 
 	var attachPathMatch bool
 	for _, attachPath := range vol.AttachPath {
-		if attachPath == path {
+		sharedPath := fmt.Sprintf("%s/%s", api.SharedVolExportPrefix, id)
+		if attachPath == path || attachPath == sharedPath {
 			attachPathMatch = true
 		}
 	}

--- a/csi/node.go
+++ b/csi/node.go
@@ -364,8 +364,8 @@ func (s *OsdCsiServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetV
 	}
 
 	var attachPathMatch bool
+	sharedPath := fmt.Sprintf("%s/%s", api.SharedVolExportPrefix, id)
 	for _, attachPath := range vol.AttachPath {
-		sharedPath := fmt.Sprintf("%s/%s", api.SharedVolExportPrefix, id)
 		if attachPath == path || attachPath == sharedPath {
 			attachPathMatch = true
 		}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:  
Adds check for shared v4 volumes that have a different attach path than the assumed CSI volume path. 

**Which issue(s) this PR fixes** (optional)  
PWX-35351

**Testing Notes**  
With the fix, we are able to see Used Space on OCP:
<img width="2504" alt="image" src="https://github.com/libopenstorage/openstorage/assets/90274225/3c4d70a0-d85c-4f6c-b97b-925e4ea59742">
