### PR TITLE
[PWX-36750] Removed IP format validation for Pure NFS endpoint for FBDA

### DIFF
--- a/api/spec/spec_handler.go
+++ b/api/spec/spec_handler.go
@@ -2,7 +2,6 @@ package spec
 
 import (
 	"fmt"
-	"net"
 	"regexp"
 	"strconv"
 	"strings"
@@ -607,9 +606,6 @@ func (d *specHandler) UpdateSpecFromOpts(opts map[string]string, spec *api.Volum
 			}
 			if spec.ProxySpec.PureFileSpec == nil {
 				spec.ProxySpec.PureFileSpec = &api.PureFileSpec{}
-			}
-			if net.ParseIP(v) == nil {
-				return nil, nil, nil, fmt.Errorf("invalid Pure NFS endpoint: %v", v)
 			}
 			spec.ProxySpec.PureFileSpec.NfsEndpoint = v
 		case api.SpecIoThrottleRdIOPS:

--- a/api/spec/spec_handler_test.go
+++ b/api/spec/spec_handler_test.go
@@ -526,18 +526,22 @@ func TestPureNFSEndpoint(t *testing.T) {
 	require.Equal(t, proxySpec.GetPureFileSpec().GetNfsEndpoint(), nfsEndpoint)
 
 	nfsEndpoint = ""
-	_, _, _, err = s.SpecFromOpts(map[string]string{
+	spec, _, _, err = s.SpecFromOpts(map[string]string{
 		api.SpecPureNFSEnpoint: nfsEndpoint,
 	})
-	require.Error(t, err, "Failed to parse nfs endpoint parameter")
-	require.Contains(t, err.Error(), "invalid Pure NFS endpoint")
+	require.NoError(t, err)
+	proxySpec = spec.GetProxySpec()
+	require.NotNil(t, proxySpec)
+	require.Equal(t, proxySpec.GetPureFileSpec().GetNfsEndpoint(), nfsEndpoint)
 
 	nfsEndpoint = "abc"
-	_, _, _, err = s.SpecFromOpts(map[string]string{
+	spec, _, _, err = s.SpecFromOpts(map[string]string{
 		api.SpecPureNFSEnpoint: nfsEndpoint,
 	})
-	require.Error(t, err, "Failed to parse nfs endpoint parameter")
-	require.Contains(t, err.Error(), "invalid Pure NFS endpoint")
+	require.NoError(t, err)
+	proxySpec = spec.GetProxySpec()
+	require.NotNil(t, proxySpec)
+	require.Equal(t, proxySpec.GetPureFileSpec().GetNfsEndpoint(), nfsEndpoint)
 }
 
 func TestXattr(t *testing.T) {


### PR DESCRIPTION
Pure NFS Endpoint for FBDA volumes can be either an IP or FQDN. Hence, removing IP format validation as part of this PR.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:  
Explain the PR and why it is needed.

**Which issue(s) this PR fixes** (optional)  
PWX-36750

**Testing Notes**  
Add testing output or passing unit test output here.

**Special notes for your reviewer**:  
Add any notes for the reviewer here.
