### PR TITLE
PWX-38618: Pods using FBDA volumes stuck in terminating state. Unmoun…

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -662,8 +662,6 @@ func (m *Mounter) Unmount(
 		if forceUnmount {
 			unmountErr := m.mountImpl.Unmount(path, flags, timeout)
 			if unmountErr == nil {
-				// If Unmount failed, assume it is due to ErrEnoent and return the failure as enoent,
-				// so that the underlying directory can be removed.
 				logrus.Infof("Unmount of path [%s] successful even though entry didn't exist in mount-table", path)
 				if options.IsBoolOptionSet(opts, options.OptionsDeleteAfterUnmount) {
 					m.RemoveMountPath(path, opts)
@@ -671,6 +669,8 @@ func (m *Mounter) Unmount(
 				// reset err
 				err = nil
 			} else {
+				// If Unmount failed, assume it is due to ErrEnoent and return the failure as enoent,
+				// so that the underlying directory can be removed.
 				logrus.Debugf("Unmount devPath[%s] from path[%s] failed with error [%v]", devPath, path, unmountErr)
 			}
 		}

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -647,7 +647,7 @@ func (m *Mounter) Unmount(
 		device = value
 	}
 	forceUnmount := false
-	if value, ok := opts[options.OptionsForceUnmount]; ok {
+	if _, ok := opts[options.OptionsForceUnmount]; ok {
 		forceUnmount = true
 	}
 	info, ok := m.mounts[device]
@@ -698,7 +698,7 @@ func (m *Mounter) Unmount(
 
 		return nil
 	}
-	err = ErrEnoent
+	err := ErrEnoent
 	if forceUnmount {
 		logrus.Warnf("Device %q is not mounted at path %q as per mount table, still attempt the Unmount", device, path)
 		unmountErr := m.mountImpl.Unmount(path, flags, timeout)

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -388,7 +388,7 @@ func (m *Mounter) load(prefixes []*regexp.Regexp, fmp findMountPoint) error {
 			targetDevice = getTargetDevice(devPrefix.String())
 			if !foundPrefix && targetDevice != "" {
 				// This should be an Exact Match and not a prefix match.
-				if strings.EqualFold(targetDevice, v.Source)  {
+				if strings.EqualFold(targetDevice, v.Source) {
 					// We could not find a mountpoint for devPrefix (/dev/mapper/vg-lvm1) but found
 					// one for its target device (/dev/dm-0). Change the sourcePath to devPrefix
 					// as fmp might have returned an incorrect or empty sourcePath
@@ -613,7 +613,7 @@ func (m *Mounter) cleanupBindMount(path, bindMountPath string, err error) error 
 	return nil
 }
 
-func (m * Mounter) printMountTable() {
+func (m *Mounter) printMountTable() {
 	logrus.Infof("Found %v mounts in mounter's cache: ", len(m.mounts))
 	logrus.Infof("Mounter has the following mountpoints: ")
 	for dev, info := range m.mounts {
@@ -648,11 +648,23 @@ func (m *Mounter) Unmount(
 	}
 	info, ok := m.mounts[device]
 	if !ok {
-		logrus.Warnf("Unable to unmount device %q path %q: %v",
-			devPath, path, ErrEnoent.Error())
+		logrus.Warnf("Unable to find device %q path %q: in mount table",
+			devPath, path)
 		m.printMountTable()
 		m.Unlock()
-		return ErrEnoent
+		err := m.mountImpl.Unmount(path, flags, timeout)
+		if err != nil {
+			logrus.Infof("Unmount devPath[%s] from path[%s] failed with error [%v]", devPath, path, err)
+			// If Unmount failed, assume it is due to ErrEnoent and return the failure as enoent,
+			// so that the underlying directory can be removted.
+			err = ErrEnoent
+			return err
+		}
+		logrus.Infof("Unmount of path [%s] successful even though entry didn't exist in mount-table", path)
+		if options.IsBoolOptionSet(opts, options.OptionsDeleteAfterUnmount) {
+			m.RemoveMountPath(path, opts)
+		}
+		return err
 	}
 	m.Unlock()
 	info.Lock()
@@ -675,8 +687,17 @@ func (m *Mounter) Unmount(
 
 		return nil
 	}
-	logrus.Warnf("Device %q is not mounted at path %q", device, path)
-	return ErrEnoent
+	logrus.Warnf("Device %q is not mounted at path %q as per mount table, still attempt the Unmount", device, path)
+	err := m.mountImpl.Unmount(path, flags, timeout)
+	if err != nil {
+		// Return Enoent if unmount failed.
+		return ErrEnoent
+	}
+	logrus.Infof("Unmount of path [%s] successful even though entry didn't exist in mount-table", path)
+	if options.IsBoolOptionSet(opts, options.OptionsDeleteAfterUnmount) {
+		m.RemoveMountPath(path, opts)
+	}
+	return err
 }
 
 func (m *Mounter) removeMountPath(path string) error {

--- a/pkg/mount/mount_test.go
+++ b/pkg/mount/mount_test.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/libopenstorage/openstorage/pkg/options"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
@@ -40,6 +41,7 @@ func TestRawMounter(t *testing.T) {
 func allTests(t *testing.T, source, dest string) {
 	load(t, source, dest)
 	mountTest(t, source, dest)
+	forceUnmountTest(t, source, dest)
 	mountTestParallel(t, source, dest)
 	inspect(t, source, dest)
 	reload(t, source, dest)
@@ -93,6 +95,14 @@ func mountTest(t *testing.T, source, dest string) {
 	err := m.Mount(0, source, dest, "", syscall.MS_BIND, "", 0, nil)
 	require.NoError(t, err, "Failed in mount")
 	err = m.Unmount(source, dest, 0, 0, nil)
+	require.NoError(t, err, "Failed in unmount")
+}
+
+func forceUnmountTest(t *testing.T, source, dest string) {
+	opts := make(map[string]string)
+	opts[options.OptionsForceUnmount] = "true"
+	syscall.Mount(source, dest, "", syscall.MS_BIND, "")
+	err := m.Unmount(source, dest, 0, 0, opts)
 	require.NoError(t, err, "Failed in unmount")
 }
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -63,6 +63,11 @@ const (
 	// - Attach
 	// It indicates which IO path to use to complete user IO
 	OptionsFastpath = "FASTPATH_STATE"
+	// OptionsForceUnmount is an option to the following Opentstorage Volume API
+	// - Unmount
+	// It is used to issue an umount system call to the requested path even
+	// if the entry for the path is not present in the mount table
+	OptionsForceUnmount = "FORCE_UNMOUNT"
 )
 
 // IsBoolOptionSet checks if a boolean option key is set


### PR DESCRIPTION
…t even if entry not found in mount table

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:  
If for any reason the mount table entry goes stale or like in the case of FBDA where we want to use IP address to mount but nfs internally mounted it using FQDN name there won't be an entry in the mount table corresponding to the mount point  in the mount table. In such cirucumstances when we get an Unmount() request for a path, trigger the Unmont()

**Which issue(s) this PR fixes** (optional)  
Closes #
or
PWX-38618

**Testing Notes**  
Manually Tested the following:
1. Create a pure-file pvc.
2. Mount the pvc directly from one of the nodes using fqdn / hostname.
3. Trigger a pod that uses the pvc. (Verified that the mount uses hostname and mount table entry contains host IP).
4. Delete the pod.
5. Verify that the termination of the pod happens successfully.

**Special notes for your reviewer**:  
Add any notes for the reviewer here.
