### PR TITLE
PWX-38585: Adds additional labels to clone requests

### DIFF
--- a/api/server/volume.go
+++ b/api/server/volume.go
@@ -1036,7 +1036,7 @@ func (vd *volAPI) snap(w http.ResponseWriter, r *http.Request) {
 			snapRes.VolumeCreateResponse.Id = res.GetSnapshotId()
 		}
 	} else {
-		res, err := volumes.Clone(ctx, &api.SdkVolumeCloneRequest{ParentId: snapReq.Id, Name: snapReq.Locator.Name})
+		res, err := volumes.Clone(ctx, &api.SdkVolumeCloneRequest{ParentId: snapReq.Id, Name: snapReq.Locator.Name, AdditionalLabels: snapReq.Locator.VolumeLabels})
 		if err != nil {
 			snapRes.VolumeCreateResponse.VolumeResponse = &api.VolumeResponse{
 				Error: err.Error(),


### PR DESCRIPTION
**What this PR does / why we need it**:  
Volume clone requests can have additional labels, which were not being plumbed through.

**Which issue(s) this PR fixes** (optional)  
PWX-38585

