### PR TITLE
PWX-38721: Fix for ip/host mismatch during FBDA mount.

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"path"
 	"path/filepath"
@@ -445,6 +446,35 @@ func (m *Mounter) load(prefixes []*regexp.Regexp, fmp findMountPoint) error {
 	return nil
 }
 
+func resolveToIPs(hostPath string) []string {
+	index := strings.LastIndex(hostPath, ":")
+	if index != -1 {
+		hostPath = hostPath[:index]
+	}
+	ips, err := net.LookupIP(hostPath)
+	if err != nil || len(ips) == 0 {
+		return []string{hostPath} // Return the original input if resolution fails
+	}
+	// Convert all IP addresses to strings
+	ipStrings := make([]string, len(ips))
+	for i, ip := range ips {
+		ipStrings[i] = ip.String()
+	}
+	return ipStrings
+}
+
+func areSameIPs(ips1, ips2 []string) bool {
+	if len(ips1) != len(ips2) {
+		return false
+	}
+	for i := range ips1 {
+		if ips1[i] != ips2[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // Mount new mountpoint for specified device.
 func (m *Mounter) Mount(
 	minor int,
@@ -476,10 +506,29 @@ func (m *Mounter) Mount(
 			return ErrMountpathNotAllowed
 		}
 	}
+	resolveDNSOnMount := false
+	if _, ok := opts[options.OptionsResolveDNSOnMount]; ok {
+		resolveDNSOnMount = true
+	}
+	var err error
 	dev, ok := m.HasTarget(path)
-	if ok && dev != device {
-		logrus.Warnf("cannot mount %q,  device %q is mounted at %q", device, dev, path)
-		return ErrExist
+	if ok {
+		if dev != device {
+			err = ErrExist
+			if resolveDNSOnMount {
+				// Resolve both using DNS lookup
+				resolvedDev := resolveToIPs(dev)
+				resolvedDevice := resolveToIPs(device)
+				if areSameIPs(resolvedDev, resolvedDevice) {
+					logrus.Infof("Device %q, is already mount at %q, as source path %q", device, path, dev)
+					return nil
+				}
+			}
+		}
+	}
+	if err != nil {
+		logrus.Warnf("Cannot mount %q, device %q is mounted at %q", device, dev, path)
+		return err
 	}
 	m.Lock()
 	info, ok := m.mounts[device]

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -68,6 +68,11 @@ const (
 	// It is used to issue an umount system call to the requested path even
 	// if the entry for the path is not present in the mount table
 	OptionsUnmountOnEnoent = "UNMOUNT_ON_ENOENT"
+	// OptionsResolveDNSOnMount is an option to the following Opentstorage Volume API
+	// - Mount
+	// It is used to issue an mount system call to the requested path to resolve
+	// the path if there is a mismatch in the mount table and the source path.
+	OptionsResolveDNSOnMount = "RESOLVE_DNS_ON_MOUNT"
 )
 
 // IsBoolOptionSet checks if a boolean option key is set


### PR DESCRIPTION
**What this PR does / why we need it**:  
Portworx will try to mount the FBDA volumes using the NFS IP. However if there exists an NFS mountpoint for the same volume which used FQDN then the mountpoint created by Portworx will end up using FQDN as well instead of IP. (This is default NFS behavior)
Now consider we get a Mount request from Kubernetes, we mount it using IP, but shows up as FQDN mount due to 1. We return a success to k8s, but k8s has given up by then, so it sends another request for the same mount. As part of the repeated request we check for an existing mountpoint and there PX detects an FQDN mountpoint instead of IP and errors out the incoming repeated mount request.

**Which issue(s) this PR fixes** (optional)  
PWX-38721

**Testing Notes**  
* Created /etc/hosts entries 10.13.248.14 paypal.flashblade.inc
* Created volume using IP
* Created a mountpoint using host fqdn
* Simulated a fake error during NodePublishVolume so the mount gets created but K8s continues to retry
* Restart portworx so the mountpath in in the incore table gets updated with fqdn
* We start getting "mount point exists error" during retries.
* Update with the fix image and the app comes up fine.

**Special notes for your reviewer**:  
* In the currrent flow, if we get another mount request but there is no host/ip mismatch, we do not return succeess from there but go ahead and execute the rest of the mount flow. 
* I am unsure why we do that. But for the current scenario, if I detect that ip/fqdn point to the same host then I return success from there.
* If I do not return success then I get the error at a later stage:
```
Aug 23 06:25:40 pwx-ocp-136-11-vg62s-worker-0-ztgz9 portworx[3070494]: time="2024-08-23T06:25:40Z" level=error msg="Error listing attrs for /var/lib/kubelet/pods/76c9895f-35c2-4f72-90c1-c86789ac056a/volumes/kubernetes.io~csi/pvc-fe162002-14e8-4bfc-b732-7aa302c5ee8e/mount err:/usr/bin/lsattr: Inappropriate ioctl for device While reading flags on /var/lib/kubelet/pods/76c9895f-35c2-4f72-90c1-c86789ac056a/volumes/kubernetes.io~csi/pvc-fe162002-14e8-4bfc-b732-7aa302c5ee8e/mount\n" file="chattr.go:58" component=openstorage/pkg/chattr
Aug 23 06:25:40 pwx-ocp-136-11-vg62s-worker-0-ztgz9 portworx[3070494]: time="2024-08-23T06:25:40Z" level=warning msg="failed to make /var/lib/kubelet/pods/76c9895f-35c2-4f72-90c1-c86789ac056a/volumes/kubernetes.io~csi/pvc-fe162002-14e8-4bfc-b732-7aa302c5ee8e/mount readonly. Err: /usr/bin/chattr +i failed: /usr/bin/chattr: Inappropriate ioctl for device while reading flags on /var/lib/kubelet/pods/76c9895f-35c2-4f72-90c1-c86789ac056a/volumes/kubernetes.io~csi/pvc-fe162002-14e8-4bfc-b732-7aa302c5ee8e/mount\n. Err: exit status 1" file="mount.go:597" component=openstorage/pkg/mount
Aug 23 06:25:40 pwx-ocp-136-11-vg62s-worker-0-ztgz9 portworx[3070494]: time="2024-08-23T06:25:40Z" level=warning msg="checking error when mounting source path /var/lib/osd/mounts/readonly/b371a3c0-c8d7-44fc-9f18-14c6707bb962 at target /var/lib/kubelet/pods/76c9895f-35c2-4f72-90c1-c86789ac056a/volumes/kubernetes.io~csi/pvc-fe162002-14e8-4bfc-b732-7aa302c5ee8e/mount: mount: /var/lib/kubelet/pods/76c9895f-35c2-4f72-90c1-c86789ac056a/volumes/kubernetes.io~csi/pvc-fe162002-14e8-4bfc-b732-7aa302c5ee8e/mount: /var/lib/osd/mounts/readonly/b371a3c0-c8d7-44fc-9f18-14c6707bb962 is not a block device.\n" file="nfs_mounter.go:69" Error="exit
 status 32" Function=nfsMounter.Mount component=porx/storage/driver/volume/nfs filter=NFSFilter
Aug 23 06:25:40 pwx-ocp-136-11-vg62s-worker-0-ztgz9 portworx[3070494]: time="2024-08-23T06:25:40Z" level=warning msg="Failed to mount source path /var/lib/osd/mounts/readonly/b371a3c0-c8d7-44fc-9f18-14c6707bb962 at target /var/lib/kubelet/pods/76c9895f-35c2-4f72-90c1-c86789ac056a/volumes/kubernetes.io~csi/pvc-fe162002-14e8-4bfc-b732-7aa302c5ee8e/mount; retry=false" file="nfs_mounter.go:79" Error="mount: /var/lib/kubelet/pods/76c9895f-35c2-4f72-90c1-c86789ac056a/volumes/kubernetes.io~csi/pvc-fe162002-14e8-4bfc-b732-7aa302c5ee8e/mount: /var/lib/osd/mounts/readonly/b371a3c0-c8d7-44fc-9f18-14c6707bb962 is not a block device.:" Funct
ion=nfsMounter.Mount component=porx/storage/driver/volume/nfs filter=NFSFilter
