### PR TITLE
PWX-38760: Handle NFS Mounter's Reload when both DNS and IPs are configured

### DIFF
--- a/api/flexvolume/flexvolume.go
+++ b/api/flexvolume/flexvolume.go
@@ -96,7 +96,7 @@ func (c *flexVolumeClient) Mount(targetMountDir string, mountDevice string,
 		return err
 	}
 	// Update the deviceDriverMap
-	mountManager, err := mount.New(mount.DeviceMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, "")
+	mountManager, err := mount.New(mount.DeviceMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, "", false)
 	if err != nil {
 		logrus.Infof("Could not read mountpoints from /proc/self/mountinfo. Device - Driver mapping not saved!")
 		return nil
@@ -111,7 +111,7 @@ func (c *flexVolumeClient) Mount(targetMountDir string, mountDevice string,
 
 func (c *flexVolumeClient) Unmount(mountDir string, options map[string]string) error {
 	// Get the mountDevice from mount manager
-	mountManager, err := mount.New(mount.DeviceMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, "")
+	mountManager, err := mount.New(mount.DeviceMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, "", false)
 	if err != nil {
 		return ErrNoMountInfo
 	}

--- a/pkg/mount/device_test.go
+++ b/pkg/mount/device_test.go
@@ -66,7 +66,7 @@ func TestBasicDeviceMounter(t *testing.T) {
 	orderedDevices := []string{device1}
 	orderedPaths := []string{mountPath1}
 
-	dm, err := New(DeviceMount, nil, []*regexp.Regexp{regexp.MustCompile(osdDevicePrefix)}, nil, []string{}, "")
+	dm, err := New(DeviceMount, nil, []*regexp.Regexp{regexp.MustCompile(osdDevicePrefix)}, nil, []string{}, "", false)
 	require.NoError(t, err, "Unexpected error on mount.New")
 
 	// Inspect
@@ -106,7 +106,7 @@ func TestBasicDeviceMounterWithMultipleMounts(t *testing.T) {
 	orderedDevices := []string{device1, device1}
 	orderedPaths := []string{mountPath1, mountPath2}
 
-	dm, err := New(DeviceMount, nil, []*regexp.Regexp{regexp.MustCompile(osdDevicePrefix)}, nil, []string{}, "")
+	dm, err := New(DeviceMount, nil, []*regexp.Regexp{regexp.MustCompile(osdDevicePrefix)}, nil, []string{}, "", false)
 	require.NoError(t, err, "Unexpected error on mount.New")
 
 	// Inspect

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -790,7 +790,7 @@ func (m *Mounter) removeMountPath(path string) error {
 	}
 
 	var bindMountPath string
-	bindMounter, err := New(BindMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, "")
+	bindMounter, err := New(BindMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, "", false)
 	if err != nil {
 		return err
 	}
@@ -957,6 +957,7 @@ func New(
 	customMounter CustomMounter,
 	allowedDirs []string,
 	trashLocation string,
+	handleDNSResolution bool,
 ) (Manager, error) {
 
 	if mountImpl == nil {
@@ -967,7 +968,7 @@ func New(
 	case DeviceMount:
 		return NewDeviceMounter(identifiers, mountImpl, allowedDirs, trashLocation)
 	case NFSMount:
-		return NewNFSMounter(identifiers, mountImpl, allowedDirs, trashLocation)
+		return NewNFSMounter(identifiers, mountImpl, allowedDirs, trashLocation, handleDNSResolution)
 	case BindMount:
 		return NewBindMounter(identifiers, mountImpl, allowedDirs, trashLocation)
 	case CustomMount:

--- a/pkg/mount/mount_test.go
+++ b/pkg/mount/mount_test.go
@@ -32,9 +32,15 @@ func setLogger(fn string, t *testing.T) {
 	require.NoError(t, err, "unable to create log file")
 	logrus.SetOutput(logFile)
 }
+func TestNFSMounterHandleDNSResolution(t *testing.T) {
+	setLogger("TestNFSMounterHandleDNSResolution", t)
+	setupNFS(t, true)
+	allTests(t, source, dest)
+}
+
 func TestNFSMounter(t *testing.T) {
 	setLogger("TestNFSMounter", t)
-	setupNFS(t)
+	setupNFS(t, false)
 	allTests(t, source, dest)
 }
 
@@ -69,9 +75,9 @@ func allTests(t *testing.T, source, dest string) {
 	shutdown(t, source, dest)
 }
 
-func setupNFS(t *testing.T) {
+func setupNFS(t *testing.T, handleDNSResolution bool) {
 	var err error
-	m, err = New(NFSMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, trashLocation)
+	m, err = New(NFSMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, trashLocation, handleDNSResolution)
 	if err != nil {
 		t.Fatalf("Failed to setup test %v", err)
 	}
@@ -81,7 +87,7 @@ func setupNFS(t *testing.T) {
 
 func setupBindMounter(t *testing.T) {
 	var err error
-	m, err = New(BindMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, trashLocation)
+	m, err = New(BindMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, trashLocation, false)
 	if err != nil {
 		t.Fatalf("Failed to setup test %v", err)
 	}
@@ -91,7 +97,7 @@ func setupBindMounter(t *testing.T) {
 
 func setupRawMounter(t *testing.T) {
 	var err error
-	m, err = New(RawMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, trashLocation)
+	m, err = New(RawMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, trashLocation, false)
 	if err != nil {
 		t.Fatalf("Failed to setup test %v", err)
 	}
@@ -510,9 +516,11 @@ func TestExtractSourcePath(t *testing.T) {
 			}
 		})
 	}
+}
+
 func TestSafeEmptyTrashDir(t *testing.T) {
 	sched.Init(time.Second)
-	m, err := New(NFSMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, "")
+	m, err := New(NFSMount, nil, []*regexp.Regexp{regexp.MustCompile("")}, nil, []string{}, "", true)
 	require.NoError(t, err, "Failed to setup test %v", err)
 
 	err = os.MkdirAll("/tmp/safe-empty-trash-dir-tests", 0755)

--- a/pkg/mount/nfs.go
+++ b/pkg/mount/nfs.go
@@ -70,10 +70,13 @@ func (m *nfsMounter) Reload(inputSource string) error {
 		return fmt.Errorf("Internal error failed to convert %T",
 			newNFSmounter)
 	}
-	var newM *Info
-	if m.handleDNSResolution {
+	newM := newNFSmounter.mounts[inputSource]
+
+	if m.handleDNSResolution && newM == nil {
+
 		// Check if the source is a IP:share combination which maps to an
 		// DNS:share combination.
+		resolvedInputSourceIPs := resolveToIPs(inputSource)
 		inputSourceExportPath := extractSourcePath(inputSource)
 		for existingSource, existingMountInfo := range newNFSmounter.mounts {
 			if inputSourceExportPath == extractSourcePath(existingSource) {
@@ -81,7 +84,6 @@ func (m *nfsMounter) Reload(inputSource string) error {
 				// Now lets check if the input source (IP or DNS) matches
 				// with the existing source (IP or DNS).
 				resolvedExistingSourceIPs := resolveToIPs(existingSource)
-				resolvedInputSourceIPs := resolveToIPs(inputSource)
 				if areSameIPs(resolvedExistingSourceIPs, resolvedInputSourceIPs) {
 					// The input source and existing source are the same.
 					// So, we can use the existing mount info even if it was for a
@@ -92,8 +94,6 @@ func (m *nfsMounter) Reload(inputSource string) error {
 			}
 		}
 
-	} else {
-		newM = newNFSmounter.mounts[inputSource]
 	}
 	return m.reload(inputSource, newM)
 }

--- a/volume/drivers/nfs/nfs.go
+++ b/volume/drivers/nfs/nfs.go
@@ -77,7 +77,7 @@ func Init(params map[string]string) (volume.VolumeDriver, error) {
 	}
 
 	// Create a mount manager for this NFS server. Blank sever is OK.
-	mounter, err := mount.New(mount.NFSMount, nil, serverRegexes, nil, []string{}, "")
+	mounter, err := mount.New(mount.NFSMount, nil, serverRegexes, nil, []string{}, "", true)
 	if err != nil {
 		logrus.Warnf("Failed to create mount manager for server: %v (%v)", server, err)
 		return nil, err


### PR DESCRIPTION


<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:  

- While reloading for a specific source, we used to check if the in-memory mount table has an entry for that source.
- Since source can be an IP or DNS, we need to check if any of the existing sources which are DNS entries resolve to the input source. If found use that mount table entry.

**Which issue(s) this PR fixes** (optional)  
Closes #
or
PWX-38760

**Testing Notes**  
UTs:
- For now running the existing UTs with setting the handleDNSResolution to true. 

Manual Tests
- Issued a repeated mount request for an NFS share using IP:/exportPath whereas on the host the mountpoint shows up as DNS:/exportPath
- Repeated mount requests for the same targetPath passed

Before
```
 [root@pwx-ocp-208-143-qbkb2-worker-0-kzw58 mount]# /opt/pwx/bin/pxctl host mount pvc-4f650a40-2bab-4d92-b431-4ae17e0367b5 --path /var/lib/osd/mounts/test2
Volume pvc-4f650a40-2bab-4d92-b431-4ae17e0367b5 successfully mounted at /var/lib/osd/mounts/test2

[root@pwx-ocp-208-143-qbkb2-worker-0-kzw58 mount]# /opt/pwx/bin/pxctl host mount pvc-4f650a40-2bab-4d92-b431-4ae17e0367b5 --path /var/lib/osd/mounts/test2
mount: Failed to mount volume pvc-4f650a40-2bab-4d92-b431-4ae17e0367b5: failed to bind mount /var/lib/osd/mounts/test2 to /var/lib/osd/mounts/readonly/8d197c09-ce97-4a69-9462-366f79957462. Err: mount: /var/lib/osd/mounts/test2: /var/lib/osd/mounts/readonly/8d197c09-ce97-4
a69-9462-366f79957462 is not a block device.

```

After
```
[root@pwx-ocp-208-143-qbkb2-worker-0-kzw58 mount]# /opt/pwx/bin/pxctl host mount pvc-4f650a40-2bab-4d92-b431-4ae17e0367b5 --path /var/lib/osd/mounts/test2
Volume pvc-4f650a40-2bab-4d92-b431-4ae17e0367b5 successfully mounted at /var/lib/osd/mounts/test2

[root@pwx-ocp-208-143-qbkb2-worker-0-kzw58 mount]# /opt/pwx/bin/pxctl host mount pvc-4f650a40-2bab-4d92-b431-4ae17e0367b5 --path /var/lib/osd/mounts/test2
Volume pvc-4f650a40-2bab-4d92-b431-4ae17e0367b5 successfully mounted at /var/lib/osd/mounts/test2

```

**Special notes for your reviewer**:  
Add any notes for the reviewer here.
