### PR TITLE
PWX-38618: Add SafeEmptyTrashDir function to Mounter.

### DIFF
--- a/pkg/mount/mount_test.go
+++ b/pkg/mount/mount_test.go
@@ -7,8 +7,10 @@ import (
 	"sync"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/libopenstorage/openstorage/pkg/options"
+	"github.com/libopenstorage/openstorage/pkg/sched"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
@@ -23,17 +25,27 @@ const (
 
 var m Manager
 
+func setLogger(fn string, t *testing.T) {
+	// The mount tests log a lot of messages, so we route the logs
+	// to a tmp location to avoid Travis CI log limits.
+	logFile, err := os.Create("/tmp/" + fn + ".log")
+	require.NoError(t, err, "unable to create log file")
+	logrus.SetOutput(logFile)
+}
 func TestNFSMounter(t *testing.T) {
+	setLogger("TestNFSMounter", t)
 	setupNFS(t)
 	allTests(t, source, dest)
 }
 
 func TestBindMounter(t *testing.T) {
+	setLogger("TestBindMounter", t)
 	setupBindMounter(t)
 	allTests(t, source, dest)
 }
 
 func TestRawMounter(t *testing.T) {
+	setLogger("TestRawMounter", t)
 	setupRawMounter(t)
 	allTests(t, rawSource, rawDest)
 }
@@ -275,6 +287,7 @@ func makeFile(pathname string) error {
 }
 
 func TestSafeEmptyTrashDir(t *testing.T) {
+	sched.Init(time.Second)
 	m, err := New(NFSMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, "")
 	require.NoError(t, err, "Failed to setup test %v", err)
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:  
- This change introduces a SafeEmptyTrashDir function. The safe implementation will only remove symbolic links if the 
prefix of the target matches with the provided path, to ensure we don't remove any other unrelated symbolic links.
- The SafeEmptyTrashDir will take in an arbitrary trash location
  and a prefix which needs cleanup.
- The symbolic links and the target paths will only be cleaned up if the target
  path has the provided prefix.

**Which issue(s) this PR fixes** (optional)  
Closes #
or
PWX-38618

**Testing Notes**  
Added a UT

**Special notes for your reviewer**:  
Add any notes for the reviewer here.
