### PR TITLE
add check for shared volumes in getVolumeStats (#2419)

### DIFF
--- a/csi/node.go
+++ b/csi/node.go
@@ -364,8 +364,9 @@ func (s *OsdCsiServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetV
 	}
 
 	var attachPathMatch bool
+	sharedPath := fmt.Sprintf("%s/%s", api.SharedVolExportPrefix, id)
 	for _, attachPath := range vol.AttachPath {
-		if attachPath == path {
+		if attachPath == path || attachPath == sharedPath {
 			attachPathMatch = true
 		}
 	}


### PR DESCRIPTION
* add check for shared volumes in getVolumeStats

Adds check for shared v4 volumes that have a different attach path than the assumed CSI volume path.

JIRA: PWX-35351

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:  
Explain the PR and why it is needed.

**Which issue(s) this PR fixes** (optional)  
Closes #
or
PWX-

**Testing Notes**  
Add testing output or passing unit test output here.

**Special notes for your reviewer**:  
Add any notes for the reviewer here.
