### PR TITLE
PWX-38618: Add SafeEmptyTrashDir function to Mounter.

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -74,6 +74,9 @@ type Manager interface {
 	RemoveMountPath(path string, opts map[string]string) error
 	// EmptyTrashDir removes all directories from the mounter trash directory
 	EmptyTrashDir() error
+	// SafeEmptyTrashDir removes all the directories from the mounter trash directory
+	// only if the targets have the provided targetPrefix
+	SafeEmptyTrashDir(targetPrefix string, trashLocation string) error
 }
 
 // MountImpl backend implementation for Mount/Unmount calls
@@ -851,20 +854,27 @@ func (m *Mounter) RemoveMountPath(mountPath string, opts map[string]string) erro
 	return nil
 }
 
+func (m *Mounter) SafeEmptyTrashDir(targetPrefix string, trashLocation string) error {
+	return m.emptyTrashDir(targetPrefix, trashLocation)
+}
+
 func (m *Mounter) EmptyTrashDir() error {
-	files, err := ioutil.ReadDir(m.trashLocation)
+	return m.emptyTrashDir("", m.trashLocation)
+}
+
+func (m *Mounter) emptyTrashDir(safeRemovalPrefix, trashLocation string) error {
+	files, err := ioutil.ReadDir(trashLocation)
 	if err != nil {
-		logrus.Errorf("failed to read trash dir: %s. Err: %v", m.trashLocation, err)
+		logrus.Errorf("failed to read trash dir: %s. Err: %v", trashLocation, err)
 		return err
 	}
 
 	if _, err := sched.Instance().Schedule(
 		func(sched.Interval) {
 			for _, file := range files {
-				logrus.Infof("[EmptyTrashDir] Scheduled removing file %v in trash location %v", file.Name(), m.trashLocation)
-				e := m.removeSoftlinkAndTarget(path.Join(m.trashLocation, file.Name()))
+				e := m.removeSoftlinkAndTarget(safeRemovalPrefix, path.Join(trashLocation, file.Name()))
 				if e != nil {
-					logrus.Errorf("failed to remove link: %s. Err: %v", path.Join(m.trashLocation, file.Name()), e)
+					logrus.Errorf("failed to remove link: %s. Err: %v", path.Join(trashLocation, file.Name()), e)
 				}
 			}
 		},
@@ -878,16 +888,29 @@ func (m *Mounter) EmptyTrashDir() error {
 	return nil
 }
 
-func (m *Mounter) removeSoftlinkAndTarget(link string) error {
+func (m *Mounter) removeSoftlinkAndTarget(safeRemovalPrefix, link string) error {
 	if _, err := os.Stat(link); err == nil {
 		target, err := os.Readlink(link)
 		if err != nil {
+			if len(safeRemovalPrefix) > 0 {
+				// In case of safe removals if we are not able to validate the target path
+				// and its prefix we dont want the caller to think we hit an error with this file.
+				// This is primarily done to not log the error.
+				return nil
+			}
 			return err
 		}
+		if len(safeRemovalPrefix) > 0 && !strings.HasPrefix(target, safeRemovalPrefix) {
+			return fmt.Errorf("target %s does not have prefix %s, skipping removal", target, safeRemovalPrefix)
+		}
+
+		logrus.Infof("[EmptyTrashDir] Scheduled removing file %v", target)
 
 		if err = m.removeMountPath(target); err != nil {
 			return err
 		}
+	} else {
+		return fmt.Errorf("failed to stat link: %s. Err: %w", link, err)
 	}
 
 	if err := os.Remove(link); err != nil {

--- a/pkg/mount/mount_test.go
+++ b/pkg/mount/mount_test.go
@@ -7,8 +7,10 @@ import (
 	"sync"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/libopenstorage/openstorage/pkg/options"
+	"github.com/libopenstorage/openstorage/pkg/sched"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
@@ -23,17 +25,27 @@ const (
 
 var m Manager
 
+func setLogger(fn string, t *testing.T) {
+	// The mount tests log a lot of messages, so we route the logs
+	// to a tmp location to avoid Travis CI log limits.
+	logFile, err := os.Create("/tmp/" + fn + ".log")
+	require.NoError(t, err, "unable to create log file")
+	logrus.SetOutput(logFile)
+}
 func TestNFSMounter(t *testing.T) {
+	setLogger("TestNFSMounter", t)
 	setupNFS(t)
 	allTests(t, source, dest)
 }
 
 func TestBindMounter(t *testing.T) {
+	setLogger("TestBindMounter", t)
 	setupBindMounter(t)
 	allTests(t, source, dest)
 }
 
 func TestRawMounter(t *testing.T) {
+	setLogger("TestRawMounter", t)
 	setupRawMounter(t)
 	allTests(t, rawSource, rawDest)
 }
@@ -275,6 +287,7 @@ func makeFile(pathname string) error {
 }
 
 func TestSafeEmptyTrashDir(t *testing.T) {
+	sched.Init(time.Second)
 	m, err := New(NFSMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, "")
 	require.NoError(t, err, "Failed to setup test %v", err)
 


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:  
- This change introduces a SafeEmptyTrashDir function. The safe implementation will only remove symbolic links if the 
prefix of the target matches with the provided path, to ensure we don't remove any other unrelated symbolic links.
- The SafeEmptyTrashDir will take in an arbitrary trash location
  and a prefix which needs cleanup.
- The symbolic links and the target paths will only be cleaned up if the target
  path has the provided prefix.

**Which issue(s) this PR fixes** (optional)  
Closes #
or
PWX-38618

**Testing Notes**  
Added a UT

**Special notes for your reviewer**:  
Add any notes for the reviewer here.
