### PR TITLE
PWX-37650: Supports adding the pod name as a locator label for clone/snap restore

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1329,6 +1329,14 @@ func (v *VolumeSpec) IsNFSProxyVolume() bool {
 	return v.GetProxySpec() != nil && v.GetProxySpec().NfsSpec != nil
 }
 
+// GetFADAPodName returns the FlashArray Pod name specified in the Pure Block spec, or empty if any fields are unspecified
+func (v *VolumeSpec) GetFADAPodName() string {
+	if v.GetProxySpec() != nil && v.GetProxySpec().PureBlockSpec != nil {
+		return v.GetProxySpec().PureBlockSpec.PodName
+	}
+	return ""
+}
+
 // GetCloneCreatorOwnership returns the appropriate ownership for the
 // new snapshot and if an update is required
 func (v *VolumeSpec) GetCloneCreatorOwnership(ctx context.Context) (*Ownership, bool) {

--- a/csi/controller.go
+++ b/csi/controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/libopenstorage/openstorage/api"
+	"github.com/libopenstorage/openstorage/api/server/sdk"
 	"github.com/libopenstorage/openstorage/pkg/grpcutil"
 	"github.com/libopenstorage/openstorage/pkg/units"
 	"github.com/libopenstorage/openstorage/pkg/util"
@@ -586,10 +587,14 @@ func (s *OsdCsiServer) CreateVolume(
 		}
 		newVolumeId = createResp.VolumeId
 	} else {
+		clonedMetadata := getClonedPVCMetadata(locator)
+		if spec.GetFADAPodName() != "" {
+			clonedMetadata[sdk.FADAPodLabelKey] = spec.GetFADAPodName()
+		}
 		cloneResp, err := volumes.Clone(ctx, &api.SdkVolumeCloneRequest{
 			Name:             req.GetName(),
 			ParentId:         source.Parent,
-			AdditionalLabels: getClonedPVCMetadata(locator),
+			AdditionalLabels: clonedMetadata,
 		})
 		if err != nil {
 			return nil, err

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 
 	"github.com/libopenstorage/openstorage/api"
+	"github.com/libopenstorage/openstorage/api/server/sdk"
 	authsecrets "github.com/libopenstorage/openstorage/pkg/auth/secrets"
 	"github.com/libopenstorage/openstorage/pkg/units"
 
@@ -1930,6 +1931,122 @@ func TestControllerCreateVolumeFromSnapshot(t *testing.T) {
 		s.MockDriver().
 			EXPECT().
 			Snapshot(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(snapID, nil).
+			Times(1),
+		s.MockDriver().
+			EXPECT().
+			Enumerate(&api.VolumeLocator{
+				VolumeIds: []string{snapID},
+			}, nil).
+			Return([]*api.Volume{
+				{
+					Id:     id,
+					Source: &api.Source{Parent: mockParentID},
+				},
+			}, nil).
+			Times(2),
+
+		s.MockDriver().
+			EXPECT().
+			Set(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil).
+			Times(1),
+
+		s.MockDriver().
+			EXPECT().
+			Enumerate(gomock.Any(), nil).
+			Return([]*api.Volume{
+				{
+					Id:     id,
+					Source: &api.Source{Parent: mockParentID},
+				},
+			}, nil).
+			Times(1),
+	)
+
+	r, err := c.CreateVolume(context.Background(), req)
+	assert.Nil(t, err)
+	assert.NotNil(t, r)
+	volumeInfo := r.GetVolume()
+
+	assert.Equal(t, id, volumeInfo.GetVolumeId())
+	assert.NotEqual(t, "true", volumeInfo.GetVolumeContext()[api.SpecSharedv4])
+	assert.Equal(t, mockParentID, volumeInfo.GetVolumeContext()[api.SpecParent])
+}
+
+func TestControllerCreateVolumeFromSnapshotFADAPod(t *testing.T) {
+	// Create server and client connection
+	s := newTestServer(t)
+	defer s.Stop()
+	c := csi.NewControllerClient(s.Conn())
+	s.mockClusterEnumerateNode(t, "node-1")
+	// Setup request
+	mockParentID := "parendId"
+	name := "myvol"
+	pod := "mypod"
+	size := int64(1234)
+	req := &csi.CreateVolumeRequest{
+		Name: name,
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{},
+		},
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: size,
+		},
+		VolumeContentSource: &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Snapshot{
+				Snapshot: &csi.VolumeContentSource_SnapshotSource{
+					SnapshotId: mockParentID,
+				},
+			},
+		},
+		Secrets: map[string]string{authsecrets.SecretTokenKey: systemUserToken},
+		Parameters: map[string]string{
+			api.SpecPurePodName: pod,
+		},
+	}
+
+	// Setup mock functions
+	id := "myid"
+	snapID := id + "-snap"
+	gomock.InOrder(
+
+		// First check on parent
+		s.MockDriver().
+			EXPECT().
+			Enumerate(&api.VolumeLocator{
+				VolumeIds: []string{mockParentID},
+			}, nil).
+			Return([]*api.Volume{{Id: mockParentID}}, nil).
+			Times(1),
+
+		// VolFromName (name)
+		s.MockDriver().
+			EXPECT().
+			Inspect([]string{name}).
+			Return(nil, fmt.Errorf("not found")).
+			Times(1),
+
+		s.MockDriver().
+			EXPECT().
+			Enumerate(gomock.Any(), nil).
+			Return(nil, fmt.Errorf("not found")).
+			Times(1),
+
+		//VolFromName parent
+		s.MockDriver().
+			EXPECT().
+			Inspect(gomock.Any()).
+			Return(
+				[]*api.Volume{{
+					Id: mockParentID,
+				}}, nil).
+			Times(1),
+
+		// create
+		s.MockDriver().
+			EXPECT().
+			Snapshot(gomock.Any(), gomock.Any(), &api.VolumeLocator{Name: name, VolumeLabels: map[string]string{sdk.FADAPodLabelKey: pod}}, gomock.Any()).
 			Return(snapID, nil).
 			Times(1),
 		s.MockDriver().


### PR DESCRIPTION
**What this PR does / why we need it**:  
When we make a clone of a volume, or restore from a snapshot, we only get the name info of the volume. We do not get parameters like the pod name, which are required to determine where to place the volume. This adds the pod name as a label in the locator.

**Which issue(s) this PR fixes** (optional)  
PWX-37650

**Testing Notes**  
Confirmed volume clones are placed correctly inside of pods as expected.
