### PR TITLE
PWX-39064: Allow force option to be passed to CanNodeRemove

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -219,7 +219,7 @@ type ClusterListenerNodeOps interface {
 	CanNodeJoin(node *api.Node, clusterInfo *ClusterInfo, nodeInitialized bool) error
 
 	// CanNodeRemove test to see if we can remove this node
-	CanNodeRemove(node *api.Node) (string, error)
+	CanNodeRemove(node *api.Node, forceRemove bool) (string, error)
 
 	// MarkNodeForRemoval instructs the listeners that the ClusterManager
 	// is going ahead with the node removal. The API does not expect any
@@ -481,7 +481,7 @@ func (nc *NullClusterListener) Remove(node *api.Node, forceRemove bool) error {
 	return nil
 }
 
-func (nc *NullClusterListener) CanNodeRemove(node *api.Node) (string, error) {
+func (nc *NullClusterListener) CanNodeRemove(node *api.Node, forceRemove bool) (string, error) {
 	return "", nil
 }
 

--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -1858,7 +1858,7 @@ func (c *ClusterManager) Remove(nodes []api.Node, forceRemove bool) error {
 			logrus.Infof("Remove node: ask cluster listener: "+
 				"can we remove node ID %s, %s",
 				nodes[i].Id, e.Value.(cluster.ClusterListener).String())
-			additionalMsg, err := e.Value.(cluster.ClusterListener).CanNodeRemove(&nodes[i])
+			additionalMsg, err := e.Value.(cluster.ClusterListener).CanNodeRemove(&nodes[i], forceRemove)
 			if err != nil && !(err == cluster.ErrRemoveCausesDataLoss && forceRemove) {
 				msg := fmt.Sprintf("Cannot remove node ID %s: %s.", nodes[i].Id, err)
 				if additionalMsg != "" {

--- a/cluster/mock/cluster_listener.mock.go
+++ b/cluster/mock/cluster_listener.mock.go
@@ -64,18 +64,18 @@ func (mr *MockClusterListenerMockRecorder) CanNodeJoin(arg0, arg1, arg2 interfac
 }
 
 // CanNodeRemove mocks base method
-func (m *MockClusterListener) CanNodeRemove(arg0 *api.Node) (string, error) {
+func (m *MockClusterListener) CanNodeRemove(arg0 *api.Node, arg1 bool) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CanNodeRemove", arg0)
+	ret := m.ctrl.Call(m, "CanNodeRemove", arg0, arg1)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CanNodeRemove indicates an expected call of CanNodeRemove
-func (mr *MockClusterListenerMockRecorder) CanNodeRemove(arg0 interface{}) *gomock.Call {
+func (mr *MockClusterListenerMockRecorder) CanNodeRemove(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanNodeRemove", reflect.TypeOf((*MockClusterListener)(nil).CanNodeRemove), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CanNodeRemove", reflect.TypeOf((*MockClusterListener)(nil).CanNodeRemove), arg0, arg1)
 }
 
 // CleanupInit mocks base method


### PR DESCRIPTION
**What this PR does / why we need it**:  
Allowing forceRemove during CanNodeRemove

**Which issue(s) this PR fixes** (optional)  
PWX-39064:

**Testing Notes**  
In the Porx PR : https://github.com/pure-px/porx/pull/14042

