### PR TITLE
PWX-37650: Supports adding the pod name as a locator label for clone/snap restore

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1332,6 +1332,14 @@ func (v *VolumeSpec) IsNFSProxyVolume() bool {
 	return v.GetProxySpec() != nil && v.GetProxySpec().NfsSpec != nil
 }
 
+// GetFADAPodName returns the FlashArray Pod name specified in the Pure Block spec, or empty if any fields are unspecified
+func (v *VolumeSpec) GetFADAPodName() string {
+	if v.GetProxySpec() != nil && v.GetProxySpec().PureBlockSpec != nil {
+		return v.GetProxySpec().PureBlockSpec.PodName
+	}
+	return ""
+}
+
 // GetCloneCreatorOwnership returns the appropriate ownership for the
 // new snapshot and if an update is required
 func (v *VolumeSpec) GetCloneCreatorOwnership(ctx context.Context) (*Ownership, bool) {

--- a/api/server/sdk/volume_ops.go
+++ b/api/server/sdk/volume_ops.go
@@ -36,6 +36,9 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+// FADAPodLabelKey is a label added to volume locators in the case of FADA volume clone/snap restore
+const FADAPodLabelKey = "pure-pod-name" // Used to plumb in the pod name for volume cloning
+
 // When create is called for an existing volume, this function is called to make sure
 // the SDK only returns that the volume is ready when the status is UP
 func (s *VolumeServer) waitForVolumeReady(ctx context.Context, id string) (*api.Volume, error) {
@@ -106,7 +109,6 @@ func (s *VolumeServer) create(
 	spec *api.VolumeSpec,
 	additionalCloneLabels map[string]string,
 ) (string, error) {
-
 	// Check if the volume has already been created or is in process of creation
 	volName := locator.GetName()
 	v, err := util.VolumeFromName(ctx, s.driver(ctx), volName)
@@ -171,8 +173,18 @@ func (s *VolumeServer) create(
 		}
 
 		// Create a snapshot from the parent
+		// Only include the FADA pod label
+		var labels map[string]string = nil
+		if locator.GetVolumeLabels() != nil {
+			if pod, ok := locator.GetVolumeLabels()[FADAPodLabelKey]; ok {
+				labels = map[string]string{
+					FADAPodLabelKey: pod,
+				}
+			}
+		}
 		id, err = s.driver(ctx).Snapshot(ctx, parent.GetId(), false, &api.VolumeLocator{
-			Name: volName,
+			Name:         volName,
+			VolumeLabels: labels,
 		}, false)
 		if err != nil {
 			if err == kvdb.ErrNotFound {
@@ -335,7 +347,8 @@ func (s *VolumeServer) Clone(
 	}
 
 	locator := &api.VolumeLocator{
-		Name: req.GetName(),
+		Name:         req.GetName(),
+		VolumeLabels: req.GetAdditionalLabels(),
 	}
 	source := &api.Source{
 		Parent: req.GetParentId(),

--- a/api/spec/spec_handler.go
+++ b/api/spec/spec_handler.go
@@ -640,6 +640,14 @@ func (d *specHandler) UpdateSpecFromOpts(opts map[string]string, spec *api.Volum
 		case api.SpecBackendVolName:
 			volName := v
 			pureBackendVolName = &volName
+		case api.SpecPurePodName:
+			if spec.ProxySpec == nil {
+				spec.ProxySpec = &api.ProxySpec{}
+			}
+			if spec.ProxySpec.PureBlockSpec == nil {
+				spec.ProxySpec.PureBlockSpec = &api.PureBlockSpec{}
+			}
+			spec.ProxySpec.PureBlockSpec.PodName = v
 		case api.SpecPureFileExportRules:
 			if spec.ProxySpec == nil {
 				spec.ProxySpec = &api.ProxySpec{}

--- a/csi/controller.go
+++ b/csi/controller.go
@@ -614,10 +614,14 @@ func (s *OsdCsiServer) CreateVolume(
 		}
 		newVolumeId = createResp.VolumeId
 	} else {
+		clonedMetadata := getClonedPVCMetadata(locator)
+		if spec.GetFADAPodName() != "" {
+			clonedMetadata[sdk.FADAPodLabelKey] = spec.GetFADAPodName()
+		}
 		cloneResp, err := volumes.Clone(ctx, &api.SdkVolumeCloneRequest{
 			Name:             req.GetName(),
 			ParentId:         source.Parent,
-			AdditionalLabels: getClonedPVCMetadata(locator),
+			AdditionalLabels: clonedMetadata,
 		})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:  
When we make a clone of a volume, or restore from a snapshot, we only get the name info of the volume. We do not get parameters like the pod name, which are required to determine where to place the volume. This adds the pod name as a label in the locator.

**Which issue(s) this PR fixes** (optional)  
PWX-37650

**Testing Notes**  
Confirmed volume clones are placed correctly inside of pods as expected.
