### PR TITLE
PWX-38585: Removes extra pod name label

### DIFF
--- a/api/server/docker.go
+++ b/api/server/docker.go
@@ -377,6 +377,7 @@ func (d *driver) create(w http.ResponseWriter, r *http.Request) {
 		_, err = volumes.Clone(ctx, &api.SdkVolumeCloneRequest{
 			Name:     name,
 			ParentId: source.Parent,
+			AdditionalLabels: locator.GetVolumeLabels(),
 		})
 	} else {
 		// create

--- a/api/server/sdk/volume_ops.go
+++ b/api/server/sdk/volume_ops.go
@@ -35,9 +35,6 @@ import (
 	"github.com/libopenstorage/openstorage/volume"
 )
 
-// FADAPodLabelKey is a label added to volume locators in the case of FADA volume clone/snap restore
-const FADAPodLabelKey = "pure-pod-name" // Used to plumb in the pod name for volume cloning
-
 // When create is called for an existing volume, this function is called to make sure
 // the SDK only returns that the volume is ready when the status is UP
 func (s *VolumeServer) waitForVolumeReady(ctx context.Context, id string) (*api.Volume, error) {
@@ -172,18 +169,9 @@ func (s *VolumeServer) create(
 		}
 
 		// Create a snapshot from the parent
-		// Only include the FADA pod label
-		var labels map[string]string = nil
-		if locator.GetVolumeLabels() != nil {
-			if pod, ok := locator.GetVolumeLabels()[FADAPodLabelKey]; ok {
-				labels = map[string]string{
-					FADAPodLabelKey: pod,
-				}
-			}
-		}
 		id, err = s.driver(ctx).Snapshot(parent.GetId(), false, &api.VolumeLocator{
 			Name:         volName,
-			VolumeLabels: labels,
+			VolumeLabels: locator.GetVolumeLabels(),
 		}, false)
 		if err != nil {
 			if err == kvdb.ErrNotFound {

--- a/csi/controller.go
+++ b/csi/controller.go
@@ -590,9 +590,6 @@ func (s *OsdCsiServer) CreateVolume(
 		if spec.GetFADAPodName() != "" {
 			labels[api.SpecPurePodName] = spec.GetFADAPodName()
 		}
-		delete(labels, intreePvcNameKey)
-		delete(labels, intreePvcNamespaceKey)
-		delete(labels, api.SpecParent)
 		cloneResp, err := volumes.Clone(ctx, &api.SdkVolumeCloneRequest{
 			Name:             req.GetName(),
 			ParentId:         source.Parent,

--- a/csi/controller.go
+++ b/csi/controller.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/libopenstorage/openstorage/api"
-	"github.com/libopenstorage/openstorage/api/server/sdk"
 	"github.com/libopenstorage/openstorage/pkg/grpcutil"
 	"github.com/libopenstorage/openstorage/pkg/units"
 	"github.com/libopenstorage/openstorage/pkg/util"
@@ -587,14 +586,17 @@ func (s *OsdCsiServer) CreateVolume(
 		}
 		newVolumeId = createResp.VolumeId
 	} else {
-		clonedMetadata := getClonedPVCMetadata(locator)
+		labels := locator.GetVolumeLabels()
 		if spec.GetFADAPodName() != "" {
-			clonedMetadata[sdk.FADAPodLabelKey] = spec.GetFADAPodName()
+			labels[api.SpecPurePodName] = spec.GetFADAPodName()
 		}
+		delete(labels, intreePvcNameKey)
+		delete(labels, intreePvcNamespaceKey)
+		delete(labels, api.SpecParent)
 		cloneResp, err := volumes.Clone(ctx, &api.SdkVolumeCloneRequest{
 			Name:             req.GetName(),
 			ParentId:         source.Parent,
-			AdditionalLabels: clonedMetadata,
+			AdditionalLabels: labels,
 		})
 		if err != nil {
 			return nil, err

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/golang/protobuf/ptypes/timestamp"
 
 	"github.com/libopenstorage/openstorage/api"
-	"github.com/libopenstorage/openstorage/api/server/sdk"
 	authsecrets "github.com/libopenstorage/openstorage/pkg/auth/secrets"
 	"github.com/libopenstorage/openstorage/pkg/units"
 
@@ -1325,7 +1324,7 @@ func TestControllerCreateVolumeBadSnapshot(t *testing.T) {
 		// Return an error from snapshot
 		s.MockDriver().
 			EXPECT().
-			Snapshot(parent, false, &api.VolumeLocator{Name: name}, false).
+			Snapshot(parent, false, &api.VolumeLocator{Name: name, VolumeLabels: nil}, false).
 			Return("", fmt.Errorf("snapshoterr")).
 			Times(1),
 	)
@@ -2046,7 +2045,7 @@ func TestControllerCreateVolumeFromSnapshotFADAPod(t *testing.T) {
 		// create
 		s.MockDriver().
 			EXPECT().
-			Snapshot(gomock.Any(), gomock.Any(), &api.VolumeLocator{Name: name, VolumeLabels: map[string]string{sdk.FADAPodLabelKey: pod}}, gomock.Any()).
+			Snapshot(gomock.Any(), gomock.Any(), &api.VolumeLocator{Name: name, VolumeLabels: map[string]string{api.SpecPurePodName: pod}}, gomock.Any()).
 			Return(snapID, nil).
 			Times(1),
 		s.MockDriver().
@@ -2232,6 +2231,238 @@ func TestControllerCreateVolumeSnapshotThroughParameters(t *testing.T) {
 
 	assert.Equal(t, id, volumeInfo.GetVolumeId())
 	assert.Equal(t, size, volumeInfo.GetCapacityBytes())
+	assert.NotEqual(t, "true", volumeInfo.GetVolumeContext()[api.SpecSharedv4])
+	assert.Equal(t, mockParentID, volumeInfo.GetVolumeContext()[api.SpecParent])
+}
+
+func TestControllerCreateVolumeFromSource(t *testing.T) {
+	// Create server and client connection
+	s := newTestServer(t)
+	defer s.Stop()
+	c := csi.NewControllerClient(s.Conn())
+	s.mockClusterEnumerateNode(t, "node-1")
+	// Setup request
+	mockParentID := "parendId"
+	name := "myvol"
+	size := int64(1234)
+	req := &csi.CreateVolumeRequest{
+		Name: name,
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{},
+		},
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: size,
+		},
+		VolumeContentSource: &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Volume{
+				Volume: &csi.VolumeContentSource_VolumeSource{
+					VolumeId: mockParentID,
+				},
+			},
+		},
+		Parameters: map[string]string{
+			"testkey": "testval",
+		},
+		Secrets: map[string]string{authsecrets.SecretTokenKey: systemUserToken},
+	}
+
+	// Setup mock functions
+	id := "myid"
+	snapID := id + "-snap"
+	gomock.InOrder(
+
+		// First check on parent
+		s.MockDriver().
+			EXPECT().
+			Enumerate(&api.VolumeLocator{
+				VolumeIds: []string{mockParentID},
+			}, nil).
+			Return([]*api.Volume{{Id: mockParentID}}, nil).
+			Times(1),
+
+		// VolFromName (name)
+		s.MockDriver().
+			EXPECT().
+			Inspect([]string{name}).
+			Return(nil, fmt.Errorf("not found")).
+			Times(1),
+
+		s.MockDriver().
+			EXPECT().
+			Enumerate(gomock.Any(), nil).
+			Return(nil, fmt.Errorf("not found")).
+			Times(1),
+
+		//VolFromName parent
+		s.MockDriver().
+			EXPECT().
+			Inspect(gomock.Any()).
+			Return(
+				[]*api.Volume{{
+					Id: mockParentID,
+				}}, nil).
+			Times(1),
+
+		// create
+		s.MockDriver().
+			EXPECT().
+			Snapshot(gomock.Any(), gomock.Any(), &api.VolumeLocator{Name: name, VolumeLabels: map[string]string{"testkey": "testval"}}, gomock.Any()).
+			Return(snapID, nil).
+			Times(1),
+		s.MockDriver().
+			EXPECT().
+			Enumerate(&api.VolumeLocator{
+				VolumeIds: []string{snapID},
+			}, nil).
+			Return([]*api.Volume{
+				{
+					Id:     id,
+					Source: &api.Source{Parent: mockParentID},
+				},
+			}, nil).
+			Times(2),
+
+		s.MockDriver().
+			EXPECT().
+			Set(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil).
+			Times(1),
+
+		s.MockDriver().
+			EXPECT().
+			Enumerate(gomock.Any(), nil).
+			Return([]*api.Volume{
+				{
+					Id:     id,
+					Source: &api.Source{Parent: mockParentID},
+				},
+			}, nil).
+			Times(1),
+	)
+
+	r, err := c.CreateVolume(context.Background(), req)
+	assert.Nil(t, err)
+	assert.NotNil(t, r)
+	volumeInfo := r.GetVolume()
+
+	assert.Equal(t, id, volumeInfo.GetVolumeId())
+	assert.NotEqual(t, "true", volumeInfo.GetVolumeContext()[api.SpecSharedv4])
+	assert.Equal(t, mockParentID, volumeInfo.GetVolumeContext()[api.SpecParent])
+}
+
+func TestControllerCreateVolumeFromSourceFADAPod(t *testing.T) {
+	// Create server and client connection
+	s := newTestServer(t)
+	defer s.Stop()
+	c := csi.NewControllerClient(s.Conn())
+	s.mockClusterEnumerateNode(t, "node-1")
+	// Setup request
+	mockParentID := "parendId"
+	name := "myvol"
+	pod := "mypod"
+	size := int64(1234)
+	req := &csi.CreateVolumeRequest{
+		Name: name,
+		VolumeCapabilities: []*csi.VolumeCapability{
+			{},
+		},
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: size,
+		},
+		VolumeContentSource: &csi.VolumeContentSource{
+			Type: &csi.VolumeContentSource_Volume{
+				Volume: &csi.VolumeContentSource_VolumeSource{
+					VolumeId: mockParentID,
+				},
+			},
+		},
+		Parameters: map[string]string{
+			"testkey":           "testval",
+			api.SpecPurePodName: pod,
+		},
+		Secrets: map[string]string{authsecrets.SecretTokenKey: systemUserToken},
+	}
+
+	// Setup mock functions
+	id := "myid"
+	snapID := id + "-snap"
+	gomock.InOrder(
+
+		// First check on parent
+		s.MockDriver().
+			EXPECT().
+			Enumerate(&api.VolumeLocator{
+				VolumeIds: []string{mockParentID},
+			}, nil).
+			Return([]*api.Volume{{Id: mockParentID}}, nil).
+			Times(1),
+
+		// VolFromName (name)
+		s.MockDriver().
+			EXPECT().
+			Inspect([]string{name}).
+			Return(nil, fmt.Errorf("not found")).
+			Times(1),
+
+		s.MockDriver().
+			EXPECT().
+			Enumerate(gomock.Any(), nil).
+			Return(nil, fmt.Errorf("not found")).
+			Times(1),
+
+		//VolFromName parent
+		s.MockDriver().
+			EXPECT().
+			Inspect(gomock.Any()).
+			Return(
+				[]*api.Volume{{
+					Id: mockParentID,
+				}}, nil).
+			Times(1),
+
+		// create
+		s.MockDriver().
+			EXPECT().
+			Snapshot(gomock.Any(), gomock.Any(), &api.VolumeLocator{Name: name, VolumeLabels: map[string]string{api.SpecPurePodName: pod, "testkey": "testval"}}, gomock.Any()).
+			Return(snapID, nil).
+			Times(1),
+		s.MockDriver().
+			EXPECT().
+			Enumerate(&api.VolumeLocator{
+				VolumeIds: []string{snapID},
+			}, nil).
+			Return([]*api.Volume{
+				{
+					Id:     id,
+					Source: &api.Source{Parent: mockParentID},
+				},
+			}, nil).
+			Times(2),
+
+		s.MockDriver().
+			EXPECT().
+			Set(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(nil).
+			Times(1),
+
+		s.MockDriver().
+			EXPECT().
+			Enumerate(gomock.Any(), nil).
+			Return([]*api.Volume{
+				{
+					Id:     id,
+					Source: &api.Source{Parent: mockParentID},
+				},
+			}, nil).
+			Times(1),
+	)
+
+	r, err := c.CreateVolume(context.Background(), req)
+	assert.Nil(t, err)
+	assert.NotNil(t, r)
+	volumeInfo := r.GetVolume()
+
+	assert.Equal(t, id, volumeInfo.GetVolumeId())
 	assert.NotEqual(t, "true", volumeInfo.GetVolumeContext()[api.SpecSharedv4])
 	assert.Equal(t, mockParentID, volumeInfo.GetVolumeContext()[api.SpecParent])
 }

--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -1324,7 +1324,7 @@ func TestControllerCreateVolumeBadSnapshot(t *testing.T) {
 		// Return an error from snapshot
 		s.MockDriver().
 			EXPECT().
-			Snapshot(parent, false, &api.VolumeLocator{Name: name, VolumeLabels: nil}, false).
+			Snapshot(parent, false, &api.VolumeLocator{Name: name, VolumeLabels: map[string]string{api.SpecParent: parent, "pvc": "", "namespace": ""}}, false).
 			Return("", fmt.Errorf("snapshoterr")).
 			Times(1),
 	)
@@ -2045,7 +2045,7 @@ func TestControllerCreateVolumeFromSnapshotFADAPod(t *testing.T) {
 		// create
 		s.MockDriver().
 			EXPECT().
-			Snapshot(gomock.Any(), gomock.Any(), &api.VolumeLocator{Name: name, VolumeLabels: map[string]string{api.SpecPurePodName: pod}}, gomock.Any()).
+			Snapshot(gomock.Any(), gomock.Any(), &api.VolumeLocator{Name: name, VolumeLabels: map[string]string{api.SpecPurePodName: pod, "pvc": "", "namespace": ""}}, gomock.Any()).
 			Return(snapID, nil).
 			Times(1),
 		s.MockDriver().
@@ -2153,7 +2153,8 @@ func TestControllerCreateVolumeSnapshotThroughParameters(t *testing.T) {
 		s.MockDriver().
 			EXPECT().
 			Snapshot(mockParentID, false, &api.VolumeLocator{
-				Name: name,
+				Name:         name,
+				VolumeLabels: map[string]string{api.SpecParent: mockParentID, "pvc": "", "namespace": ""},
 			},
 				false).
 			Return(id, nil).
@@ -2306,7 +2307,7 @@ func TestControllerCreateVolumeFromSource(t *testing.T) {
 		// create
 		s.MockDriver().
 			EXPECT().
-			Snapshot(gomock.Any(), gomock.Any(), &api.VolumeLocator{Name: name, VolumeLabels: map[string]string{"testkey": "testval"}}, gomock.Any()).
+			Snapshot(gomock.Any(), gomock.Any(), &api.VolumeLocator{Name: name, VolumeLabels: map[string]string{"testkey": "testval", "pvc": "", "namespace": ""}}, gomock.Any()).
 			Return(snapID, nil).
 			Times(1),
 		s.MockDriver().
@@ -2423,7 +2424,7 @@ func TestControllerCreateVolumeFromSourceFADAPod(t *testing.T) {
 		// create
 		s.MockDriver().
 			EXPECT().
-			Snapshot(gomock.Any(), gomock.Any(), &api.VolumeLocator{Name: name, VolumeLabels: map[string]string{api.SpecPurePodName: pod, "testkey": "testval"}}, gomock.Any()).
+			Snapshot(gomock.Any(), gomock.Any(), &api.VolumeLocator{Name: name, VolumeLabels: map[string]string{api.SpecPurePodName: pod, "testkey": "testval", "pvc": "", "namespace": ""}}, gomock.Any()).
 			Return(snapID, nil).
 			Times(1),
 		s.MockDriver().


### PR DESCRIPTION
**What this PR does / why we need it**:  
We are currently setting the pod name in two separate labels in a clone, which aside from a bad UX just makes things more complicated. This collapses it down to one variable.

It also passes all labels in one case instead of just the pod name label.

**Which issue(s) this PR fixes** (optional)  
PWX-38585

**Testing Notes** 
Manually tested pxctl clone and PVC-based clone and confirmed that labels are piped through properly.
Letting UTs run and fail here so I can fix them.