### PR TITLE
PWX-38611 : Replacing gob.Register with gob.RegisterName while passing the actual path from PX 

### DIFF
--- a/api/client/cluster/client.go
+++ b/api/client/cluster/client.go
@@ -299,7 +299,7 @@ func (c *clusterClient) Uuid() string {
 	return ""
 }
 
-func (c *clusterClient) StartWithConfiguration(bool, string, []string, string, *cluster.ClusterServerConfiguration) error {
+func (c *clusterClient) StartWithConfiguration(bool, string, []string, string, *cluster.ClusterServerConfiguration, string) error {
 	return nil
 }
 

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -376,6 +376,7 @@ type Cluster interface {
 		snapshotPrefixes []string,
 		selfClusterDomain string,
 		config *ClusterServerConfiguration,
+		gobRegisterName string,
 	) error
 
 	// Get a unique identifier for this cluster. Depending on the implementation, this could

--- a/cluster/cluster_not_supported.go
+++ b/cluster/cluster_not_supported.go
@@ -11,8 +11,8 @@ import (
 	"github.com/libopenstorage/openstorage/pkg/defrag"
 	"github.com/libopenstorage/openstorage/pkg/diags"
 	"github.com/libopenstorage/openstorage/pkg/job"
-	"github.com/libopenstorage/openstorage/pkg/schedule"
 	"github.com/libopenstorage/openstorage/pkg/nodedrain"
+	"github.com/libopenstorage/openstorage/pkg/schedule"
 	"github.com/libopenstorage/openstorage/pkg/storagepool"
 	"github.com/libopenstorage/openstorage/schedpolicy"
 	"github.com/libopenstorage/openstorage/secrets"
@@ -117,7 +117,7 @@ func (m *NullClusterManager) Start(arg1 bool, arg2 string, arg3 string) error {
 }
 
 // StartWithConfiguration
-func (m *NullClusterManager) StartWithConfiguration(arg1 bool, arg2 string, arg3 []string, arg4 string, arg5 *ClusterServerConfiguration) error {
+func (m *NullClusterManager) StartWithConfiguration(arg1 bool, arg2 string, arg3 []string, arg4 string, arg5 *ClusterServerConfiguration, arg6 string) error {
 	return ErrNotImplemented
 }
 

--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -1448,7 +1448,8 @@ func (c *ClusterManager) Start(
 		gossipPort,
 		[]string{ClusterDBKey},
 		selfClusterDomain,
-		&cluster.ClusterServerConfiguration{})
+		&cluster.ClusterServerConfiguration{},
+		"")
 }
 
 func (c *ClusterManager) StartWithConfiguration(
@@ -1457,6 +1458,7 @@ func (c *ClusterManager) StartWithConfiguration(
 	snapshotPrefixes []string,
 	selfClusterDomain string,
 	config *cluster.ClusterServerConfiguration,
+	gobRegisterName string,
 ) error {
 	var err error
 
@@ -1511,7 +1513,7 @@ func (c *ClusterManager) StartWithConfiguration(
 	// Start the gossip protocol.
 	// Replacing gob.Register with gob.RegisterName to avoid any issue caused due to the movement from portworx to pure-px
 	// gossip: Error in unmarshalling peer's local data. Error : gob: name not registered for interface.
-	gob.RegisterName("github.com/portworx/porx/vendor/github.com/libopenstorage/openstorage/api.Node", api.Node{})
+	gob.RegisterName(gobRegisterName+"api.Node", api.Node{})
 	quorumTimeout := types.DEFAULT_QUORUM_TIMEOUT
 	if c.config.QuorumTimeoutInSeconds > 0 {
 		quorumTimeout = time.Duration(c.config.QuorumTimeoutInSeconds) * time.Second

--- a/cluster/manager/manager_test.go
+++ b/cluster/manager/manager_test.go
@@ -93,7 +93,7 @@ func TestUpdateSchedulerNodeName(t *testing.T) {
 
 	err = inst.StartWithConfiguration(false, "1001", []string{}, "", &cluster.ClusterServerConfiguration{
 		ConfigSystemTokenManager: manager,
-	})
+	}, "gobRegisterName/path")
 	assert.NoError(t, err)
 
 	node, err := inst.Inspect(nodeID)

--- a/cluster/mock/cluster.mock.go
+++ b/cluster/mock/cluster.mock.go
@@ -1080,17 +1080,17 @@ func (mr *MockClusterMockRecorder) Start(arg0, arg1, arg2 interface{}) *gomock.C
 }
 
 // StartWithConfiguration mocks base method.
-func (m *MockCluster) StartWithConfiguration(arg0 bool, arg1 string, arg2 []string, arg3 string, arg4 *cluster.ClusterServerConfiguration) error {
+func (m *MockCluster) StartWithConfiguration(arg0 bool, arg1 string, arg2 []string, arg3 string, arg4 *cluster.ClusterServerConfiguration, arg5 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartWithConfiguration", arg0, arg1, arg2, arg3, arg4)
+	ret := m.ctrl.Call(m, "StartWithConfiguration", arg0, arg1, arg2, arg3, arg4, arg5)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // StartWithConfiguration indicates an expected call of StartWithConfiguration.
-func (mr *MockClusterMockRecorder) StartWithConfiguration(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+func (mr *MockClusterMockRecorder) StartWithConfiguration(arg0, arg1, arg2, arg3, arg4, arg5 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWithConfiguration", reflect.TypeOf((*MockCluster)(nil).StartWithConfiguration), arg0, arg1, arg2, arg3, arg4)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartWithConfiguration", reflect.TypeOf((*MockCluster)(nil).StartWithConfiguration), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
 // UncordonAttachments mocks base method.

--- a/cmd/osd/main.go
+++ b/cmd/osd/main.go
@@ -630,6 +630,7 @@ func start(c *cli.Context) error {
 				ConfigObjectStoreManager: objectstore.NewfakeObjectstore(),
 				ConfigSystemTokenManager: auth.SystemTokenManagerInst(),
 			},
+			"",
 		); err != nil {
 			return fmt.Errorf("Unable to start cluster manager: %v", err)
 		}


### PR DESCRIPTION
What this PR does / why we need it:
With recent update from portworx to pure-px, we were seeing errors during porx upgrade in decoding of gossip message.
"gossip: Error in unmarshalling peer's local data. Error : gob: name not registered for interface: "github.com/portworx/porx/vendor/github.com/libopenstorage/openstorage/api.Node"

Since the latest porx was not able to decipher the old path, we have changes gob.Register() to gob.RegisterName() to explicitly inform the complete path.

Which issue(s) this PR fixes (optional)
Closes #
PWX-38452 and PWX-38611

Testing Notes
Tested the below scenarios -

Upgrade a 3 node cluster from 3.1.4 to 3.2.0 using operator 24.1.1
Upgrade a 3 node cluster from 3.1.4 to 3.2.0 using operator 24.2.0-dev
Sequentially Upgrade a 10 node cluster from 3.1.4 to 3.2.0 using operator 24.2.0-dev
parallel upgrade (4 nodes at a time )a 10 node cluster from 3.1.4 to 3.2.0 using operator 24.2.0-dev
Special notes for your reviewer:
we are not seeing the log anymore "gossip: Error in unmarshalling peer's local data. Error : gob: name not registered for interface: "github.com/portworx/porx/vendor/github.com/libopenstorage/openstorage/api.Node"