### PR TITLE
Revert "PWX-37595: honour force flag over node status (#2479)"

### DIFF
--- a/cluster/manager/manager.go
+++ b/cluster/manager/manager.go
@@ -1830,8 +1830,7 @@ func (c *ClusterManager) Remove(nodes []api.Node, forceRemove bool) error {
 			// If node is not down, do not remove it
 			if nodeCacheStatus != api.Status_STATUS_OFFLINE &&
 				nodeCacheStatus != api.Status_STATUS_MAINTENANCE &&
-				nodeCacheStatus != api.Status_STATUS_DECOMMISSION &&
-				!forceRemove {
+				nodeCacheStatus != api.Status_STATUS_DECOMMISSION {
 
 				msg := fmt.Sprintf(decommissionErrMsg, nodes[i].Id)
 				logrus.Errorf(msg+", node status: %s", nodeCacheStatus)

--- a/cluster/manager/manager_test.go
+++ b/cluster/manager/manager_test.go
@@ -16,16 +16,11 @@ limitations under the License.
 package manager
 
 import (
-	"container/list"
-	"errors"
 	"fmt"
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-	"github.com/libopenstorage/openstorage/api"
 	"github.com/libopenstorage/openstorage/cluster"
-	"github.com/libopenstorage/openstorage/cluster/mock"
 	"github.com/libopenstorage/openstorage/config"
 	"github.com/libopenstorage/openstorage/pkg/auth"
 	"github.com/libopenstorage/openstorage/pkg/auth/systemtoken"
@@ -118,40 +113,4 @@ func TestUpdateSchedulerNodeName(t *testing.T) {
 	assert.True(t, auth.IsJwtToken(tokenResp.Token))
 
 	cleanup()
-}
-
-func TestRemoveOnlineNode(t *testing.T) {
-	const testNodeID = "test id"
-	mockErr := errors.New("mock err")
-	ctrl := gomock.NewController(t)
-	mockListener := mock.NewMockClusterListener(ctrl)
-	nodeToRemove := api.Node{
-		Id:     testNodeID,
-		Status: api.Status_STATUS_OK,
-	}
-	clusterListener := list.New()
-	clusterListener.PushBack(mockListener)
-	testManager := ClusterManager{
-		nodeCache: map[string]api.Node{
-			testNodeID: nodeToRemove,
-		},
-		listeners: clusterListener,
-	}
-
-	kv, err := kvdb.New(mem.Name, "test", []string{}, nil, kvdb.LogFatalErrorCB)
-	assert.NoError(t, err)
-	err = kvdb.SetInstance(kv)
-	assert.NoError(t, err)
-
-	// when force flag is false, node status check should take precedence
-	err = testManager.Remove([]api.Node{nodeToRemove}, false)
-	assert.Error(t, err)
-	assert.EqualError(t, err, fmt.Sprintf(decommissionErrMsg, testNodeID))
-
-	// when force flag is true, we shouldn't abort due to node status
-	mockListener.EXPECT().String().Return(testNodeID)
-	mockListener.EXPECT().MarkNodeDown(gomock.Any()).Return(mockErr)
-
-	err = testManager.Remove([]api.Node{nodeToRemove}, true)
-	assert.EqualError(t, err, mockErr.Error())
 }


### PR DESCRIPTION
This reverts commit 24e88ce1ee8f298a62c41cead5aee13d7ae27cfb.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:  
Explain the PR and why it is needed.
Reverting the changes as we need more analysis on the issue.
**Which issue(s) this PR fixes** (optional)  
Closes #
or
PWX-

**Testing Notes**  
Add testing output or passing unit test output here.

**Special notes for your reviewer**:  
Add any notes for the reviewer here.
1. make pr-verify o/p
```
make pr-verify
go fmt  | grep -v "api.pb.go" | wc -l | grep "^0";
package github.com/libopenstorage/openstorage: no Go files in /root/go/src/github.com/libopenstorage/openstorage
0
go run tools/sdkver/sdkver.go --check-major=0 --check-minor=101
0.101.54
git-validation -run DCO,short-subject
INFO[0000] using commit range: 2872d00f..a81e7a46
 * a81e7a46 "Revert \"PWX-37595: honour force flag over node status (#2479)\"" ... PASS
make docker-proto
make[1]: Entering directory '/root/go/src/github.com/libopenstorage/openstorage'
docker pull quay.io/openstorage/osd-proto:pre-gomodules
pre-gomodules: Pulling from openstorage/osd-proto
Digest: sha256:76b09a1a0231f9cf78f22eecd243d7ddb2bcc464e0cea9493a2d08dfe534ef14
Status: Image is up to date for quay.io/openstorage/osd-proto:pre-gomodules
quay.io/openstorage/osd-proto:pre-gomodules
docker run \
        --privileged --rm \
        -v /root/go/src/github.com/libopenstorage/openstorage:/go/src/github.com/libopenstorage/openstorage \
        -e "GOPATH=/go" \
        -e "DOCKER_PROTO=yes" \
        -e "PATH=/bin:/usr/bin:/usr/local/bin:/go/bin:/usr/local/go/bin" \
        quay.io/openstorage/osd-proto:pre-gomodules \
                make proto mockgen
>>> Generating protobuf definitions from api/api.proto
protoc -I /go/src/github.com/libopenstorage/openstorage \
        -I /usr/local/include \
        -I /go/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
        --go_out=plugins=grpc:. \
        /go/src/github.com/libopenstorage/openstorage/api/api.proto
protoc -I /go/src/github.com/libopenstorage/openstorage \
        -I /usr/local/include \
        -I /go/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
        --grpc-gateway_out=logtostderr=true:. \
        /go/src/github.com/libopenstorage/openstorage/api/api.proto
protoc -I /go/src/github.com/libopenstorage/openstorage \
        -I /usr/local/include \
        -I /go/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis \
        --swagger_out=logtostderr=true:/go/src/github.com/libopenstorage/openstorage/api/server/sdk \
        /go/src/github.com/libopenstorage/openstorage/api/api.proto
>>> Upgrading swagger 2.0 to openapi 3.0
mv api/server/sdk/api/api.swagger.json api/server/sdk/api/20api.swagger.json
swagger2openapi api/server/sdk/api/20api.swagger.json -o api/server/sdk/api/api.swagger.json
rm -f api/server/sdk/api/20api.swagger.json
>>> Generating grpc protobuf definitions from pkg/flexvolume/flexvolume.proto
protoc -I/usr/local/include -I/go/src/github.com/libopenstorage/openstorage -I/go/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --go_out=plugins=grpc:. /go/src/github.com/libopenstorage/openstorage/pkg/flexvolume/flexvolume.proto
protoc -I/usr/local/include -I/go/src/github.com/libopenstorage/openstorage -I/go/src/github.com/grpc-ecosystem/grpc-gateway/third_party/googleapis --grpc-gateway_out=logtostderr=true:. /go/src/github.com/libopenstorage/openstorage/pkg/flexvolume/flexvolume.proto
>>> Generating protobuf definitions from pkg/jsonpb/testing/testing.proto
protoc -I /go/src/github.com/libopenstorage/openstorage /go/src/github.com/libopenstorage/openstorage/pkg/jsonpb/testing/testing.proto --go_out=plugins=grpc:.
>>> Updating SDK versions
go run tools/sdkver/sdkver.go --swagger api/server/sdk/api/api.swagger.json
0.101.54
go get github.com/golang/mock/gomock
go get github.com/golang/mock/mockgen || echo "ignoring go get build error"
package io/fs: unrecognized import path "io/fs" (import path does not begin with hostname)
ignoring go get build error
cd /go/src/github.com/golang/mock/mockgen && git checkout v1.2.0 && go install github.com/golang/mock/mockgen
Note: checking out 'v1.2.0'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>

HEAD is now at 51421b9 mockgen: use Controller.Helper() in generated mocks
mockgen -destination=api/mock/mock_storagepool.go -package=mock github.com/libopenstorage/openstorage/api OpenStoragePoolServer,OpenStoragePoolClient
mockgen -destination=api/mock/mock_cluster.go -package=mock github.com/libopenstorage/openstorage/api OpenStorageClusterServer,OpenStorageClusterClient
mockgen -destination=api/mock/mock_node.go -package=mock github.com/libopenstorage/openstorage/api OpenStorageNodeServer,OpenStorageNodeClient
mockgen -destination=api/mock/mock_diags.go -package=mock github.com/libopenstorage/openstorage/api OpenStorageDiagsServer,OpenStorageDiagsClient
mockgen -destination=api/mock/mock_volume.go -package=mock github.com/libopenstorage/openstorage/api OpenStorageVolumeServer,OpenStorageVolumeClient
mockgen -destination=api/mock/mock_watch.go -package=mock github.com/libopenstorage/openstorage/api OpenStorageWatchServer,OpenStorageWatchClient,OpenStorageWatch_WatchClient,OpenStorageWatch_WatchServer
mockgen -destination=api/mock/mock_bucket.go -package=mock github.com/libopenstorage/openstorage/api OpenStorageBucketServer,OpenStorageBucketClient
mockgen -destination=cluster/mock/cluster.mock.go -package=mock github.com/libopenstorage/openstorage/cluster Cluster
mockgen -destination=cluster/mock/cluster_listener.mock.go -package=mock github.com/libopenstorage/openstorage/cluster ClusterListener
mockgen -destination=api/mock/mock_fstrim.go -package=mock github.com/libopenstorage/openstorage/api OpenStorageFilesystemTrimServer,OpenStorageFilesystemTrimClient
mockgen -destination=api/mock/mock_fscheck.go -package=mock github.com/libopenstorage/openstorage/api OpenStorageFilesystemCheckServer,OpenStorageFilesystemCheckClient
mockgen -destination=api/mock/mock_defrag.go -package=mock github.com/libopenstorage/openstorage/api OpenStorageFilesystemDefragServer,OpenStorageFilesystemDefragClient
mockgen -destination=api/server/mock/mock_schedops_k8s.go -package=mock github.com/portworx/sched-ops/k8s/core Ops
mockgen -destination=volume/drivers/mock/driver.mock.go -package=mock github.com/libopenstorage/openstorage/volume VolumeDriver
mockgen -destination=bucket/drivers/mock/bucket_driver.mock.go -package=mock github.com/libopenstorage/openstorage/bucket BucketDriver
make[1]: Leaving directory '/root/go/src/github.com/libopenstorage/openstorage'
git diff  | wc -l | grep "^0"
0
hack/check-api-version.sh
fatal: ambiguous argument 'release-9.0..HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
git grep -rw GPL vendor | grep LICENSE | egrep -v "yaml.v2" | wc -l | grep "^0"
0
hack/check-registered-rest.sh
+ cat api/api.pb.go
+ grep func Register.*
+ wc -l
+ registerFuncs=24
+ cat+ grep Register.*Handler,
+ wc -l
 api/server/sdk/rest_gateway.go
+ registered=24
+ [ 24 != 24 ]
+ echo All REST handlers are registered in api/server/sdk/rest_gateway.go.
All REST handlers are registered in api/server/sdk/rest_gateway.go.
```

make osd-tests docker-test
```
make osd-tests docker-test
packr2 clean
packr2
make[1]: Entering directory '/root/go/src/github.com/libopenstorage/openstorage/cmd/osd-sanity'
cp osd-sanity /root/go/bin
make[1]: Leaving directory '/root/go/src/github.com/libopenstorage/openstorage/cmd/osd-sanity'
go install -gcflags="all=-N -l" -tags "daemon" github.com/libopenstorage/openstorage/alert github.com/libopenstorage/openstorage/alerts github.com/libopenstorage/openstorage/alerts/mock github.com/libopenstorage/openstorage/api github.com/libopenstorage/openstorage/api/client github.com/libopenstorage/openstorage/api/client/cluster github.com/libopenstorage/openstorage/api/client/volume github.com/libopenstorage/openstorage/api/errors github.com/libopenstorage/openstorage/api/flexvolume github.com/libopenstorage/openstorage/api/mock github.com/libopenstorage/openstorage/api/server github.com/libopenstorage/openstorage/api/server/mock github.com/libopenstorage/openstorage/api/server/sdk github.com/libopenstorage/openstorage/api/spec github.com/libopenstorage/openstorage/bucket github.com/libopenstorage/openstorage/bucket/drivers/fake github.com/libopenstorage/openstorage/bucket/drivers/mock github.com/libopenstorage/openstorage/bucket/drivers/purefb github.com/libopenstorage/openstorage/bucket/drivers/s3 github.com/libopenstorage/openstorage/cli github.com/libopenstorage/openstorage/cluster github.com/libopenstorage/openstorage/cluster/manager github.com/libopenstorage/openstorage/cluster/mock github.com/libopenstorage/openstorage/cmd/osd github.com/libopenstorage/openstorage/cmd/osd-token-generator github.com/libopenstorage/openstorage/config github.com/libopenstorage/openstorage/csi github.com/libopenstorage/openstorage/csi/sched github.com/libopenstorage/openstorage/csi/sched/k8s github.com/libopenstorage/openstorage/csi/v0.3 github.com/libopenstorage/openstorage/csi/v0.3/spec github.com/libopenstorage/openstorage/graph github.com/libopenstorage/openstorage/graph/drivers github.com/libopenstorage/openstorage/graph/drivers/chainfs github.com/libopenstorage/openstorage/graph/drivers/layer0 github.com/libopenstorage/openstorage/graph/drivers/proxy github.com/libopenstorage/openstorage/objectstore github.com/libopenstorage/openstorage/osdconfig github.com/libopenstorage/openstorage/pkg/auth github.com/libopenstorage/openstorage/pkg/auth/secrets github.com/libopenstorage/openstorage/pkg/auth/systemtoken github.com/libopenstorage/openstorage/pkg/chaos github.com/libopenstorage/openstorage/pkg/chattr github.com/libopenstorage/openstorage/pkg/clusterdomain github.com/libopenstorage/openstorage/pkg/correlation github.com/libopenstorage/openstorage/pkg/dbg github.com/libopenstorage/openstorage/pkg/defaultcontext github.com/libopenstorage/openstorage/pkg/defrag github.com/libopenstorage/openstorage/pkg/device github.com/libopenstorage/openstorage/pkg/diags github.com/libopenstorage/openstorage/pkg/exec github.com/libopenstorage/openstorage/pkg/flexvolume github.com/libopenstorage/openstorage/pkg/flexvolume/cmd/flexvolume github.com/libopenstorage/openstorage/pkg/grpcserver github.com/libopenstorage/openstorage/pkg/grpcutil github.com/libopenstorage/openstorage/pkg/job github.com/libopenstorage/openstorage/pkg/jsonpb github.com/libopenstorage/openstorage/pkg/jsonpb/testing github.com/libopenstorage/openstorage/pkg/keylock github.com/libopenstorage/openstorage/pkg/loadbalancer github.com/libopenstorage/openstorage/pkg/loadbalancer/mock github.com/libopenstorage/openstorage/pkg/mount github.com/libopenstorage/openstorage/pkg/nodedrain github.com/libopenstorage/openstorage/pkg/options github.com/libopenstorage/openstorage/pkg/parser github.com/libopenstorage/openstorage/pkg/proto/time github.com/libopenstorage/openstorage/pkg/role github.com/libopenstorage/openstorage/pkg/sched github.com/libopenstorage/openstorage/pkg/schedule github.com/libopenstorage/openstorage/pkg/seed github.com/libopenstorage/openstorage/pkg/storagepolicy github.com/libopenstorage/openstorage/pkg/storagepool github.com/libopenstorage/openstorage/pkg/units github.com/libopenstorage/openstorage/pkg/util github.com/libopenstorage/openstorage/schedpolicy github.com/libopenstorage/openstorage/secrets github.com/libopenstorage/openstorage/tools/sdkver github.com/libopenstorage/openstorage/volume github.com/libopenstorage/openstorage/volume/drivers github.com/libopenstorage/openstorage/volume/drivers/btrfs github.com/libopenstorage/openstorage/volume/drivers/buse github.com/libopenstorage/openstorage/volume/drivers/common github.com/libopenstorage/openstorage/volume/drivers/fake github.com/libopenstorage/openstorage/volume/drivers/fuse github.com/libopenstorage/openstorage/volume/drivers/mock github.com/libopenstorage/openstorage/volume/drivers/nfs github.com/libopenstorage/openstorage/volume/drivers/pwx github.com/libopenstorage/openstorage/volume/drivers/test github.com/libopenstorage/openstorage/volume/drivers/vfs
go install github.com/libopenstorage/openstorage/cmd/osd-token-generator
./hack/csi-sanity-test.sh
+ jobs -l
+ sudo -E /root/go/bin/osd -d --driver=name=fake --sdkport 9106 --sdkrestport 9116
[1]+ 1887113 Running                 sudo -E $GOPATH/bin/osd -d --driver=name=fake --sdkport 9106 --sdkrestport 9116 &
+ go get -u github.com/kubernetes-csi/csi-test/...
INFO[0000] OSD enabling cluster mode.
INFO[0000] Starting REST service on socket : /var/lib/osd/cluster/osd.sock
INFO[0000] Starting volume driver: fake
INFO[0000] Fake driver initialized
INFO[0000] Starting REST service on socket : /run/docker/plugins/fake.sock
INFO[0000] Starting REST service on socket : /var/lib/osd/driver/fake.sock
INFO[0000] Starting REST service on port : 9001
INFO[0000] No CSI filter being added for  scheduler
INFO[0000] CSI 1.7 gRPC Server ready on /var/lib/osd/driver/fake-csi.sock
INFO[0000] Starting fake object storage driver on :8085
INFO[0000] Converting VolumeSpecs to SdkStoragePolicyObjects...
INFO[0000] SDK TLS disabled                              name=SDK-tcp
INFO[0000] SDK-tcp gRPC Server ready on 0.0.0.0:9106
INFO[0000] SDK TLS disabled                              name=SDK-unix
INFO[0000] SDK-unix gRPC Server ready on /var/lib/osd/driver/fake-sdk.sock
INFO[0000] SDK gRPC REST Gateway started on port :9116
INFO[0000] Cluster manager starting...
INFO[0000] initializing osdconfig manager
INFO[0000] Init gossip:  10.13.188.35:9002
INFO[0000] Cluster is uninitialized...
INFO[0000] Initializing a new cluster.
INFO[0000] Node 1 joining cluster...
INFO[0000] Cluster ID: openstorage.cluster
INFO[0000] Node Mgmt IP: 10.13.188.35
INFO[0000] Node Data IP: 10.13.188.35
INFO[0000] Node HWType: UnknownMachine
INFO[0000] Node SecurityStatus: UNSECURED
INFO[0000] This node participates in quorum decisions
INFO[0000] Cluster manager starting watch at version 9
INFO[0000] Waiting for the cluster to reach quorum...
INFO[0000] Starting Gossip...
+ sudo /root/go/bin/csi-sanity --csi.endpoint=/var/lib/osd/driver/fake-csi.sock
Running Suite: CSI Driver Test Suite - /root/go/src/github.com/libopenstorage/openstorage
=========================================================================================
Random Seed: 1727267616

Will run 91 of 92 specs
•Connecting to /var/lib/osd/driver/fake-sdk.sock
•INFO[0001] csi.CreateVolume request received. Volume: DeleteSnapshot-volume-1-F80BBE32-27370CFA  component=csi-driver correlation-id=b37e058c-9548-4fa2-bbfc-13aac794ff20 origin=csi-driver
INFO[0001] Round-robin connecting to node 10.13.188.35:9106  component=round-robin-balancer correlation-id=b37e058c-9548-4fa2-bbfc-13aac794ff20 origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=b37e058c-9548-4fa2-bbfc-13aac794ff20 origin=csi-driver
INFO[0001] Creating snap DeleteSnapshot-snapshot-1-F80BBE32-27370CFA for vol 6753f6fe-c651-4383-879a-2703403183bd
I0925 12:33:36.218954 1887513 resources.go:301] deleting snapshot ID 2f770102-1975-433f-b4ae-5d671e917399
INFO[0001] csi.NodeUnpublishVolume request received. VolumeID: 6753f6fe-c651-4383-879a-2703403183bd, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=fb1f8525-b73f-4c1a-bb43-f55040a61c55 origin=csi-driver
INFO[0001] CSI Volume 6753f6fe-c651-4383-879a-2703403183bd unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=fb1f8525-b73f-4c1a-bb43-f55040a61c55 origin=csi-driver
INFO[0001] csi.DeleteVolume request received. VolumeID: 6753f6fe-c651-4383-879a-2703403183bd  component=csi-driver correlation-id=4f3b8744-620e-4200-a97f-5afd04fcd138 origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=4f3b8744-620e-4200-a97f-5afd04fcd138 origin=csi-driver
•••INFO[0001] csi.NodePublishVolume request received. VolumeID: , TargetPath:   component=csi-driver correlation-id=8301a802-cfc1-4faa-ae45-a233297fcbb0 origin=csi-driver
•INFO[0001] csi.NodePublishVolume request received. VolumeID: fake-vol-id-ca21f59f-0, TargetPath:   component=csi-driver correlation-id=74dab592-038a-4aa4-8e51-991e1f263427 origin=csi-driver
•INFO[0001] csi.NodePublishVolume request received. VolumeID: fake-vol-id-fe7b7db9-3, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=7430752e-b243-469d-8dec-9576ed1962dd origin=csi-driver
•INFO[0001] csi.NodeUnpublishVolume request received. VolumeID: , TargetPath:   component=csi-driver correlation-id=d2098c77-e53d-4093-94d4-3b0b9a230e8b origin=csi-driver
•INFO[0001] csi.NodeUnpublishVolume request received. VolumeID: fake-vol-id-54803991-0, TargetPath:   component=csi-driver correlation-id=5652c72f-7afa-4abe-a81c-577ea0a21efe origin=csi-driver
•INFO[0001] csi.CreateVolume request received. Volume: sanity-node-unpublish-volume-F80BBE32-27370CFA  component=csi-driver correlation-id=69cb7a70-9d5c-4161-86b2-016062ed9990 origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=69cb7a70-9d5c-4161-86b2-016062ed9990 origin=csi-driver
INFO[0001] csi.NodePublishVolume request received. VolumeID: 7973e4e1-0ff6-43d4-b704-e5248be3894d, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=2af2bfe9-5093-48de-a761-f50575d4973b origin=csi-driver
INFO[0001] Volume 7973e4e1-0ff6-43d4-b704-e5248be3894d attached on node
INFO[0001] Volume 7973e4e1-0ff6-43d4-b704-e5248be3894d mounted on node
INFO[0001] CSI Volume 7973e4e1-0ff6-43d4-b704-e5248be3894d mounted on /tmp/csi-mount/target  component=csi-driver correlation-id=2af2bfe9-5093-48de-a761-f50575d4973b origin=csi-driver
INFO[0001] csi.NodeUnpublishVolume request received. VolumeID: 7973e4e1-0ff6-43d4-b704-e5248be3894d, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=d9669b9d-dd1c-472d-bc4d-d5ece2643614 origin=csi-driver
INFO[0001] CSI Volume 7973e4e1-0ff6-43d4-b704-e5248be3894d unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=d9669b9d-dd1c-472d-bc4d-d5ece2643614 origin=csi-driver
INFO[0001] csi.NodeUnpublishVolume request received. VolumeID: 7973e4e1-0ff6-43d4-b704-e5248be3894d, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=593f8427-a5b4-4a3f-9e1c-81296fceca78 origin=csi-driver
INFO[0001] CSI Volume 7973e4e1-0ff6-43d4-b704-e5248be3894d unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=593f8427-a5b4-4a3f-9e1c-81296fceca78 origin=csi-driver
INFO[0001] csi.DeleteVolume request received. VolumeID: 7973e4e1-0ff6-43d4-b704-e5248be3894d  component=csi-driver correlation-id=e96a7ab9-40c6-4867-b264-c78019ba5bb7 origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=e96a7ab9-40c6-4867-b264-c78019ba5bb7 origin=csi-driver
•SSSSS••INFO[0001] Volume fake-vol-id-5d23e773-7 cannot be found: Key not found  component=csi-driver correlation-id=0f2c2c49-64a6-4f52-a1ae-178f8e20352c origin=csi-driver
•INFO[0001] csi.CreateVolume request received. Volume: sanity-node-get-volume-stats-F80BBE32-27370CFA  component=csi-driver correlation-id=f4e65489-97a3-4f07-921a-c462e6cf0e71 origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=f4e65489-97a3-4f07-921a-c462e6cf0e71 origin=csi-driver
INFO[0001] csi.NodePublishVolume request received. VolumeID: 0f795f09-ecf1-4191-aaed-3f9952f9027d, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=e0d8bf98-54fe-4d08-b1ae-df0ee1aff009 origin=csi-driver
INFO[0001] Volume 0f795f09-ecf1-4191-aaed-3f9952f9027d attached on node
INFO[0001] Volume 0f795f09-ecf1-4191-aaed-3f9952f9027d mounted on node
INFO[0001] CSI Volume 0f795f09-ecf1-4191-aaed-3f9952f9027d mounted on /tmp/csi-mount/target  component=csi-driver correlation-id=e0d8bf98-54fe-4d08-b1ae-df0ee1aff009 origin=csi-driver
INFO[0001] csi.NodeUnpublishVolume request received. VolumeID: 0f795f09-ecf1-4191-aaed-3f9952f9027d, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=93a61ff3-37ca-4c87-b415-be750f4051d1 origin=csi-driver
INFO[0001] CSI Volume 0f795f09-ecf1-4191-aaed-3f9952f9027d unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=93a61ff3-37ca-4c87-b415-be750f4051d1 origin=csi-driver
INFO[0001] csi.DeleteVolume request received. VolumeID: 0f795f09-ecf1-4191-aaed-3f9952f9027d  component=csi-driver correlation-id=0182f3c6-568b-4df6-a47a-7989da425c42 origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=0182f3c6-568b-4df6-a47a-7989da425c42 origin=csi-driver
•SSSSINFO[0001] csi.CreateVolume request received. Volume: sanity-node-full-1-F80BBE32-27370CFA  component=csi-driver correlation-id=d71cc27e-30ff-4cd4-a023-6361aef9d4b0 origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=d71cc27e-30ff-4cd4-a023-6361aef9d4b0 origin=csi-driver
INFO[0001] csi.NodePublishVolume request received. VolumeID: a4c6c1fc-db1a-4722-85a5-ba3bd15298f1, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=a8da8e25-c5c7-4947-a34c-47bebe99a5e2 origin=csi-driver
INFO[0001] Volume a4c6c1fc-db1a-4722-85a5-ba3bd15298f1 attached on node
INFO[0001] Volume a4c6c1fc-db1a-4722-85a5-ba3bd15298f1 mounted on node
INFO[0001] CSI Volume a4c6c1fc-db1a-4722-85a5-ba3bd15298f1 mounted on /tmp/csi-mount/target  component=csi-driver correlation-id=a8da8e25-c5c7-4947-a34c-47bebe99a5e2 origin=csi-driver
INFO[0001] csi.NodeUnpublishVolume request received. VolumeID: a4c6c1fc-db1a-4722-85a5-ba3bd15298f1, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=bbbfd9ee-1e63-46ba-9954-77a86d3de467 origin=csi-driver
INFO[0001] CSI Volume a4c6c1fc-db1a-4722-85a5-ba3bd15298f1 unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=bbbfd9ee-1e63-46ba-9954-77a86d3de467 origin=csi-driver
INFO[0001] csi.DeleteVolume request received. VolumeID: a4c6c1fc-db1a-4722-85a5-ba3bd15298f1  component=csi-driver correlation-id=b27030c2-2347-47fb-a68e-bd9edfd9aabe origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=b27030c2-2347-47fb-a68e-bd9edfd9aabe origin=csi-driver
•INFO[0001] csi.CreateVolume request received. Volume: sanity-node-full-10-F80BBE32-27370CFA  component=csi-driver correlation-id=3b8bc579-7e3e-41f4-ba1d-5f32deae5e1b origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=3b8bc579-7e3e-41f4-ba1d-5f32deae5e1b origin=csi-driver
INFO[0001] csi.NodePublishVolume request received. VolumeID: 8e19978f-30ee-43f9-a461-6df5b0ffb4e5, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=bcb8a7fe-93b4-4e3a-afb0-a9f363d2dc36 origin=csi-driver
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 attached on node
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on node
INFO[0001] CSI Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on /tmp/csi-mount/target  component=csi-driver correlation-id=bcb8a7fe-93b4-4e3a-afb0-a9f363d2dc36 origin=csi-driver
INFO[0001] csi.NodePublishVolume request received. VolumeID: 8e19978f-30ee-43f9-a461-6df5b0ffb4e5, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=8dda1617-08f2-43d7-8935-5144c8b5f0b5 origin=csi-driver
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 attached on node
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on node
INFO[0001] CSI Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on /tmp/csi-mount/target  component=csi-driver correlation-id=8dda1617-08f2-43d7-8935-5144c8b5f0b5 origin=csi-driver
INFO[0001] csi.NodePublishVolume request received. VolumeID: 8e19978f-30ee-43f9-a461-6df5b0ffb4e5, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=5f4e3f99-82ab-44ef-8dc4-388f342f7cf4 origin=csi-driver
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 attached on node
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on node
INFO[0001] CSI Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on /tmp/csi-mount/target  component=csi-driver correlation-id=5f4e3f99-82ab-44ef-8dc4-388f342f7cf4 origin=csi-driver
INFO[0001] csi.NodePublishVolume request received. VolumeID: 8e19978f-30ee-43f9-a461-6df5b0ffb4e5, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=35a7c837-e77b-42d5-8969-6d49ac09cea6 origin=csi-driver
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 attached on node
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on node
INFO[0001] CSI Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on /tmp/csi-mount/target  component=csi-driver correlation-id=35a7c837-e77b-42d5-8969-6d49ac09cea6 origin=csi-driver
INFO[0001] csi.NodePublishVolume request received. VolumeID: 8e19978f-30ee-43f9-a461-6df5b0ffb4e5, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=d3869d81-6c01-4d86-a6a7-7a97f7655aaf origin=csi-driver
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 attached on node
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on node
INFO[0001] CSI Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on /tmp/csi-mount/target  component=csi-driver correlation-id=d3869d81-6c01-4d86-a6a7-7a97f7655aaf origin=csi-driver
INFO[0001] csi.NodePublishVolume request received. VolumeID: 8e19978f-30ee-43f9-a461-6df5b0ffb4e5, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=c684f9d6-8544-439d-bf9c-15b51c7ff59d origin=csi-driver
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 attached on node
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on node
INFO[0001] CSI Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on /tmp/csi-mount/target  component=csi-driver correlation-id=c684f9d6-8544-439d-bf9c-15b51c7ff59d origin=csi-driver
INFO[0001] csi.NodePublishVolume request received. VolumeID: 8e19978f-30ee-43f9-a461-6df5b0ffb4e5, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=32b0e67b-fefe-4579-b9b6-09f45b3e2e85 origin=csi-driver
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 attached on node
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on node
INFO[0001] CSI Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on /tmp/csi-mount/target  component=csi-driver correlation-id=32b0e67b-fefe-4579-b9b6-09f45b3e2e85 origin=csi-driver
INFO[0001] csi.NodePublishVolume request received. VolumeID: 8e19978f-30ee-43f9-a461-6df5b0ffb4e5, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=5f6e9ebb-c109-4c08-ac69-36ae2ef9eee0 origin=csi-driver
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 attached on node
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on node
INFO[0001] CSI Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on /tmp/csi-mount/target  component=csi-driver correlation-id=5f6e9ebb-c109-4c08-ac69-36ae2ef9eee0 origin=csi-driver
INFO[0001] csi.NodePublishVolume request received. VolumeID: 8e19978f-30ee-43f9-a461-6df5b0ffb4e5, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=0570a3e7-5348-4200-9d24-2ee4daef5305 origin=csi-driver
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 attached on node
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on node
INFO[0001] CSI Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on /tmp/csi-mount/target  component=csi-driver correlation-id=0570a3e7-5348-4200-9d24-2ee4daef5305 origin=csi-driver
INFO[0001] csi.NodePublishVolume request received. VolumeID: 8e19978f-30ee-43f9-a461-6df5b0ffb4e5, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=fb28ae1a-1bc0-42a9-a0b6-e44217eb89c1 origin=csi-driver
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 attached on node
INFO[0001] Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on node
INFO[0001] CSI Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 mounted on /tmp/csi-mount/target  component=csi-driver correlation-id=fb28ae1a-1bc0-42a9-a0b6-e44217eb89c1 origin=csi-driver
INFO[0001] csi.NodeUnpublishVolume request received. VolumeID: 8e19978f-30ee-43f9-a461-6df5b0ffb4e5, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=a15b71cc-2749-4054-b534-3d19331d5de4 origin=csi-driver
INFO[0001] CSI Volume 8e19978f-30ee-43f9-a461-6df5b0ffb4e5 unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=a15b71cc-2749-4054-b534-3d19331d5de4 origin=csi-driver
INFO[0001] csi.DeleteVolume request received. VolumeID: 8e19978f-30ee-43f9-a461-6df5b0ffb4e5  component=csi-driver correlation-id=04b415b7-c737-40a5-b184-c9f31dbd5b5a origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=04b415b7-c737-40a5-b184-c9f31dbd5b5a origin=csi-driver
•••INFO[0001] csi.CreateVolume request received. Volume: sanity-expand-volume-F80BBE32-27370CFA  component=csi-driver correlation-id=e1ae8a49-7f8e-4786-96b0-9147681dedd0 origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=e1ae8a49-7f8e-4786-96b0-9147681dedd0 origin=csi-driver
INFO[0001] csi.DeleteVolume request received. VolumeID: 034734d6-c6db-42ae-85b5-fd819ce272ba  component=csi-driver correlation-id=a0ce5f44-c385-4b1e-8ebb-a15f5fd214cd origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=a0ce5f44-c385-4b1e-8ebb-a15f5fd214cd origin=csi-driver
•••INFO[0001] csi.CreateVolume request received. Volume: CreateSnapshot-volume-1-F80BBE32-27370CFA  component=csi-driver correlation-id=123c126b-08fb-412f-a112-dacc10521b5e origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=123c126b-08fb-412f-a112-dacc10521b5e origin=csi-driver
INFO[0001] Creating snap CreateSnapshot-snapshot-1-F80BBE32-27370CFA for vol 50462fb4-43b5-47ee-9448-031a15a3fc96
I0925 12:33:36.353059 1887513 resources.go:301] deleting snapshot ID e6856420-43be-41fa-945a-da8c07fcf937
I0925 12:33:36.354179 1887513 resources.go:301] deleting snapshot ID e6856420-43be-41fa-945a-da8c07fcf937
INFO[0001] csi.NodeUnpublishVolume request received. VolumeID: 50462fb4-43b5-47ee-9448-031a15a3fc96, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=0426828c-c473-4452-91f0-7eb8be0cf282 origin=csi-driver
INFO[0001] CSI Volume 50462fb4-43b5-47ee-9448-031a15a3fc96 unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=0426828c-c473-4452-91f0-7eb8be0cf282 origin=csi-driver
INFO[0001] csi.DeleteVolume request received. VolumeID: 50462fb4-43b5-47ee-9448-031a15a3fc96  component=csi-driver correlation-id=95ed3e36-5d8b-49cb-9de4-e10386264e96 origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=95ed3e36-5d8b-49cb-9de4-e10386264e96 origin=csi-driver
•INFO[0001] csi.CreateVolume request received. Volume: CreateSnapshot-volume-2-F80BBE32-27370CFA  component=csi-driver correlation-id=b9e2d671-cf4a-4868-9a0c-7ee641359a5c origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=b9e2d671-cf4a-4868-9a0c-7ee641359a5c origin=csi-driver
INFO[0001] Creating snap CreateSnapshot-snapshot-2-F80BBE32-27370CFA for vol 8c837327-df78-48d1-bfc0-ace944ed929f
INFO[0001] csi.CreateVolume request received. Volume: CreateSnapshot-volume-3-F80BBE32-27370CFA  component=csi-driver correlation-id=76e1f950-0b09-43ef-aa38-7d41075f7846 origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=76e1f950-0b09-43ef-aa38-7d41075f7846 origin=csi-driver
INFO[0001] csi.NodeUnpublishVolume request received. VolumeID: c8dd1a37-a31c-43be-bd81-686959989094, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=acf5e0d3-94a2-42f5-8564-10583e9748c8 origin=csi-driver
INFO[0001] CSI Volume c8dd1a37-a31c-43be-bd81-686959989094 unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=acf5e0d3-94a2-42f5-8564-10583e9748c8 origin=csi-driver
INFO[0001] csi.DeleteVolume request received. VolumeID: c8dd1a37-a31c-43be-bd81-686959989094  component=csi-driver correlation-id=6f2a3020-eaa1-4809-a0ed-fe26079cda31 origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=6f2a3020-eaa1-4809-a0ed-fe26079cda31 origin=csi-driver
I0925 12:33:36.370770 1887513 resources.go:301] deleting snapshot ID d4209d20-163e-4c89-a11e-262620b49151
INFO[0001] csi.NodeUnpublishVolume request received. VolumeID: 8c837327-df78-48d1-bfc0-ace944ed929f, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=4d114e52-2be8-4bc2-bf9e-7aca85183a53 origin=csi-driver
INFO[0001] CSI Volume 8c837327-df78-48d1-bfc0-ace944ed929f unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=4d114e52-2be8-4bc2-bf9e-7aca85183a53 origin=csi-driver
INFO[0001] csi.DeleteVolume request received. VolumeID: 8c837327-df78-48d1-bfc0-ace944ed929f  component=csi-driver correlation-id=e7b3c2c2-d599-4c06-9e86-9ab48fe709a9 origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=e7b3c2c2-d599-4c06-9e86-9ab48fe709a9 origin=csi-driver
•INFO[0001] csi.CreateVolume request received. Volume: CreateSnapshot-volume-maxlen-name-F80BBE32-27370CFA  component=csi-driver correlation-id=e56332b2-9ea8-4566-8fed-4916acb39cc6 origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=e56332b2-9ea8-4566-8fed-4916acb39cc6 origin=csi-driver
INFO[0001] Creating snap CreateSnapshot-snapshot-maxlen-F80BBE32-27370CFAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa for vol 095abe9c-cfe0-4156-b1b6-fce0ab508329
I0925 12:33:36.381341 1887513 resources.go:301] deleting snapshot ID 758f9ea8-fb72-4d3a-b76b-f6df8b9b3ef2
I0925 12:33:36.382364 1887513 resources.go:301] deleting snapshot ID 758f9ea8-fb72-4d3a-b76b-f6df8b9b3ef2
INFO[0001] csi.NodeUnpublishVolume request received. VolumeID: 095abe9c-cfe0-4156-b1b6-fce0ab508329, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=b3ce998e-9ebc-4c4d-aa4b-9a13bc7f7474 origin=csi-driver
INFO[0001] CSI Volume 095abe9c-cfe0-4156-b1b6-fce0ab508329 unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=b3ce998e-9ebc-4c4d-aa4b-9a13bc7f7474 origin=csi-driver
INFO[0001] csi.DeleteVolume request received. VolumeID: 095abe9c-cfe0-4156-b1b6-fce0ab508329  component=csi-driver correlation-id=d5aab9c9-f129-4cbb-85af-0ca2ad3e0dc7 origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=d5aab9c9-f129-4cbb-85af-0ca2ad3e0dc7 origin=csi-driver
••SSSS
------------------------------
P [PENDING]
Controller Service [Controller Server] ListVolumes pagination should detect volumes added between pages and accept tokens when the last volume from a page is deleted
/root/go/src/github.com/kubernetes-csi/csi-test/pkg/sanity/controller.go:265
------------------------------
INFO[0001] csi.CreateVolume request received. Volume:    component=csi-driver correlation-id=6a93a96b-e567-44a1-a624-836d3f1b683d origin=csi-driver
•INFO[0001] csi.CreateVolume request received. Volume: sanity-controller-create-no-volume-capabilities-F80BBE32-27370CFA  component=csi-driver correlation-id=2ad740b7-6b86-4204-82ac-7ec69115a910 origin=csi-driver
•INFO[0001] csi.CreateVolume request received. Volume: sanity-controller-create-single-no-capacity-F80BBE32-27370CFA  component=csi-driver correlation-id=20b13494-bf68-428b-b7c0-7f81d44c19ec origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=20b13494-bf68-428b-b7c0-7f81d44c19ec origin=csi-driver
INFO[0001] csi.NodeUnpublishVolume request received. VolumeID: cf1097e5-42fc-4935-b669-da3e72242db1, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=faa3095b-93c0-448e-8879-27df85fd8757 origin=csi-driver
INFO[0001] CSI Volume cf1097e5-42fc-4935-b669-da3e72242db1 unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=faa3095b-93c0-448e-8879-27df85fd8757 origin=csi-driver
INFO[0001] csi.DeleteVolume request received. VolumeID: cf1097e5-42fc-4935-b669-da3e72242db1  component=csi-driver correlation-id=d79bc7fc-efb7-4dee-af67-d2e59a5003eb origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=d79bc7fc-efb7-4dee-af67-d2e59a5003eb origin=csi-driver
•INFO[0001] csi.CreateVolume request received. Volume: sanity-controller-create-single-with-capacity-F80BBE32-27370CFA  component=csi-driver correlation-id=3249c4eb-d072-49b1-8c13-f3ee7214987b origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=3249c4eb-d072-49b1-8c13-f3ee7214987b origin=csi-driver
INFO[0001] csi.NodeUnpublishVolume request received. VolumeID: d31c4cd5-9f46-46e9-93f1-3d1efff986bb, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=0c219e53-bfd8-4c05-ac5e-4e825ffbbdd1 origin=csi-driver
INFO[0001] CSI Volume d31c4cd5-9f46-46e9-93f1-3d1efff986bb unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=0c219e53-bfd8-4c05-ac5e-4e825ffbbdd1 origin=csi-driver
INFO[0001] csi.DeleteVolume request received. VolumeID: d31c4cd5-9f46-46e9-93f1-3d1efff986bb  component=csi-driver correlation-id=0341b6ff-e01a-428d-ab93-410403dcf7ee origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=0341b6ff-e01a-428d-ab93-410403dcf7ee origin=csi-driver
•INFO[0001] csi.CreateVolume request received. Volume: sanity-controller-create-twice-F80BBE32-27370CFA  component=csi-driver correlation-id=669dd902-fa81-467a-b5e0-67079ecd8e90 origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=669dd902-fa81-467a-b5e0-67079ecd8e90 origin=csi-driver
INFO[0001] csi.CreateVolume request received. Volume: sanity-controller-create-twice-F80BBE32-27370CFA  component=csi-driver correlation-id=beeceffa-e5ad-4ef4-bce6-2978c6488028 origin=csi-driver
INFO[0001] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=beeceffa-e5ad-4ef4-bce6-2978c6488028 origin=csi-driver
INFO[0001] Waiting for volume sanity-controller-create-twice-F80BBE32-27370CFA to become available
INFO[0002] Starting collector watch on  at 0
INFO[0002] Cluster db snapshot at: 13
INFO[0002] Stopping updates collector
INFO[0006] csi.NodeUnpublishVolume request received. VolumeID: 72009bc1-0ab9-45b1-acc9-eab67270d3b6, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=6ab4763a-67a1-4355-bcc5-e1b56995a35a origin=csi-driver
INFO[0006] CSI Volume 72009bc1-0ab9-45b1-acc9-eab67270d3b6 unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=6ab4763a-67a1-4355-bcc5-e1b56995a35a origin=csi-driver
INFO[0006] csi.DeleteVolume request received. VolumeID: 72009bc1-0ab9-45b1-acc9-eab67270d3b6  component=csi-driver correlation-id=7f1e40d5-9140-440b-ac91-df7c22bea981 origin=csi-driver
INFO[0006] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=7f1e40d5-9140-440b-ac91-df7c22bea981 origin=csi-driver
INFO[0006] csi.NodeUnpublishVolume request received. VolumeID: 72009bc1-0ab9-45b1-acc9-eab67270d3b6, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=45df0d66-36a0-45dc-a4e5-7637c0ff9e67 origin=csi-driver
INFO[0006] csi.DeleteVolume request received. VolumeID: 72009bc1-0ab9-45b1-acc9-eab67270d3b6  component=csi-driver correlation-id=5b754849-df89-4152-b24e-547b25ef8395 origin=csi-driver
INFO[0006] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=5b754849-df89-4152-b24e-547b25ef8395 origin=csi-driver
•INFO[0006] csi.CreateVolume request received. Volume: sanity-controller-create-twice-different-F80BBE32-27370CFA  component=csi-driver correlation-id=a0493cc3-dfd3-4be0-81be-f034b1e4fd26 origin=csi-driver
INFO[0006] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=a0493cc3-dfd3-4be0-81be-f034b1e4fd26 origin=csi-driver
INFO[0006] csi.CreateVolume request received. Volume: sanity-controller-create-twice-different-F80BBE32-27370CFA  component=csi-driver correlation-id=45411838-d9c1-471d-81ed-744d32625dd4 origin=csi-driver
INFO[0006] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=45411838-d9c1-471d-81ed-744d32625dd4 origin=csi-driver
INFO[0006] Waiting for volume sanity-controller-create-twice-different-F80BBE32-27370CFA to become available
INFO[0007] sending result 1497446197 with iteration 0
INFO[0011] csi.NodeUnpublishVolume request received. VolumeID: 4418c3e8-88f4-46be-808f-c222b425802b, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=6de58967-0277-45c8-b4cf-e02f90d58681 origin=csi-driver
INFO[0011] CSI Volume 4418c3e8-88f4-46be-808f-c222b425802b unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=6de58967-0277-45c8-b4cf-e02f90d58681 origin=csi-driver
INFO[0011] csi.DeleteVolume request received. VolumeID: 4418c3e8-88f4-46be-808f-c222b425802b  component=csi-driver correlation-id=47182c83-ccfe-49bd-a0b7-024c2c5d93b5 origin=csi-driver
INFO[0011] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=47182c83-ccfe-49bd-a0b7-024c2c5d93b5 origin=csi-driver
•INFO[0011] csi.CreateVolume request received. Volume: sanity-controller-create-maxlen-F80BBE32-27370CFAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  component=csi-driver correlation-id=2ccf58dc-f74e-4af0-8039-62c0c69b04b6 origin=csi-driver
INFO[0011] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=2ccf58dc-f74e-4af0-8039-62c0c69b04b6 origin=csi-driver
INFO[0011] csi.NodeUnpublishVolume request received. VolumeID: c4b79651-c481-4fbc-bf7b-06908dfadc43, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=bc435f1d-cd54-4deb-a5d5-2114cc345b3e origin=csi-driver
INFO[0011] CSI Volume c4b79651-c481-4fbc-bf7b-06908dfadc43 unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=bc435f1d-cd54-4deb-a5d5-2114cc345b3e origin=csi-driver
INFO[0011] csi.DeleteVolume request received. VolumeID: c4b79651-c481-4fbc-bf7b-06908dfadc43  component=csi-driver correlation-id=280e4656-0ce9-4217-a753-b0c322b1451e origin=csi-driver
INFO[0011] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=280e4656-0ce9-4217-a753-b0c322b1451e origin=csi-driver
•INFO[0011] csi.CreateVolume request received. Volume: sanity-controller-source-vol-F80BBE32-27370CFA  component=csi-driver correlation-id=483dbf55-f4e7-430a-be1e-b038e3838104 origin=csi-driver
INFO[0011] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=483dbf55-f4e7-430a-be1e-b038e3838104 origin=csi-driver
INFO[0011] Creating snap sanity-controller-snap-from-vol-F80BBE32-27370CFA for vol 2bacbb63-a048-43ba-8efc-d40c749a8d49
INFO[0011] csi.CreateVolume request received. Volume: sanity-controller-vol-from-snap-F80BBE32-27370CFA  component=csi-driver correlation-id=b2d25559-e33a-4572-9fa1-1be2283aeeb0 origin=csi-driver
INFO[0011] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=b2d25559-e33a-4572-9fa1-1be2283aeeb0 origin=csi-driver
INFO[0011] Creating snap sanity-controller-vol-from-snap-F80BBE32-27370CFA for vol ad4c16ce-1c51-4ce6-8961-1307f86568dd
INFO[0011] csi.NodeUnpublishVolume request received. VolumeID: c8784983-dd46-4cbb-b1d2-a558723c686c, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=025634cd-bf35-46e0-89f1-f97d154ccba3 origin=csi-driver
INFO[0011] CSI Volume c8784983-dd46-4cbb-b1d2-a558723c686c unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=025634cd-bf35-46e0-89f1-f97d154ccba3 origin=csi-driver
INFO[0011] csi.DeleteVolume request received. VolumeID: c8784983-dd46-4cbb-b1d2-a558723c686c  component=csi-driver correlation-id=7b610737-89da-4825-b15b-92bfe2aca036 origin=csi-driver
INFO[0011] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=7b610737-89da-4825-b15b-92bfe2aca036 origin=csi-driver
I0925 12:33:46.450153 1887513 resources.go:301] deleting snapshot ID ad4c16ce-1c51-4ce6-8961-1307f86568dd
INFO[0011] csi.NodeUnpublishVolume request received. VolumeID: 2bacbb63-a048-43ba-8efc-d40c749a8d49, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=b1e790a5-f602-43e5-a26e-b109b7c57b81 origin=csi-driver
INFO[0011] CSI Volume 2bacbb63-a048-43ba-8efc-d40c749a8d49 unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=b1e790a5-f602-43e5-a26e-b109b7c57b81 origin=csi-driver
INFO[0011] csi.DeleteVolume request received. VolumeID: 2bacbb63-a048-43ba-8efc-d40c749a8d49  component=csi-driver correlation-id=d4300da5-9e2b-4669-9bc8-e3500e921a7f origin=csi-driver
INFO[0011] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=d4300da5-9e2b-4669-9bc8-e3500e921a7f origin=csi-driver
•INFO[0011] csi.CreateVolume request received. Volume: sanity-controller-vol-from-snap-F80BBE32-27370CFA  component=csi-driver correlation-id=da6e1a77-1ffe-4683-84f5-89cd4d2c5018 origin=csi-driver
INFO[0011] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=da6e1a77-1ffe-4683-84f5-89cd4d2c5018 origin=csi-driver
•INFO[0011] csi.CreateVolume request received. Volume: sanity-controller-source-vol-F80BBE32-27370CFA  component=csi-driver correlation-id=b75e2994-4ce1-4767-a4a9-72bb30639f8b origin=csi-driver
INFO[0011] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=b75e2994-4ce1-4767-a4a9-72bb30639f8b origin=csi-driver
INFO[0011] csi.CreateVolume request received. Volume: sanity-controller-vol-from-vol-F80BBE32-27370CFA  component=csi-driver correlation-id=e68417f9-4dc0-4eec-804a-06f265c3cec3 origin=csi-driver
INFO[0011] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=e68417f9-4dc0-4eec-804a-06f265c3cec3 origin=csi-driver
INFO[0011] Creating snap sanity-controller-vol-from-vol-F80BBE32-27370CFA for vol 233ebe93-8ca5-4405-b22f-1ba9403b6af4
INFO[0011] csi.NodeUnpublishVolume request received. VolumeID: 732dd27d-43a9-4d0f-9b89-5c418224d88a, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=6a3a201e-acda-4a52-8891-d91be2b03c49 origin=csi-driver
INFO[0011] CSI Volume 732dd27d-43a9-4d0f-9b89-5c418224d88a unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=6a3a201e-acda-4a52-8891-d91be2b03c49 origin=csi-driver
INFO[0011] csi.DeleteVolume request received. VolumeID: 732dd27d-43a9-4d0f-9b89-5c418224d88a  component=csi-driver correlation-id=8cdabab4-51f6-4ce0-9d2e-709e613ce7f8 origin=csi-driver
INFO[0011] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=8cdabab4-51f6-4ce0-9d2e-709e613ce7f8 origin=csi-driver
INFO[0011] csi.NodeUnpublishVolume request received. VolumeID: 233ebe93-8ca5-4405-b22f-1ba9403b6af4, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=a78ea9db-461e-4f53-95dc-e0326d1a589d origin=csi-driver
INFO[0011] CSI Volume 233ebe93-8ca5-4405-b22f-1ba9403b6af4 unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=a78ea9db-461e-4f53-95dc-e0326d1a589d origin=csi-driver
INFO[0011] csi.DeleteVolume request received. VolumeID: 233ebe93-8ca5-4405-b22f-1ba9403b6af4  component=csi-driver correlation-id=d944fcd8-f201-4c35-950c-617ddc47d55d origin=csi-driver
INFO[0011] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=d944fcd8-f201-4c35-950c-617ddc47d55d origin=csi-driver
•INFO[0011] csi.CreateVolume request received. Volume: sanity-controller-vol-from-snap-F80BBE32-27370CFA  component=csi-driver correlation-id=09105086-827a-46ac-841f-55f5074af543 origin=csi-driver
INFO[0011] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=09105086-827a-46ac-841f-55f5074af543 origin=csi-driver
•SSINFO[0011] csi.DeleteVolume request received. VolumeID:   component=csi-driver correlation-id=c1f55431-f466-449e-a1e0-a501648a5d19 origin=csi-driver
•INFO[0011] csi.DeleteVolume request received. VolumeID: fake-vol-id  component=csi-driver correlation-id=8ea61744-81da-4156-b999-f81ae653191e origin=csi-driver
INFO[0011] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=8ea61744-81da-4156-b999-f81ae653191e origin=csi-driver
•INFO[0012] csi.CreateVolume request received. Volume: sanity-controller-create-appropriate-F80BBE32-27370CFA  component=csi-driver correlation-id=f2b2c6e7-8031-4437-bf1f-b1dcfa9b800b origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=f2b2c6e7-8031-4437-bf1f-b1dcfa9b800b origin=csi-driver
INFO[0012] csi.DeleteVolume request received. VolumeID: 48670750-fa43-4ef6-846c-298f27743d9d  component=csi-driver correlation-id=e4f7a62d-2747-4ed4-858c-d87ec9672f0a origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=e4f7a62d-2747-4ed4-858c-d87ec9672f0a origin=csi-driver
••INFO[0012] csi.CreateVolume request received. Volume: sanity-controller-validate-nocaps-F80BBE32-27370CFA  component=csi-driver correlation-id=02b8c1e1-deb7-47a8-9d17-525cb653e7b0 origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=02b8c1e1-deb7-47a8-9d17-525cb653e7b0 origin=csi-driver
INFO[0012] csi.NodeUnpublishVolume request received. VolumeID: e8b06454-ca7f-4140-9957-1459f95992db, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=28abd98c-03f8-4430-803a-a2b902cabbc9 origin=csi-driver
INFO[0012] CSI Volume e8b06454-ca7f-4140-9957-1459f95992db unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=28abd98c-03f8-4430-803a-a2b902cabbc9 origin=csi-driver
INFO[0012] csi.DeleteVolume request received. VolumeID: e8b06454-ca7f-4140-9957-1459f95992db  component=csi-driver correlation-id=a6648836-0268-4b22-baad-8995f9f551d5 origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=a6648836-0268-4b22-baad-8995f9f551d5 origin=csi-driver
•INFO[0012] csi.CreateVolume request received. Volume: sanity-controller-validate-F80BBE32-27370CFA  component=csi-driver correlation-id=2acf4b74-81cb-4886-9d7c-ea22f89d14dd origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=2acf4b74-81cb-4886-9d7c-ea22f89d14dd origin=csi-driver
INFO[0012] csi.ValidateVolumeCapabilities of id 4e5a61ba-e4f7-480e-878b-3f2b947953a0 capabilities []*csi.VolumeCapability{(*csi.VolumeCapability)(0xc0006391c0)}   component=csi-driver correlation-id=cda38dd9-f3f0-4f6b-bdbf-6823340039fa origin=csi-driver
INFO[0012] csi.NodeUnpublishVolume request received. VolumeID: 4e5a61ba-e4f7-480e-878b-3f2b947953a0, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=7ea2a8f7-6599-4429-9001-29218238cb5a origin=csi-driver
INFO[0012] CSI Volume 4e5a61ba-e4f7-480e-878b-3f2b947953a0 unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=7ea2a8f7-6599-4429-9001-29218238cb5a origin=csi-driver
INFO[0012] csi.DeleteVolume request received. VolumeID: 4e5a61ba-e4f7-480e-878b-3f2b947953a0  component=csi-driver correlation-id=ed3925ea-0a4c-4c32-9543-12b70dcfede7 origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=ed3925ea-0a4c-4c32-9543-12b70dcfede7 origin=csi-driver
•INFO[0012] csi.ValidateVolumeCapabilities of id fake-vol-id-9251c411-7 capabilities []*csi.VolumeCapability{(*csi.VolumeCapability)(0xc0005d9a40)}   component=csi-driver correlation-id=fa0725f5-6157-41ee-a23a-43f030b52810 origin=csi-driver
•SSSSSSSSSSINFO[0012] ListSnapshots for multiple snapshots received. sourceVolumeId: , startingToken: , maxEntries: 0  component=csi-driver correlation-id=0cd29535-30b3-43b4-9e27-11c1caaa99ee origin=csi-driver
•INFO[0012] csi.CreateVolume request received. Volume: listSnapshots-volume-unrelated-s-1-F80BBE32-27370CFA  component=csi-driver correlation-id=456e6eea-9400-4210-ad65-2b5d9a05d7ec origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=456e6eea-9400-4210-ad65-2b5d9a05d7ec origin=csi-driver
INFO[0012] sending result 1810709278 with iteration 1
INFO[0012] Creating snap listSnapshots-snapshot-unrelated-s-1-F80BBE32-27370CFA for vol 5870308c-2347-4255-961c-514bc757ceca
INFO[0012] csi.CreateVolume request received. Volume: listSnapshots-volume-target-s-F80BBE32-27370CFA  component=csi-driver correlation-id=09e3ed01-e43e-4c65-a4b1-bf667c2ffde7 origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=09e3ed01-e43e-4c65-a4b1-bf667c2ffde7 origin=csi-driver
INFO[0012] Creating snap listSnapshots-snapshot-target-s-F80BBE32-27370CFA for vol 1fdf60e0-150a-4a02-98d5-594bed3b5cbe
INFO[0012] csi.CreateVolume request received. Volume: listSnapshots-volume-unrelated-s-2-F80BBE32-27370CFA  component=csi-driver correlation-id=7174d8e9-df4e-4fa4-8e9a-faf23f279295 origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=7174d8e9-df4e-4fa4-8e9a-faf23f279295 origin=csi-driver
INFO[0012] Creating snap listSnapshots-snapshot-unrelated-s-2-F80BBE32-27370CFA for vol e79ea49d-a66c-480f-abe5-2ee0fce41b2f
INFO[0012] ListSnapshots for a single snapshot df40c8c1-7408-4c61-b71a-c494a64cf989 received  component=csi-driver correlation-id=0771ff98-ffed-412c-9e61-8040894b76ad origin=csi-driver
I0925 12:33:46.531192 1887513 resources.go:301] deleting snapshot ID fac8f680-ee76-442c-8a71-49fbe54dfeb8
INFO[0012] csi.NodeUnpublishVolume request received. VolumeID: e79ea49d-a66c-480f-abe5-2ee0fce41b2f, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=abfa4464-d3e3-458e-a1b1-e12cc78e1c78 origin=csi-driver
INFO[0012] CSI Volume e79ea49d-a66c-480f-abe5-2ee0fce41b2f unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=abfa4464-d3e3-458e-a1b1-e12cc78e1c78 origin=csi-driver
INFO[0012] csi.DeleteVolume request received. VolumeID: e79ea49d-a66c-480f-abe5-2ee0fce41b2f  component=csi-driver correlation-id=35c9e149-e6b3-4090-ba09-69d52e699572 origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=35c9e149-e6b3-4090-ba09-69d52e699572 origin=csi-driver
I0925 12:33:46.536455 1887513 resources.go:301] deleting snapshot ID df40c8c1-7408-4c61-b71a-c494a64cf989
INFO[0012] csi.NodeUnpublishVolume request received. VolumeID: 1fdf60e0-150a-4a02-98d5-594bed3b5cbe, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=317d632a-df4d-4a09-9628-970bcf370c0d origin=csi-driver
INFO[0012] CSI Volume 1fdf60e0-150a-4a02-98d5-594bed3b5cbe unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=317d632a-df4d-4a09-9628-970bcf370c0d origin=csi-driver
INFO[0012] csi.DeleteVolume request received. VolumeID: 1fdf60e0-150a-4a02-98d5-594bed3b5cbe  component=csi-driver correlation-id=55a749b7-7347-44ff-ae70-ffe9e6973946 origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=55a749b7-7347-44ff-ae70-ffe9e6973946 origin=csi-driver
I0925 12:33:46.541104 1887513 resources.go:301] deleting snapshot ID 19a8f72b-06dc-4880-b196-34cfaed9973d
INFO[0012] csi.NodeUnpublishVolume request received. VolumeID: 5870308c-2347-4255-961c-514bc757ceca, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=4235b509-c332-4b9d-868f-98ae927a70a3 origin=csi-driver
INFO[0012] CSI Volume 5870308c-2347-4255-961c-514bc757ceca unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=4235b509-c332-4b9d-868f-98ae927a70a3 origin=csi-driver
INFO[0012] csi.DeleteVolume request received. VolumeID: 5870308c-2347-4255-961c-514bc757ceca  component=csi-driver correlation-id=1034c3fd-0bc7-446c-a417-ffb61db81d82 origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=1034c3fd-0bc7-446c-a417-ffb61db81d82 origin=csi-driver
•INFO[0012] ListSnapshots for a single snapshot none-exist-id received  component=csi-driver correlation-id=17a3abb5-880b-42ae-bb26-43f099194522 origin=csi-driver
•INFO[0012] csi.CreateVolume request received. Volume: listSnapshots-volume-unrelated-v-1-F80BBE32-27370CFA  component=csi-driver correlation-id=59b3a8e7-baf1-4b36-a193-5a25605671df origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=59b3a8e7-baf1-4b36-a193-5a25605671df origin=csi-driver
INFO[0012] Creating snap listSnapshots-snapshot-unrelated-v-1-F80BBE32-27370CFA for vol b1b76e2f-2d08-42e0-9f17-1a7adfc25d2f
INFO[0012] csi.CreateVolume request received. Volume: listSnapshots-volume-target-v-F80BBE32-27370CFA  component=csi-driver correlation-id=af98d0d4-ae7c-49a8-b961-97338e601b5c origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=af98d0d4-ae7c-49a8-b961-97338e601b5c origin=csi-driver
INFO[0012] Creating snap listSnapshots-snapshot-target-v-F80BBE32-27370CFA for vol 20277cb1-04ae-4561-b075-0a585e1c9ca7
INFO[0012] csi.CreateVolume request received. Volume: listSnapshots-volume-unrelated-v-2-F80BBE32-27370CFA  component=csi-driver correlation-id=95328f91-60ec-4d66-9d52-c9c90d1ac1fb origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=95328f91-60ec-4d66-9d52-c9c90d1ac1fb origin=csi-driver
INFO[0012] Creating snap listSnapshots-snapshot-unrelated-v-2-F80BBE32-27370CFA for vol 3aa38e03-07fa-4a24-a376-e808bce463c2
INFO[0012] ListSnapshots for multiple snapshots received. sourceVolumeId: 20277cb1-04ae-4561-b075-0a585e1c9ca7, startingToken: , maxEntries: 0  component=csi-driver correlation-id=b6ff1fe6-ae48-4896-b8bb-7ac3de65de63 origin=csi-driver
I0925 12:33:46.565777 1887513 resources.go:301] deleting snapshot ID 5309d290-308c-43cc-81cc-50794057d38d
INFO[0012] csi.NodeUnpublishVolume request received. VolumeID: 3aa38e03-07fa-4a24-a376-e808bce463c2, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=ccd4300a-5116-4c6b-8141-cbfb2521e848 origin=csi-driver
INFO[0012] CSI Volume 3aa38e03-07fa-4a24-a376-e808bce463c2 unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=ccd4300a-5116-4c6b-8141-cbfb2521e848 origin=csi-driver
INFO[0012] csi.DeleteVolume request received. VolumeID: 3aa38e03-07fa-4a24-a376-e808bce463c2  component=csi-driver correlation-id=70ed69de-da33-4ab7-9b78-c78ad07af300 origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=70ed69de-da33-4ab7-9b78-c78ad07af300 origin=csi-driver
I0925 12:33:46.572360 1887513 resources.go:301] deleting snapshot ID ceed7c4e-25ec-4bfe-a66c-b62c775d7594
INFO[0012] csi.NodeUnpublishVolume request received. VolumeID: 20277cb1-04ae-4561-b075-0a585e1c9ca7, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=bd6715e6-fd48-4ed1-840c-d73fd94610f0 origin=csi-driver
INFO[0012] CSI Volume 20277cb1-04ae-4561-b075-0a585e1c9ca7 unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=bd6715e6-fd48-4ed1-840c-d73fd94610f0 origin=csi-driver
INFO[0012] csi.DeleteVolume request received. VolumeID: 20277cb1-04ae-4561-b075-0a585e1c9ca7  component=csi-driver correlation-id=bf9ff0f6-84d6-4efb-9a18-a83f6004fed6 origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=bf9ff0f6-84d6-4efb-9a18-a83f6004fed6 origin=csi-driver
I0925 12:33:46.576966 1887513 resources.go:301] deleting snapshot ID d44e7156-262e-4aa8-985d-8edc699bc870
INFO[0012] csi.NodeUnpublishVolume request received. VolumeID: b1b76e2f-2d08-42e0-9f17-1a7adfc25d2f, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=08f8ea07-c7af-4bce-964b-504539016769 origin=csi-driver
INFO[0012] CSI Volume b1b76e2f-2d08-42e0-9f17-1a7adfc25d2f unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=08f8ea07-c7af-4bce-964b-504539016769 origin=csi-driver
INFO[0012] csi.DeleteVolume request received. VolumeID: b1b76e2f-2d08-42e0-9f17-1a7adfc25d2f  component=csi-driver correlation-id=77863750-4963-4c2d-bd4a-6bd0c9132ab8 origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=77863750-4963-4c2d-bd4a-6bd0c9132ab8 origin=csi-driver
•INFO[0012] ListSnapshots for multiple snapshots received. sourceVolumeId: fake-vol-id-2db54e13-5, startingToken: , maxEntries: 0  component=csi-driver correlation-id=930966e2-06de-48b1-b608-27885ac4604d origin=csi-driver
•INFO[0012] ListSnapshots for multiple snapshots received. sourceVolumeId: , startingToken: , maxEntries: 0  component=csi-driver correlation-id=7a73938c-db50-4585-9e4c-ca36815f92d6 origin=csi-driver
INFO[0012] csi.CreateVolume request received. Volume: listSnapshots-volume-3-F80BBE32-27370CFA  component=csi-driver correlation-id=290ef41b-5a54-4c77-a918-2009c48dc345 origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=290ef41b-5a54-4c77-a918-2009c48dc345 origin=csi-driver
INFO[0012] Creating snap listSnapshots-snapshot-3-F80BBE32-27370CFA for vol 52c750ca-d9d3-402e-8755-915931875021
INFO[0012] ListSnapshots for multiple snapshots received. sourceVolumeId: , startingToken: , maxEntries: 0  component=csi-driver correlation-id=41299b3b-b2d7-4f1f-b05f-f1a16643ab53 origin=csi-driver
INFO[0012] ListSnapshots for multiple snapshots received. sourceVolumeId: , startingToken: , maxEntries: 0  component=csi-driver correlation-id=664cdd3e-4449-4182-8568-c851194b74ca origin=csi-driver
INFO[0012] csi.NodeUnpublishVolume request received. VolumeID: 52c750ca-d9d3-402e-8755-915931875021, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=a71df581-65cf-4854-b948-d0305b3c2d0f origin=csi-driver
INFO[0012] CSI Volume 52c750ca-d9d3-402e-8755-915931875021 unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=a71df581-65cf-4854-b948-d0305b3c2d0f origin=csi-driver
INFO[0012] csi.DeleteVolume request received. VolumeID: 52c750ca-d9d3-402e-8755-915931875021  component=csi-driver correlation-id=6a68c546-9761-4701-96b1-1c5871a1df2c origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=6a68c546-9761-4701-96b1-1c5871a1df2c origin=csi-driver
•INFO[0012] ListSnapshots for multiple snapshots received. sourceVolumeId: , startingToken: , maxEntries: 0  component=csi-driver correlation-id=0a5bec04-ac86-4428-92c9-56800e330efb origin=csi-driver
INFO[0012] csi.CreateVolume request received. Volume: volume1-F80BBE32-27370CFA  component=csi-driver correlation-id=68b2c627-5502-4a2b-bb36-3bca459af573 origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=68b2c627-5502-4a2b-bb36-3bca459af573 origin=csi-driver
INFO[0012] Creating snap snapshot1-F80BBE32-27370CFA for vol a10824c7-cca7-4460-a845-85990b939e71
INFO[0012] csi.CreateVolume request received. Volume: volume2-F80BBE32-27370CFA  component=csi-driver correlation-id=dcee5e23-50f6-47ea-baed-70b7877f982c origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=dcee5e23-50f6-47ea-baed-70b7877f982c origin=csi-driver
INFO[0012] Creating snap snapshot2-F80BBE32-27370CFA for vol bd97c09d-e3c9-44e4-98a8-ffad7fda3070
INFO[0012] csi.CreateVolume request received. Volume: volume3-F80BBE32-27370CFA  component=csi-driver correlation-id=27e87ca7-6dfc-4793-b4d2-bde3943f1dcf origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=27e87ca7-6dfc-4793-b4d2-bde3943f1dcf origin=csi-driver
INFO[0012] Creating snap snapshot3-F80BBE32-27370CFA for vol df121356-816f-44b7-9a04-754a207c677a
INFO[0012] csi.CreateVolume request received. Volume: volume4-F80BBE32-27370CFA  component=csi-driver correlation-id=a027f788-5b48-4b1f-8c9c-1068e5fa9a0b origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=a027f788-5b48-4b1f-8c9c-1068e5fa9a0b origin=csi-driver
INFO[0012] Creating snap snapshot4-F80BBE32-27370CFA for vol db8a1a91-5a73-418f-97ea-7d2070e5ffdd
INFO[0012] csi.CreateVolume request received. Volume: volume5-F80BBE32-27370CFA  component=csi-driver correlation-id=3e7af8b9-163b-4eb4-ac42-75ef89924b06 origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=3e7af8b9-163b-4eb4-ac42-75ef89924b06 origin=csi-driver
INFO[0012] Creating snap snapshot5-F80BBE32-27370CFA for vol ec5fe0c5-0df1-45d9-82f7-07e4860cdfe6
INFO[0012] ListSnapshots for multiple snapshots received. sourceVolumeId: , startingToken: , maxEntries: 2  component=csi-driver correlation-id=b38d3a55-1aa9-43ea-8edf-52446dfcb7e1 origin=csi-driver
INFO[0012] ListSnapshots for multiple snapshots received. sourceVolumeId: , startingToken: 2e53038b-2fc9-4399-bec3-30dcc1f86a68, maxEntries: 0  component=csi-driver correlation-id=4cd9991e-66c8-41c3-98e4-4f1b80852c3c origin=csi-driver
I0925 12:33:46.635583 1887513 resources.go:301] deleting snapshot ID 08eab3c5-9559-464a-859e-b962653fbeec
INFO[0012] csi.NodeUnpublishVolume request received. VolumeID: ec5fe0c5-0df1-45d9-82f7-07e4860cdfe6, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=e66adee3-0dcf-4a1f-b461-7668df963fb7 origin=csi-driver
INFO[0012] CSI Volume ec5fe0c5-0df1-45d9-82f7-07e4860cdfe6 unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=e66adee3-0dcf-4a1f-b461-7668df963fb7 origin=csi-driver
INFO[0012] csi.DeleteVolume request received. VolumeID: ec5fe0c5-0df1-45d9-82f7-07e4860cdfe6  component=csi-driver correlation-id=a3b7c374-e2eb-4645-b3ef-d559d0fcbefc origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=a3b7c374-e2eb-4645-b3ef-d559d0fcbefc origin=csi-driver
I0925 12:33:46.644363 1887513 resources.go:301] deleting snapshot ID 131d2ee0-616d-47ad-99aa-3b623166527b
INFO[0012] csi.NodeUnpublishVolume request received. VolumeID: db8a1a91-5a73-418f-97ea-7d2070e5ffdd, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=95e2abaa-6fd4-49e6-bb6e-9524c675fdad origin=csi-driver
INFO[0012] CSI Volume db8a1a91-5a73-418f-97ea-7d2070e5ffdd unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=95e2abaa-6fd4-49e6-bb6e-9524c675fdad origin=csi-driver
INFO[0012] csi.DeleteVolume request received. VolumeID: db8a1a91-5a73-418f-97ea-7d2070e5ffdd  component=csi-driver correlation-id=912755b6-65c9-40e3-8499-6641643fb0d0 origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=912755b6-65c9-40e3-8499-6641643fb0d0 origin=csi-driver
I0925 12:33:46.650709 1887513 resources.go:301] deleting snapshot ID 54bae8b9-d3eb-41ca-82f6-9086285fe5ec
INFO[0012] csi.NodeUnpublishVolume request received. VolumeID: df121356-816f-44b7-9a04-754a207c677a, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=91ba4cdc-8ea9-4d8e-9b0b-8a3d8078622d origin=csi-driver
INFO[0012] CSI Volume df121356-816f-44b7-9a04-754a207c677a unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=91ba4cdc-8ea9-4d8e-9b0b-8a3d8078622d origin=csi-driver
INFO[0012] csi.DeleteVolume request received. VolumeID: df121356-816f-44b7-9a04-754a207c677a  component=csi-driver correlation-id=309ad507-9379-4244-9571-248439b81d52 origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=309ad507-9379-4244-9571-248439b81d52 origin=csi-driver
I0925 12:33:46.657187 1887513 resources.go:301] deleting snapshot ID 2e53038b-2fc9-4399-bec3-30dcc1f86a68
INFO[0012] csi.NodeUnpublishVolume request received. VolumeID: bd97c09d-e3c9-44e4-98a8-ffad7fda3070, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=085e218d-40d2-42cc-afaa-62e3d99aab9e origin=csi-driver
INFO[0012] CSI Volume bd97c09d-e3c9-44e4-98a8-ffad7fda3070 unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=085e218d-40d2-42cc-afaa-62e3d99aab9e origin=csi-driver
INFO[0012] csi.DeleteVolume request received. VolumeID: bd97c09d-e3c9-44e4-98a8-ffad7fda3070  component=csi-driver correlation-id=03093798-d979-4566-b0da-1bcdf9eb2627 origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=03093798-d979-4566-b0da-1bcdf9eb2627 origin=csi-driver
I0925 12:33:46.662044 1887513 resources.go:301] deleting snapshot ID f1d299ea-6060-4c38-92b5-a813f501f7b7
INFO[0012] csi.NodeUnpublishVolume request received. VolumeID: a10824c7-cca7-4460-a845-85990b939e71, TargetPath: /tmp/csi-mount/target  component=csi-driver correlation-id=04932c17-52fc-468c-9d13-d641b7221f96 origin=csi-driver
INFO[0012] CSI Volume a10824c7-cca7-4460-a845-85990b939e71 unmounted from path /tmp/csi-mount/target  component=csi-driver correlation-id=04932c17-52fc-468c-9d13-d641b7221f96 origin=csi-driver
INFO[0012] csi.DeleteVolume request received. VolumeID: a10824c7-cca7-4460-a845-85990b939e71  component=csi-driver correlation-id=578fcd68-c579-4419-b985-e05ca36eab72 origin=csi-driver
INFO[0012] Using remote connection to SDK node 10.13.188.35:9106  component=round-robin-balancer correlation-id=578fcd68-c579-4419-b985-e05ca36eab72 origin=csi-driver
•SSSSSS•••SSSSSS

Ran 54 of 92 Specs in 10.481 seconds
SUCCESS! -- 54 Passed | 0 Failed | 1 Pending | 37 Skipped
+ assert_success
+ '[' 0 -ne 0 ']'
+ echo 'CSI sanity tests passed, cleaning up!'
CSI sanity tests passed, cleaning up!
+ cleanup
+ sudo pkill -15 -f /root/go/bin/osd
./hack/docker-integration-test.sh
++ /root/go/bin/osd-token-generator --auth-config=hack/sdk-auth-sample.yml --shared-secret=testsecret
+ token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4
+ jobs -l
+ sudo -E /root/go/bin/osd -d --driver=name=fake --sdkport 9106 --jwt-shared-secret=testsecret --jwt-system-shared-secret=testsecret --sdkrestport 9116
[1]+ 1887575 Running                 sudo -E $GOPATH/bin/osd -d --driver=name=fake --sdkport 9106 --jwt-shared-secret=testsecret --jwt-system-shared-secret=testsecret --sdkrestport 9116 &
+ timeout 30 sh -c 'until curl --silent -H "Authorization:bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4" -X GET -d {} http://localhost:9116/v1/clusters/inspectcurrent | grep STATUS_OK; do sleep 1; done'
INFO[0000] OSD enabling cluster mode.
INFO[0000] Starting REST service on socket : /var/lib/osd/cluster/osd.sock
INFO[0000] Starting volume driver: fake
INFO[0000] Fake driver initialized
INFO[0000] Starting REST service on socket : /run/docker/plugins/fake.sock
INFO[0000] Starting REST service on socket : /var/lib/osd/driver/fake.sock
INFO[0000] Starting REST service on port : 9001
INFO[0000] No CSI filter being added for  scheduler
INFO[0000] CSI 1.7 gRPC Server ready on /var/lib/osd/driver/fake-csi.sock
INFO[0000] Converting VolumeSpecs to SdkStoragePolicyObjects...
INFO[0000] Starting fake object storage driver on :8085
INFO[0000] Authentication enabled for issuer: openstorage.io  name=SDK-tcp
INFO[0000] Authentication enabled for issuer: openstorage.io  name=SDK-unix
INFO[0000] SDK TLS disabled                              name=SDK-tcp
INFO[0000] SDK-tcp gRPC Server ready on 0.0.0.0:9106
INFO[0000] SDK TLS disabled                              name=SDK-unix
INFO[0000] SDK-unix gRPC Server ready on /var/lib/osd/driver/fake-sdk.sock
INFO[0000] SDK gRPC REST Gateway started on port :9116
INFO[0000] Cluster manager starting...
INFO[0000] initializing osdconfig manager
INFO[0000] Init gossip:  10.13.188.35:9002
INFO[0000] Cluster is uninitialized...
INFO[0000] Initializing a new cluster.
INFO[0000] Node 1 joining cluster...
INFO[0000] Cluster ID: openstorage.cluster
INFO[0000] Node Mgmt IP: 10.13.188.35
INFO[0000] Node Data IP: 10.13.188.35
INFO[0000] Node HWType: UnknownMachine
INFO[0000] Node SecurityStatus: SECURED
INFO[0000] This node participates in quorum decisions
INFO[0000] Cluster manager starting watch at version 9
INFO[0000] Waiting for the cluster to reach quorum...
INFO[0000] Starting Gossip...
INFO[0002] Starting collector watch on  at 0
INFO[0002] Cluster db snapshot at: 13
INFO[0002] Stopping updates collector
{"cluster":{"status":"STATUS_OK","id":"openstorage.cluster","name":"openstorage.cluster"}}
+ assert_success
+ '[' 0 -ne 0 ']'
++ sudo docker volume create -d fake -o size=1234 -o token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4
INFO[0003]                                               Driver=fake ID=2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197 Request=create
+ volume_name=2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197
+ assert_success
+ '[' 0 -ne 0 ']'
+ sudo docker volume inspect token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4,name=2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197
[
    {
        "CreatedAt": "0001-01-01T00:00:00Z",
        "Driver": "fake",
        "Labels": null,
        "Mountpoint": "",
        "Name": "token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4,name=2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197",
        "Options": null,
        "Scope": "global"
    }
]
+ assert_success
+ '[' 0 -ne 0 ']'
+ get_volume_id 2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197
++ curl -X POST http://localhost:9116/v1/volumes/filters -H 'accept: application/json' -H Content-Type:application/json -H 'Authorization:bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4' -d '{ "name": "2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197"}'
++ jq '.[]'
++ jq '.[0]' -r
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   132  100    55  100    77  27500  38500 --:--:-- --:--:-- --:--:-- 66000
+ volume_id=b9615f6d-43c7-438d-b428-eed0bf45f453
+ assert_attached false
+ get_volume_id 2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197
++ curl -X POST http://localhost:9116/v1/volumes/filters -H 'accept: application/json' -H Content-Type:application/json -H 'Authorization:bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4' -d '{ "name": "2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197"}'
++ jq '.[]'
++ jq '.[0]' -r
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   132  100    55  100    77  27500  38500 --:--:-- --:--:-- --:--:-- 66000
+ volume_id=b9615f6d-43c7-438d-b428-eed0bf45f453
++ curl -X GET http://localhost:9116/v1/volumes/inspect/b9615f6d-43c7-438d-b428-eed0bf45f453 -H accept:application/json -H 'Authorization:bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4'
++ jq .volume
++ jq .attach_path
++ jq '.[0]' -r
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   593  100   593    0     0   144k      0 --:--:-- --:--:-- --:--:--  144k
+ attach_path=null
+ '[' false == true ']'
+ echo 'Asserting volume detached: null'
Asserting volume detached: null
+ '[' null == null ']'
+ return 0
+ app_name=APP_TEST_2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197
+ sudo docker run -d --name APP_TEST_2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197 --volume-driver fake -v size=12345,token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4,name=2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197:/app asia.gcr.io/k8s-artifacts-prod/nginx-slim:0.21
2e4f9189c4f1ea66ad2582ecbc7244c3c1730b136ec17211d0398a49d86d6c27
INFO[0003] Volume b9615f6d-43c7-438d-b428-eed0bf45f453 attached on node
INFO[0003] Volume b9615f6d-43c7-438d-b428-eed0bf45f453 mounted on node
+ assert_success
+ '[' 0 -ne 0 ']'
+ assert_attached true
+ get_volume_id 2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197
++ curl -X POST http://localhost:9116/v1/volumes/filters -H 'accept: application/json' -H Content-Type:application/json -H 'Authorization:bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4' -d '{ "name": "2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197"}'
++ jq '.[]'
++ jq '.[0]' -r
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   132  100    55  100    77  18333  25666 --:--:-- --:--:-- --:--:-- 44000
+ volume_id=b9615f6d-43c7-438d-b428-eed0bf45f453
++ curl -X GET http://localhost:9116/v1/volumes/inspect/b9615f6d-43c7-438d-b428-eed0bf45f453 -H accept:application/json -H 'Authorization:bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4'
++ jq .volume
++ jq .attach_path
++ jq '.[0]' -r
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   760  100   760    0     0   247k      0 --:--:-- --:--:-- --:--:--  371k
+ attach_path=/var/lib/osd/mounts/2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f84019788d473180fe4d05401fa37141f357715d22435d87b21a00dec325c9d82932d55
+ '[' true == true ']'
+ echo 'Asserting volume attached: /var/lib/osd/mounts/2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f84019788d473180fe4d05401fa37141f357715d22435d87b21a00dec325c9d82932d55'
Asserting volume attached: /var/lib/osd/mounts/2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f84019788d473180fe4d05401fa37141f357715d22435d87b21a00dec325c9d82932d55
+ '[' /var/lib/osd/mounts/2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f84019788d473180fe4d05401fa37141f357715d22435d87b21a00dec325c9d82932d55 '!=' null ']'
+ return 0
+ sudo docker stop APP_TEST_2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197
APP_TEST_2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197
+ assert_success
+ '[' 0 -ne 0 ']'
+ assert_attached false
+ get_volume_id 2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197
++ curl -X POST http://localhost:9116/v1/volumes/filters -H 'accept: application/json' -H Content-Type:application/json -H 'Authorization:bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4' -d '{ "name": "2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197"}'
++ jq '.[]'
++ jq '.[0]' -r
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   132  100    55  100    77  27500  38500 --:--:-- --:--:-- --:--:-- 66000
+ volume_id=b9615f6d-43c7-438d-b428-eed0bf45f453
++ curl -X GET http://localhost:9116/v1/volumes/inspect/b9615f6d-43c7-438d-b428-eed0bf45f453 -H accept:application/json -H 'Authorization:bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4'
++ jq .volume
++ jq .attach_path
++ jq '.[0]' -r
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   593  100   593    0     0   193k      0 --:--:-- --:--:-- --:--:--  193k
+ attach_path=null
+ '[' false == true ']'
+ echo 'Asserting volume detached: null'
Asserting volume detached: null
+ '[' null == null ']'
+ return 0
+ sudo docker rm APP_TEST_2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197
APP_TEST_2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197
+ sudo docker run -d --name APP_TEST_2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197 --volume-driver fake -v size=12345,token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4,name=b9615f6d-43c7-438d-b428-eed0bf45f453:/app asia.gcr.io/k8s-artifacts-prod/nginx-slim:0.21
22b50f70df8e0a4c38888e17e515a39152854f14d65adc01e2e167d1875fee6a
INFO[0004] Volume b9615f6d-43c7-438d-b428-eed0bf45f453 attached on node
INFO[0004] Volume b9615f6d-43c7-438d-b428-eed0bf45f453 mounted on node
+ assert_success
+ '[' 0 -ne 0 ']'
+ assert_attached true
+ get_volume_id 2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197
++ curl -X POST http://localhost:9116/v1/volumes/filters -H 'accept: application/json' -H Content-Type:application/json -H 'Authorization:bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4' -d '{ "name": "2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197"}'
++ jq '.[]'
++ jq '.[0]' -r
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   132  100    55  100    77  27500  38500 --:--:-- --:--:-- --:--:-- 66000
+ volume_id=b9615f6d-43c7-438d-b428-eed0bf45f453
++ curl -X GET http://localhost:9116/v1/volumes/inspect/b9615f6d-43c7-438d-b428-eed0bf45f453 -H accept:application/json -H 'Authorization:bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4'
++ jq .volume
++ jq .attach_path
++ jq '.[0]' -r
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   732  100   732    0     0   238k      0 --:--:-- --:--:-- --:--:--  238k
+ attach_path=/var/lib/osd/mounts/b9615f6d-43c7-438d-b428-eed0bf45f453f9fc9130cdda8a8f86e62421ef155ec142c6e706d1ec276633dbb22655c0c5a4
+ '[' true == true ']'
+ echo 'Asserting volume attached: /var/lib/osd/mounts/b9615f6d-43c7-438d-b428-eed0bf45f453f9fc9130cdda8a8f86e62421ef155ec142c6e706d1ec276633dbb22655c0c5a4'
Asserting volume attached: /var/lib/osd/mounts/b9615f6d-43c7-438d-b428-eed0bf45f453f9fc9130cdda8a8f86e62421ef155ec142c6e706d1ec276633dbb22655c0c5a4
+ '[' /var/lib/osd/mounts/b9615f6d-43c7-438d-b428-eed0bf45f453f9fc9130cdda8a8f86e62421ef155ec142c6e706d1ec276633dbb22655c0c5a4 '!=' null ']'
+ return 0
+ sudo docker stop APP_TEST_2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197
APP_TEST_2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197
+ assert_success
+ '[' 0 -ne 0 ']'
+ assert_attached false
+ get_volume_id 2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197
++ curl -X POST http://localhost:9116/v1/volumes/filters -H 'accept: application/json' -H Content-Type:application/json -H 'Authorization:bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4' -d '{ "name": "2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197"}'
++ jq '.[]'
++ jq '.[0]' -r
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   132  100    55  100    77  27500  38500 --:--:-- --:--:-- --:--:-- 66000
+ volume_id=b9615f6d-43c7-438d-b428-eed0bf45f453
++ curl -X GET http://localhost:9116/v1/volumes/inspect/b9615f6d-43c7-438d-b428-eed0bf45f453 -H accept:application/json -H 'Authorization:bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4'
++ jq .volume
++ jq .attach_path
++ jq '.[0]' -r
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   593  100   593    0     0   144k      0 --:--:-- --:--:-- --:--:--  144k
+ attach_path=null
+ '[' false == true ']'
+ echo 'Asserting volume detached: null'
Asserting volume detached: null
+ '[' null == null ']'
+ return 0
+ sudo docker rm APP_TEST_2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197
APP_TEST_2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197
+ assert_success
+ '[' 0 -ne 0 ']'
+ sudo docker volume rm token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4,name=2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197
INFO[0005]                                               Driver=fake ID=2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197 Request=remove
token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4,name=2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197
+ assert_success
+ '[' 0 -ne 0 ']'
++ curl -X POST http://localhost:9116/v1/volumes/filters -H 'accept: application/json' -H Content-Type:application/json -H 'Authorization:bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJlbWFpbCI6IjEyM0BhYmMuY29tIiwiZXhwIjoxNzI3MzU0MDI2LCJncm91cHMiOlsiKiJdLCJpYXQiOjE3MjcyNjc2MjYsImlzcyI6Im9wZW5zdG9yYWdlLmlvIiwibmFtZSI6IlRlc3QiLCJyb2xlcyI6WyJzeXN0ZW0uYWRtaW4iXSwic3ViIjoiYjNCbGJuTjBiM0poWjJVdWFXOHZWR1Z6ZEM4eE1qTkFZV0pqTG1OdmJRPT0ifQ.uz3NBewUVkxPk-vTgcycR8LE7-sKv-r1YesMKMq3Ok4' -d '{ "name": "2aef9ddbf702b741fb6596a9110241bab621b4aa7afdd6da65fcdc580f840197"}'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    79  100     2  100    77   1000  38500 --:--:-- --:--:-- --:--:-- 39500
+ volume_id='{}'
+ test '{}' = '{}'
+ assert_success
+ '[' 0 -ne 0 ']'
+ echo 'Docker integration tests passed, cleaning up!'
Docker integration tests passed, cleaning up!
+ cleanup
+ sudo pkill -15 -f /root/go/bin/osd
# This image is local only and will not be pushed
docker build -t openstorage/osd-dev -f Dockerfile.osd-dev .
[+] Building 1.0s (9/9) FINISHED                                                   docker:default
 => [internal] load build definition from Dockerfile.osd-dev                                 0.0s
 => => transferring dockerfile: 421B                                                         0.0s
 => [internal] load metadata for quay.io/openstorage/osd-dev-base:1.14                       0.6s
 => [internal] load .dockerignore                                                            0.0s
 => => transferring context: 45B                                                             0.0s
 => [internal] load build context                                                            0.4s
 => => transferring context: 305.40kB                                                        0.3s
 => [1/4] FROM quay.io/openstorage/osd-dev-base:1.14@sha256:d9ded4c6dbcfe28426a8f71f2538174  0.0s
 => CACHED [2/4] ADD . /go/src/github.com/libopenstorage/openstorage/                        0.0s
 => CACHED [3/4] WORKDIR /go/src/github.com/libopenstorage/openstorage                       0.0s
 => CACHED [4/4] RUN   curl -sSL -o docker.tgz https://download.docker.com/linux/static/sta  0.0s
 => exporting to image                                                                       0.0s
 => => exporting layers                                                                      0.0s
 => => writing image sha256:0644fd92d705bb6c1d45626b7799d25ffef22e042809ec26dfcb1e1e14e51d2  0.0s
 => => naming to docker.io/openstorage/osd-dev                                               0.0s
docker run \
        --privileged \
        -v /var/run/docker.sock:/var/run/docker.sock \
        -v /mnt:/mnt \
        -e AWS_REGION \
        -e AWS_ZONE \
        -e AWS_INSTANCE_NAME \
        -e AWS_ACCESS_KEY_ID \
        -e AWS_SECRET_ACCESS_KEY \
        -e GOOGLE_APPLICATION_CREDENTIALS \
        -e GCE_INSTANCE_NAME \
        -e GCE_INSTANCE_ZONE \
        -e GCE_INSTANCE_PROJECT \
        -e AZURE_INSTANCE_NAME \
        -e AZURE_SUBSCRIPTION_ID \
        -e AZURE_RESOURCE_GROUP_NAME \
        -e AZURE_ENVIRONMENT \
        -e AZURE_TENANT_ID \
        -e AZURE_CLIENT_ID \
        -e AZURE_CLIENT_SECRET \
        -e "TAGS=daemon" \
        -e "PKGS=github.com/libopenstorage/openstorage/alert github.com/libopenstorage/openstorage/alerts github.com/libopenstorage/openstorage/alerts/mock github.com/libopenstorage/openstorage/api github.com/libopenstorage/openstorage/api/client github.com/libopenstorage/openstorage/api/client/cluster github.com/libopenstorage/openstorage/api/client/volume github.com/libopenstorage/openstorage/api/errors github.com/libopenstorage/openstorage/api/flexvolume github.com/libopenstorage/openstorage/api/mock github.com/libopenstorage/openstorage/api/server github.com/libopenstorage/openstorage/api/server/mock github.com/libopenstorage/openstorage/api/server/sdk github.com/libopenstorage/openstorage/api/spec github.com/libopenstorage/openstorage/bucket github.com/libopenstorage/openstorage/bucket/drivers/fake github.com/libopenstorage/openstorage/bucket/drivers/mock github.com/libopenstorage/openstorage/bucket/drivers/purefb github.com/libopenstorage/openstorage/bucket/drivers/s3 github.com/libopenstorage/openstorage/cli github.com/libopenstorage/openstorage/cluster github.com/libopenstorage/openstorage/cluster/manager github.com/libopenstorage/openstorage/cluster/mock github.com/libopenstorage/openstorage/cmd/osd github.com/libopenstorage/openstorage/cmd/osd-token-generator github.com/libopenstorage/openstorage/config github.com/libopenstorage/openstorage/csi github.com/libopenstorage/openstorage/csi/sched github.com/libopenstorage/openstorage/csi/sched/k8s github.com/libopenstorage/openstorage/csi/v0.3 github.com/libopenstorage/openstorage/csi/v0.3/spec github.com/libopenstorage/openstorage/graph github.com/libopenstorage/openstorage/graph/drivers github.com/libopenstorage/openstorage/graph/drivers/chainfs github.com/libopenstorage/openstorage/graph/drivers/layer0 github.com/libopenstorage/openstorage/graph/drivers/proxy github.com/libopenstorage/openstorage/objectstore github.com/libopenstorage/openstorage/osdconfig github.com/libopenstorage/openstorage/pkg/auth github.com/libopenstorage/openstorage/pkg/auth/secrets github.com/libopenstorage/openstorage/pkg/auth/systemtoken github.com/libopenstorage/openstorage/pkg/chaos github.com/libopenstorage/openstorage/pkg/chattr github.com/libopenstorage/openstorage/pkg/clusterdomain github.com/libopenstorage/openstorage/pkg/correlation github.com/libopenstorage/openstorage/pkg/dbg github.com/libopenstorage/openstorage/pkg/defaultcontext github.com/libopenstorage/openstorage/pkg/defrag github.com/libopenstorage/openstorage/pkg/device github.com/libopenstorage/openstorage/pkg/diags github.com/libopenstorage/openstorage/pkg/exec github.com/libopenstorage/openstorage/pkg/flexvolume github.com/libopenstorage/openstorage/pkg/flexvolume/cmd/flexvolume github.com/libopenstorage/openstorage/pkg/grpcserver github.com/libopenstorage/openstorage/pkg/grpcutil github.com/libopenstorage/openstorage/pkg/job github.com/libopenstorage/openstorage/pkg/jsonpb github.com/libopenstorage/openstorage/pkg/jsonpb/testing github.com/libopenstorage/openstorage/pkg/keylock github.com/libopenstorage/openstorage/pkg/loadbalancer github.com/libopenstorage/openstorage/pkg/loadbalancer/mock github.com/libopenstorage/openstorage/pkg/mount github.com/libopenstorage/openstorage/pkg/nodedrain github.com/libopenstorage/openstorage/pkg/options github.com/libopenstorage/openstorage/pkg/parser github.com/libopenstorage/openstorage/pkg/proto/time github.com/libopenstorage/openstorage/pkg/role github.com/libopenstorage/openstorage/pkg/sched github.com/libopenstorage/openstorage/pkg/schedule github.com/libopenstorage/openstorage/pkg/seed github.com/libopenstorage/openstorage/pkg/storagepolicy github.com/libopenstorage/openstorage/pkg/storagepool github.com/libopenstorage/openstorage/pkg/units github.com/libopenstorage/openstorage/pkg/util github.com/libopenstorage/openstorage/schedpolicy github.com/libopenstorage/openstorage/secrets github.com/libopenstorage/openstorage/tools/sdkver github.com/libopenstorage/openstorage/volume github.com/libopenstorage/openstorage/volume/drivers github.com/libopenstorage/openstorage/volume/drivers/btrfs github.com/libopenstorage/openstorage/volume/drivers/buse github.com/libopenstorage/openstorage/volume/drivers/common github.com/libopenstorage/openstorage/volume/drivers/fake github.com/libopenstorage/openstorage/volume/drivers/fuse github.com/libopenstorage/openstorage/volume/drivers/mock github.com/libopenstorage/openstorage/volume/drivers/nfs github.com/libopenstorage/openstorage/volume/drivers/pwx github.com/libopenstorage/openstorage/volume/drivers/test github.com/libopenstorage/openstorage/volume/drivers/vfs" \
        -e "BUILDFLAGS=" \
        -e "TESTFLAGS=" \
        -e "GO111MODULE=auto" \
        openstorage/osd-dev \
                make test
fatal: not a git repository (or any of the parent directories): .git
packr2 clean
packr2
GODEBUG=x509ignoreCN=0 go test -tags "daemon"  github.com/libopenstorage/openstorage/alert github.com/libopenstorage/openstorage/alerts github.com/libopenstorage/openstorage/alerts/mock github.com/libopenstorage/openstorage/api github.com/libopenstorage/openstorage/api/client github.com/libopenstorage/openstorage/api/client/cluster github.com/libopenstorage/openstorage/api/client/volume github.com/libopenstorage/openstorage/api/errors github.com/libopenstorage/openstorage/api/flexvolume github.com/libopenstorage/openstorage/api/mock github.com/libopenstorage/openstorage/api/server github.com/libopenstorage/openstorage/api/server/mock github.com/libopenstorage/openstorage/api/server/sdk github.com/libopenstorage/openstorage/api/spec github.com/libopenstorage/openstorage/bucket github.com/libopenstorage/openstorage/bucket/drivers/fake github.com/libopenstorage/openstorage/bucket/drivers/mock github.com/libopenstorage/openstorage/bucket/drivers/purefb github.com/libopenstorage/openstorage/bucket/drivers/s3 github.com/libopenstorage/openstorage/cli github.com/libopenstorage/openstorage/cluster github.com/libopenstorage/openstorage/cluster/manager github.com/libopenstorage/openstorage/cluster/mock github.com/libopenstorage/openstorage/cmd/osd github.com/libopenstorage/openstorage/cmd/osd-token-generator github.com/libopenstorage/openstorage/config github.com/libopenstorage/openstorage/csi github.com/libopenstorage/openstorage/csi/sched github.com/libopenstorage/openstorage/csi/sched/k8s github.com/libopenstorage/openstorage/csi/v0.3 github.com/libopenstorage/openstorage/csi/v0.3/spec github.com/libopenstorage/openstorage/graph github.com/libopenstorage/openstorage/graph/drivers github.com/libopenstorage/openstorage/graph/drivers/chainfs github.com/libopenstorage/openstorage/graph/drivers/layer0 github.com/libopenstorage/openstorage/graph/drivers/proxy github.com/libopenstorage/openstorage/objectstore github.com/libopenstorage/openstorage/osdconfig github.com/libopenstorage/openstorage/pkg/auth github.com/libopenstorage/openstorage/pkg/auth/secrets github.com/libopenstorage/openstorage/pkg/auth/systemtoken github.com/libopenstorage/openstorage/pkg/chaos github.com/libopenstorage/openstorage/pkg/chattr github.com/libopenstorage/openstorage/pkg/clusterdomain github.com/libopenstorage/openstorage/pkg/correlation github.com/libopenstorage/openstorage/pkg/dbg github.com/libopenstorage/openstorage/pkg/defaultcontext github.com/libopenstorage/openstorage/pkg/defrag github.com/libopenstorage/openstorage/pkg/device github.com/libopenstorage/openstorage/pkg/diags github.com/libopenstorage/openstorage/pkg/exec github.com/libopenstorage/openstorage/pkg/flexvolume github.com/libopenstorage/openstorage/pkg/flexvolume/cmd/flexvolume github.com/libopenstorage/openstorage/pkg/grpcserver github.com/libopenstorage/openstorage/pkg/grpcutil github.com/libopenstorage/openstorage/pkg/job github.com/libopenstorage/openstorage/pkg/jsonpb github.com/libopenstorage/openstorage/pkg/jsonpb/testing github.com/libopenstorage/openstorage/pkg/keylock github.com/libopenstorage/openstorage/pkg/loadbalancer github.com/libopenstorage/openstorage/pkg/loadbalancer/mock github.com/libopenstorage/openstorage/pkg/mount github.com/libopenstorage/openstorage/pkg/nodedrain github.com/libopenstorage/openstorage/pkg/options github.com/libopenstorage/openstorage/pkg/parser github.com/libopenstorage/openstorage/pkg/proto/time github.com/libopenstorage/openstorage/pkg/role github.com/libopenstorage/openstorage/pkg/sched github.com/libopenstorage/openstorage/pkg/schedule github.com/libopenstorage/openstorage/pkg/seed github.com/libopenstorage/openstorage/pkg/storagepolicy github.com/libopenstorage/openstorage/pkg/storagepool github.com/libopenstorage/openstorage/pkg/units github.com/libopenstorage/openstorage/pkg/util github.com/libopenstorage/openstorage/schedpolicy github.com/libopenstorage/openstorage/secrets github.com/libopenstorage/openstorage/tools/sdkver github.com/libopenstorage/openstorage/volume github.com/libopenstorage/openstorage/volume/drivers github.com/libopenstorage/openstorage/volume/drivers/btrfs github.com/libopenstorage/openstorage/volume/drivers/buse github.com/libopenstorage/openstorage/volume/drivers/common github.com/libopenstorage/openstorage/volume/drivers/fake github.com/libopenstorage/openstorage/volume/drivers/fuse github.com/libopenstorage/openstorage/volume/drivers/mock github.com/libopenstorage/openstorage/volume/drivers/nfs github.com/libopenstorage/openstorage/volume/drivers/pwx github.com/libopenstorage/openstorage/volume/drivers/test github.com/libopenstorage/openstorage/volume/drivers/vfs
ok      github.com/libopenstorage/openstorage/alert     8.345s
ok      github.com/libopenstorage/openstorage/alerts    2.046s
?       github.com/libopenstorage/openstorage/alerts/mock       [no test files]
ok      github.com/libopenstorage/openstorage/api       0.064s
ok      github.com/libopenstorage/openstorage/api/client        6.385s
?       github.com/libopenstorage/openstorage/api/client/cluster        [no test files]
ok      github.com/libopenstorage/openstorage/api/client/volume 0.029s
?       github.com/libopenstorage/openstorage/api/errors        [no test files]
?       github.com/libopenstorage/openstorage/api/flexvolume    [no test files]
?       github.com/libopenstorage/openstorage/api/mock  [no test files]
ok      github.com/libopenstorage/openstorage/api/server        9.583s
?       github.com/libopenstorage/openstorage/api/server/mock   [no test files]
ok      github.com/libopenstorage/openstorage/api/server/sdk    37.124s
ok      github.com/libopenstorage/openstorage/api/spec  0.021s
?       github.com/libopenstorage/openstorage/bucket    [no test files]
?       github.com/libopenstorage/openstorage/bucket/drivers/fake       [no test files]
?       github.com/libopenstorage/openstorage/bucket/drivers/mock       [no test files]
?       github.com/libopenstorage/openstorage/bucket/drivers/purefb     [no test files]
?       github.com/libopenstorage/openstorage/bucket/drivers/s3 [no test files]
ok      github.com/libopenstorage/openstorage/cli       0.047s
?       github.com/libopenstorage/openstorage/cluster   [no test files]
ok      github.com/libopenstorage/openstorage/cluster/manager   2.224s
?       github.com/libopenstorage/openstorage/cluster/mock      [no test files]
?       github.com/libopenstorage/openstorage/cmd/osd   [no test files]
?       github.com/libopenstorage/openstorage/cmd/osd-token-generator   [no test files]
?       github.com/libopenstorage/openstorage/config    [no test files]
ok      github.com/libopenstorage/openstorage/csi       15.657s
?       github.com/libopenstorage/openstorage/csi/sched [no test files]
?       github.com/libopenstorage/openstorage/csi/sched/k8s     [no test files]
ok      github.com/libopenstorage/openstorage/csi/v0.3  0.139s
?       github.com/libopenstorage/openstorage/csi/v0.3/spec     [no test files]
?       github.com/libopenstorage/openstorage/graph     [no test files]
?       github.com/libopenstorage/openstorage/graph/drivers     [no test files]
?       github.com/libopenstorage/openstorage/graph/drivers/chainfs     [no test files]
?       github.com/libopenstorage/openstorage/graph/drivers/layer0      [no test files]
?       github.com/libopenstorage/openstorage/graph/drivers/proxy       [no test files]
ok      github.com/libopenstorage/openstorage/objectstore       0.049s
ok      github.com/libopenstorage/openstorage/osdconfig 0.033s
ok      github.com/libopenstorage/openstorage/pkg/auth  0.069s
ok      github.com/libopenstorage/openstorage/pkg/auth/secrets  0.038s
ok      github.com/libopenstorage/openstorage/pkg/auth/systemtoken      0.047s
?       github.com/libopenstorage/openstorage/pkg/chaos [no test files]
ok      github.com/libopenstorage/openstorage/pkg/chattr        0.086s
?       github.com/libopenstorage/openstorage/pkg/clusterdomain [no test files]
ok      github.com/libopenstorage/openstorage/pkg/correlation   0.024s
?       github.com/libopenstorage/openstorage/pkg/dbg   [no test files]
ok      github.com/libopenstorage/openstorage/pkg/defaultcontext        0.027s
?       github.com/libopenstorage/openstorage/pkg/defrag        [no test files]
?       github.com/libopenstorage/openstorage/pkg/device        [no test files]
?       github.com/libopenstorage/openstorage/pkg/diags [no test files]
?       github.com/libopenstorage/openstorage/pkg/exec  [no test files]
?       github.com/libopenstorage/openstorage/pkg/flexvolume    [no test files]
?       github.com/libopenstorage/openstorage/pkg/flexvolume/cmd/flexvolume     [no test files]
ok      github.com/libopenstorage/openstorage/pkg/grpcserver    3.031s
ok      github.com/libopenstorage/openstorage/pkg/grpcutil      0.039s
?       github.com/libopenstorage/openstorage/pkg/job   [no test files]
?       github.com/libopenstorage/openstorage/pkg/jsonpb        [no test files]
ok      github.com/libopenstorage/openstorage/pkg/jsonpb/testing        0.042s
ok      github.com/libopenstorage/openstorage/pkg/keylock       8.021s
ok      github.com/libopenstorage/openstorage/pkg/loadbalancer  0.011s
?       github.com/libopenstorage/openstorage/pkg/loadbalancer/mock     [no test files]
ok      github.com/libopenstorage/openstorage/pkg/mount 38.891s
?       github.com/libopenstorage/openstorage/pkg/nodedrain     [no test files]
?       github.com/libopenstorage/openstorage/pkg/options       [no test files]
ok      github.com/libopenstorage/openstorage/pkg/parser        0.025s
?       github.com/libopenstorage/openstorage/pkg/proto/time    [no test files]
ok      github.com/libopenstorage/openstorage/pkg/role  0.015s
ok      github.com/libopenstorage/openstorage/pkg/sched 124.530s
?       github.com/libopenstorage/openstorage/pkg/schedule      [no test files]
ok      github.com/libopenstorage/openstorage/pkg/seed  13.102s
ok      github.com/libopenstorage/openstorage/pkg/storagepolicy 0.032s
?       github.com/libopenstorage/openstorage/pkg/storagepool   [no test files]
ok      github.com/libopenstorage/openstorage/pkg/units 0.013s
ok      github.com/libopenstorage/openstorage/pkg/util  0.019s
ok      github.com/libopenstorage/openstorage/schedpolicy       0.012s
?       github.com/libopenstorage/openstorage/secrets   [no test files]
?       github.com/libopenstorage/openstorage/tools/sdkver      [no test files]
?       github.com/libopenstorage/openstorage/volume    [no test files]
?       github.com/libopenstorage/openstorage/volume/drivers    [no test files]
?       github.com/libopenstorage/openstorage/volume/drivers/btrfs      [no test files]
?       github.com/libopenstorage/openstorage/volume/drivers/buse       [no test files]
ok      github.com/libopenstorage/openstorage/volume/drivers/common     0.041s
ok      github.com/libopenstorage/openstorage/volume/drivers/fake       0.948s
?       github.com/libopenstorage/openstorage/volume/drivers/fuse       [no test files]
?       github.com/libopenstorage/openstorage/volume/drivers/mock       [no test files]
ok      github.com/libopenstorage/openstorage/volume/drivers/nfs        2.342s
ok      github.com/libopenstorage/openstorage/volume/drivers/pwx        0.066s
?       github.com/libopenstorage/openstorage/volume/drivers/test       [no test files]
?       github.com/libopenstorage/openstorage/volume/drivers/vfs        [no test files]
```