### PR TITLE
PWX-38721: Fix for ip/host mismatch during FBDA mount. (#2467)

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -467,15 +467,14 @@ func resolveToIPs(hostPath string) []string {
 }
 
 func areSameIPs(ips1, ips2 []string) bool {
-	if len(ips1) != len(ips2) {
-		return false
-	}
-	for i := range ips1 {
-		if ips1[i] != ips2[i] {
-			return false
+	for _, ip1 := range ips1 {
+		for _, ip2 := range ips2 {
+			if ip1 == ip2 {
+				return true
+			}
 		}
 	}
-	return true
+	return false
 }
 
 // Mount new mountpoint for specified device.

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -477,6 +477,15 @@ func areSameIPs(ips1, ips2 []string) bool {
 	return false
 }
 
+func extractSourcePath(hostPath string) string {
+	index := strings.LastIndex(hostPath, ":")
+	if index != -1 && index < len(hostPath)-1 {
+		return hostPath[index+1:]
+	}
+	// Return the original input if resolution fails
+	return hostPath
+}
+
 // Mount new mountpoint for specified device.
 func (m *Mounter) Mount(
 	minor int,
@@ -518,13 +527,18 @@ func (m *Mounter) Mount(
 		if dev != device {
 			err = ErrExist
 			if resolveDNSOnMount {
-				// Resolve both using DNS lookup
-				resolvedDev := resolveToIPs(dev)
-				resolvedDevice := resolveToIPs(device)
-				if areSameIPs(resolvedDev, resolvedDevice) {
-					logrus.Infof("Device %q, is already mount at %q, as source path %q", device, path, dev)
-					return nil
+				resolvedDevPath := extractSourcePath(dev)
+				resolvedDevicePath := extractSourcePath(device)
+				if resolvedDevPath == resolvedDevicePath {
+					// Resolve both using DNS lookup
+					resolvedDevIPs := resolveToIPs(dev)
+					resolvedDeviceIPs := resolveToIPs(device)
+					if areSameIPs(resolvedDevIPs, resolvedDeviceIPs) {
+						logrus.Infof("Device %q, is already mount at %q, as source path %q", device, path, dev)
+						return nil
+					}
 				}
+
 			}
 		}
 	}

--- a/pkg/mount/mount_test.go
+++ b/pkg/mount/mount_test.go
@@ -44,6 +44,9 @@ func allTests(t *testing.T, source, dest string) {
 	enoentUnmountTest(t, source, dest)
 	doubleUnmountTest(t, source, dest)
 	enoentUnmountTestWithoutOptions(t, source, dest)
+	doubleMountTest(t, source, dest)
+	mountTestPathMismatchFailure(t, source, dest)
+	mountTestPathMismatchSuccessWithOptions(t, source, dest)
 	mountTestParallel(t, source, dest)
 	inspect(t, source, dest)
 	reload(t, source, dest)
@@ -100,6 +103,55 @@ func mountTest(t *testing.T, source, dest string) {
 	require.NoError(t, err, "Failed in unmount")
 }
 
+func doubleMountTest(t *testing.T, source, dest string) {
+	err := m.Mount(0, source, dest, "", syscall.MS_BIND, "", 0, nil)
+	require.NoError(t, err, "Failed in mount")
+
+	// Mount point is already created and new request lands on the same mount point
+	err = m.Mount(0, source, dest, "", syscall.MS_BIND, "", 0, nil)
+	require.NoError(t, err, "Unexpected error in mount")
+
+	err = m.Unmount(source, dest, 0, 0, nil)
+	require.NoError(t, err, "Failed in unmount")
+}
+
+func mountTestPathMismatchFailure(t *testing.T, source, dest string) {
+	cleandir("localhost:" + source)
+	cleandir("127.0.0.1:" + source)
+	err := m.Mount(0, "localhost:"+source, dest, "", syscall.MS_BIND, "", 0, nil)
+	require.NoError(t, err, "Failed in mount")
+
+	// Mount point is already created and new request lands on the same mount point
+	// but source paths are different
+	err = m.Mount(0, "127.0.0.1:"+source, dest, "", syscall.MS_BIND, "", 0, nil)
+	// Expected error as source paths are different
+	require.Error(t, err, "Expected error in mount")
+
+	err = m.Unmount("localhost:"+source, dest, 0, 0, nil)
+	require.NoError(t, err, "Failed in unmount")
+	shutdown(t, "localhost:"+source, dest)
+	shutdown(t, "127.0.0.1:"+source, dest)
+}
+
+func mountTestPathMismatchSuccessWithOptions(t *testing.T, source, dest string) {
+	opts := make(map[string]string)
+	opts[options.OptionsResolveDNSOnMount] = "true"
+	cleandir("localhost:" + source)
+	cleandir("127.0.0.1:" + source)
+	err := m.Mount(0, "localhost:"+source, dest, "", syscall.MS_BIND, "", 0, opts)
+	require.NoError(t, err, "Failed in mount")
+
+	// Mount point is already created and new request lands on the same mount point
+	// and source paths resolve to same IP with OptionsResolveDNSOnMount
+	err = m.Mount(0, "127.0.0.1:"+source, dest, "", syscall.MS_BIND, "", 0, opts)
+	// Expected success as source paths are different but resolve to same IP
+	require.NoError(t, err, "Failed in mount")
+
+	err = m.Unmount("localhost:"+source, dest, 0, 0, nil)
+	require.NoError(t, err, "Failed in unmount")
+	shutdown(t, "localhost:"+source, dest)
+	shutdown(t, "127.0.0.1:"+source, dest)
+}
 func enoentUnmountTest(t *testing.T, source, dest string) {
 	opts := make(map[string]string)
 	opts[options.OptionsUnmountOnEnoent] = "true"
@@ -123,7 +175,6 @@ func enoentUnmountTestWithoutOptions(t *testing.T, source, dest string) {
 	require.Error(t, err, "Failed in unmount, expected an error")
 	syscall.Unmount(dest, 0)
 }
-
 
 // mountTestParallel runs mount and unmount in parallel with serveral dirs
 // in addition, we trigger failed unmount to test race condition in the case
@@ -273,4 +324,95 @@ func makeFile(pathname string) error {
 	}
 
 	return nil
+}
+
+func TestResolveToIPs(t *testing.T) {
+	tests := []struct {
+		hostPath string
+		expected []string
+	}{
+		// Case: Valid hostname with path
+		{"localhost:/path", []string{"127.0.0.1"}},
+
+		// Case: Valid hostname without path
+		{"localhost", []string{"127.0.0.1"}},
+
+		// Case: Invalid hostname
+		{"invalidhost", []string{"invalidhost"}},
+
+		// Case: IP address with path
+		{"192.168.1.1:/path", []string{"192.168.1.1"}},
+
+		// Case: IP address without path
+		{"192.168.1.1", []string{"192.168.1.1"}},
+
+		// Case: Empty string
+		{"", []string{""}},
+	}
+	for _, test := range tests {
+		result := resolveToIPs(test.hostPath)
+		if !areSameIPs(result, test.expected) {
+			t.Errorf("resolveToIPs(%v) = %v; expected %v", test.hostPath, result, test.expected)
+		}
+	}
+}
+func TestAreSameIPs(t *testing.T) {
+	tests := []struct {
+		name     string
+		ips1     []string
+		ips2     []string
+		expected bool
+	}{
+		{
+			name:     "One matching IP",
+			ips1:     []string{"192.168.1.1", "192.168.1.2"},
+			ips2:     []string{"10.0.0.1", "192.168.1.2"},
+			expected: true,
+		},
+		{
+			name:     "No matching IPs",
+			ips1:     []string{"192.168.1.1", "192.168.1.2"},
+			ips2:     []string{"10.0.0.1", "10.0.0.2"},
+			expected: false,
+		},
+		{
+			name:     "Empty second slice",
+			ips1:     []string{"192.168.1.1", "192.168.1.2"},
+			ips2:     []string{},
+			expected: false,
+		},
+		{
+			name:     "Empty first slice",
+			ips1:     []string{},
+			ips2:     []string{"192.168.1.1", "192.168.1.2"},
+			expected: false,
+		},
+		{
+			name:     "Both slices empty",
+			ips1:     []string{},
+			ips2:     []string{},
+			expected: false,
+		},
+		{
+			name:     "Identical IPs in both slices",
+			ips1:     []string{"192.168.1.1", "192.168.1.2"},
+			ips2:     []string{"192.168.1.1", "192.168.1.2"},
+			expected: true,
+		},
+		{
+			name:     "Multiple matches",
+			ips1:     []string{"192.168.1.1", "10.0.0.1"},
+			ips2:     []string{"192.168.1.1", "10.0.0.1"},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := areSameIPs(tt.ips1, tt.ips2)
+			if result != tt.expected {
+				t.Errorf("areSameIPs(%v, %v) = %v; expected %v", tt.ips1, tt.ips2, result, tt.expected)
+			}
+		})
+	}
 }

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -68,6 +68,11 @@ const (
 	// It is used to issue an umount system call to the requested path even
 	// if the entry for the path is not present in the mount table
 	OptionsUnmountOnEnoent = "UNMOUNT_ON_ENOENT"
+	// OptionsResolveDNSOnMount is an option to the following Opentstorage Volume API
+	// - Mount
+	// It is used to issue an mount system call to the requested path to resolve
+	// the path if there is a mismatch in the mount table and the source path.
+	OptionsResolveDNSOnMount = "RESOLVE_DNS_ON_MOUNT"
 )
 
 // IsBoolOptionSet checks if a boolean option key is set


### PR DESCRIPTION
**What this PR does / why we need it**:  
Portworx will try to mount the FBDA volumes using the NFS IP. However if there exists an NFS mountpoint for the same volume which used FQDN then the mountpoint created by Portworx will end up using FQDN as well instead of IP. (This is default NFS behavior)
Now consider we get a Mount request from Kubernetes, we mount it using IP, but shows up as FQDN mount due to 1. We return a success to k8s, but k8s has given up by then, so it sends another request for the same mount. As part of the repeated request we check for an existing mountpoint and there PX detects an FQDN mountpoint instead of IP and errors out the incoming repeated mount request.

**Which issue(s) this PR fixes** (optional)  
PWX-38721

**Testing Notes**  
* Created /etc/hosts entries 10.13.248.14 paypal.flashblade.inc
* Created volume using IP
* Created a mountpoint using host fqdn
* Simulated a fake error during NodePublishVolume so the mount gets created but K8s continues to retry
* Restart portworx so the mountpath in in the incore table gets updated with fqdn
* We start getting "mount point exists error" during retries.
* Update with the fix image and the app comes up fine.

**Special notes for your reviewer**:  
* In the currrent flow, if we get another mount request but there is no host/ip mismatch, we do not return succeess from there but go ahead and execute the rest of the mount flow. 
* I am unsure why we do that. But for the current scenario, if I detect that ip/fqdn point to the same host then I return success from there.
* If I do not return success then I get the error at a later stage:
```
Aug 23 06:25:40 pwx-ocp-136-11-vg62s-worker-0-ztgz9 portworx[3070494]: time="2024-08-23T06:25:40Z" level=error msg="Error listing attrs for /var/lib/kubelet/pods/76c9895f-35c2-4f72-90c1-c86789ac056a/volumes/kubernetes.io~csi/pvc-fe162002-14e8-4bfc-b732-7aa302c5ee8e/mount err:/usr/bin/lsattr: Inappropriate ioctl for device While reading flags on /var/lib/kubelet/pods/76c9895f-35c2-4f72-90c1-c86789ac056a/volumes/kubernetes.io~csi/pvc-fe162002-14e8-4bfc-b732-7aa302c5ee8e/mount\n" file="chattr.go:58" component=openstorage/pkg/chattr
Aug 23 06:25:40 pwx-ocp-136-11-vg62s-worker-0-ztgz9 portworx[3070494]: time="2024-08-23T06:25:40Z" level=warning msg="failed to make /var/lib/kubelet/pods/76c9895f-35c2-4f72-90c1-c86789ac056a/volumes/kubernetes.io~csi/pvc-fe162002-14e8-4bfc-b732-7aa302c5ee8e/mount readonly. Err: /usr/bin/chattr +i failed: /usr/bin/chattr: Inappropriate ioctl for device while reading flags on /var/lib/kubelet/pods/76c9895f-35c2-4f72-90c1-c86789ac056a/volumes/kubernetes.io~csi/pvc-fe162002-14e8-4bfc-b732-7aa302c5ee8e/mount\n. Err: exit status 1" file="mount.go:597" component=openstorage/pkg/mount
Aug 23 06:25:40 pwx-ocp-136-11-vg62s-worker-0-ztgz9 portworx[3070494]: time="2024-08-23T06:25:40Z" level=warning msg="checking error when mounting source path /var/lib/osd/mounts/readonly/b371a3c0-c8d7-44fc-9f18-14c6707bb962 at target /var/lib/kubelet/pods/76c9895f-35c2-4f72-90c1-c86789ac056a/volumes/kubernetes.io~csi/pvc-fe162002-14e8-4bfc-b732-7aa302c5ee8e/mount: mount: /var/lib/kubelet/pods/76c9895f-35c2-4f72-90c1-c86789ac056a/volumes/kubernetes.io~csi/pvc-fe162002-14e8-4bfc-b732-7aa302c5ee8e/mount: /var/lib/osd/mounts/readonly/b371a3c0-c8d7-44fc-9f18-14c6707bb962 is not a block device.\n" file="nfs_mounter.go:69" Error="exit
 status 32" Function=nfsMounter.Mount component=porx/storage/driver/volume/nfs filter=NFSFilter
Aug 23 06:25:40 pwx-ocp-136-11-vg62s-worker-0-ztgz9 portworx[3070494]: time="2024-08-23T06:25:40Z" level=warning msg="Failed to mount source path /var/lib/osd/mounts/readonly/b371a3c0-c8d7-44fc-9f18-14c6707bb962 at target /var/lib/kubelet/pods/76c9895f-35c2-4f72-90c1-c86789ac056a/volumes/kubernetes.io~csi/pvc-fe162002-14e8-4bfc-b732-7aa302c5ee8e/mount; retry=false" file="nfs_mounter.go:79" Error="mount: /var/lib/kubelet/pods/76c9895f-35c2-4f72-90c1-c86789ac056a/volumes/kubernetes.io~csi/pvc-fe162002-14e8-4bfc-b732-7aa302c5ee8e/mount: /var/lib/osd/mounts/readonly/b371a3c0-c8d7-44fc-9f18-14c6707bb962 is not a block device.:" Funct
ion=nfsMounter.Mount component=porx/storage/driver/volume/nfs filter=NFSFilter
