### PR TITLE
Improve logging for better debugging of attach/mount and unmount

### DIFF
--- a/api/server/sdk/volume_node_ops.go
+++ b/api/server/sdk/volume_node_ops.go
@@ -23,6 +23,7 @@ import (
 	"github.com/libopenstorage/openstorage/api"
 	mountattachoptions "github.com/libopenstorage/openstorage/pkg/options"
 	"github.com/libopenstorage/openstorage/volume"
+	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -76,6 +77,7 @@ func (s *VolumeServer) Attach(
 	}
 
 	s.auditLog(ctx, "mountattach.attach", "Volume %s attached", req.GetVolumeId())
+	logrus.Infof("Volume %s attached on node", req.GetVolumeId())
 	return &api.SdkVolumeAttachResponse{DevicePath: devPath}, nil
 }
 
@@ -119,6 +121,7 @@ func (s *VolumeServer) Detach(
 	}
 
 	s.auditLog(ctx, "mountattach.detach", "Volume %s detached", req.GetVolumeId())
+	logrus.Infof("Volume %s detached on node", req.GetVolumeId())
 	return &api.SdkVolumeDetachResponse{}, nil
 }
 
@@ -154,6 +157,7 @@ func (s *VolumeServer) Mount(
 			err.Error())
 	}
 	s.auditLog(ctx, "mountattach.mount", "Volume %s mounted", req.GetVolumeId())
+	logrus.Infof("Volume %s mounted on node", req.GetVolumeId())
 	return &api.SdkVolumeMountResponse{}, err
 }
 
@@ -202,5 +206,6 @@ func (s *VolumeServer) Unmount(
 	}
 
 	s.auditLog(ctx, "mountattach.unmount", "Volume %s mounted", req.GetVolumeId())
+	logrus.Infof("Volume %s unmounted on node", req.GetVolumeId())
 	return &api.SdkVolumeUnmountResponse{}, nil
 }

--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -437,12 +437,14 @@ func (vd *volAPI) volumeSet(w http.ResponseWriter, r *http.Request) {
 				Options:       attachOptions,
 				DriverOptions: req.GetOptions(),
 			})
+			vd.logRequest(method, volumeID).Infof("Attachment completed for volume")
 		} else if req.Action.IsDetach() {
 			_, err = mountAttachClient.Detach(ctx, &api.SdkVolumeDetachRequest{
 				VolumeId:      volumeID,
 				Options:       detachOptions,
 				DriverOptions: req.GetOptions(),
 			})
+			vd.logRequest(method, volumeID).Infof("Detachment completed for volume")
 		}
 
 		if err == nil {
@@ -455,6 +457,7 @@ func (vd *volAPI) volumeSet(w http.ResponseWriter, r *http.Request) {
 						MountPath:     req.Action.MountPath,
 						DriverOptions: req.GetOptions(),
 					})
+					vd.logRequest(method, volumeID).Infof("Mount completed for volume on path %s", req.Action.MountPath)
 				}
 			} else if req.Action.IsUnMount() {
 				_, err = mountAttachClient.Unmount(ctx, &api.SdkVolumeUnmountRequest{
@@ -463,6 +466,7 @@ func (vd *volAPI) volumeSet(w http.ResponseWriter, r *http.Request) {
 					Options:       unmountOptions,
 					DriverOptions: req.GetOptions(),
 				})
+				vd.logRequest(method, volumeID).Infof("Unmount completed for volume on path %s", req.Action.MountPath)
 			}
 		}
 	}
@@ -483,6 +487,7 @@ func (vd *volAPI) volumeSet(w http.ResponseWriter, r *http.Request) {
 	} else {
 		resp.Volume = resVol.GetVolume()
 	}
+	vd.logRequest(method, volumeID).Infof("Inspect completed for volume")
 	// Do not clear inspect err for attach
 	if err != nil {
 		resp.VolumeResponse = &api.VolumeResponse{


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:  
Explain the PR and why it is needed.

While debugging issues related to hung mount while using in tree driver, we noticed that there is no clear signal using logs to check when the Open Storage API call was completed. This PR adds logs to help with this scenario

**Which issue(s) this PR fixes** (optional)  
PWX-38876 (Not actual fix)

**Testing Notes**  

```
@sradhakrishnan-6-1 portworx[470138]: time="2024-09-05T08:01:04Z" level=info msg="Attachment completed for volume" file="volume.go:440" Driver=pxd ID=1100666696692950591 Request=volumeSet component=openstorage/api/server
@sradhakrishnan-6-1 portworx[470138]: time="2024-09-05T08:01:04Z" level=info msg="Mount completed for volume on path /var/lib/osd/pxns/1100666696692950591" file="volume.go:460" Driver=pxd ID=1100666696692950591 Request=volumeSet component=openstorage/api/server

@ip-10-13-168-20.pwx.purestorage.com portworx[989379]: time="2024-09-06T04:02:33Z" level=info msg="Detachment completed for volume" file="volume.go:447" Driver=pxd ID=pvc-02e36b44-41e7-4ce9-8960-2a3e40c38d3e Request=volumeSet component=openstorage/api/server
:@ip-10-13-168-20.pwx.purestorage.com portworx[989379]: time="2024-09-06T04:02:33Z" level=info msg="Unmount completed for volume on path /var/lib/kubelet/pods/d612ec19-448d-4aab-889e-6543bfa95cfe/volumes/kubernetes.io~portworx-volume/pvc-02e36b44-41e7-4ce9-8960-2a3e40c38d3e" file="volume.go:469" Driver=pxd ID=pvc-02e36b44-41e7-4ce9-8960-2a3e40c38d3e Request=volumeSet component=openstorage/api/server
```
**Special notes for your reviewer**:  
Add any notes for the reviewer here.
