### PR TITLE
PWX-38611 : [cherry-pick]Replacing gob.Register with gob.RegisterName

### DIFF
--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -1509,7 +1509,9 @@ func (c *ClusterManager) StartWithConfiguration(
 	c.system = systemutils.New()
 
 	// Start the gossip protocol.
-	gob.Register(api.Node{})
+	// Replacing gob.Register with gob.RegisterName to avoid any issue caused due to the movement from portworx to pure-px
+	// gossip: Error in unmarshalling peer's local data. Error : gob: name not registered for interface.
+	gob.RegisterName("github.com/portworx/porx/vendor/github.com/libopenstorage/openstorage/api.Node", api.Node{})
 	quorumTimeout := types.DEFAULT_QUORUM_TIMEOUT
 	if c.config.QuorumTimeoutInSeconds > 0 {
 		quorumTimeout = time.Duration(c.config.QuorumTimeoutInSeconds) * time.Second


### PR DESCRIPTION
What this PR does / why we need it:
With recent update from portworx to pure-px, we were seeing errors during porx upgrade in decoding of gossip message.
"gossip: Error in unmarshalling peer's local data. Error : gob: name not registered for interface: "github.com/portworx/porx/vendor/github.com/libopenstorage/openstorage/api.Node"

Since the latest porx was not able to decipher the old path, we have changes gob.Register() to gob.RegisterName() to explicitly inform the complete path.

Which issue(s) this PR fixes (optional)
Closes #
PWX-38452 and PWX-38611

Testing Notes
Tested the below scenarios -

Upgrade a 3 node cluster from 3.1.4 to 3.2.0 using operator 24.1.1
Upgrade a 3 node cluster from 3.1.4 to 3.2.0 using operator 24.2.0-dev
Sequentially Upgrade a 10 node cluster from 3.1.4 to 3.2.0 using operator 24.2.0-dev
parallel upgrade (4 nodes at a time )a 10 node cluster from 3.1.4 to 3.2.0 using operator 24.2.0-dev
Special notes for your reviewer:
we are not seeing the log anymore "gossip: Error in unmarshalling peer's local data. Error : gob: name not registered for interface: "github.com/portworx/porx/vendor/github.com/libopenstorage/openstorage/api.Node"