### PR TITLE
Set export rules when ROX access mode is used in Pure File Volumes

### DIFF
--- a/csi/controller_test.go
+++ b/csi/controller_test.go
@@ -3655,6 +3655,57 @@ func TestResolveSpecFromCSI(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Should set export rules for Pure based volumes and ROX is used",
+			req: &csi.CreateVolumeRequest{
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY,
+						},
+					},
+				},
+			},
+			existingSpec: &api.VolumeSpec{
+				ProxySpec: &api.ProxySpec{
+					ProxyProtocol: api.ProxyProtocol_PROXY_PROTOCOL_PURE_FILE,
+				},
+			},
+
+			expectedSpec: &api.VolumeSpec{
+				Shared: false,
+				ProxySpec: &api.ProxySpec{
+					ProxyProtocol: api.ProxyProtocol_PROXY_PROTOCOL_PURE_FILE,
+					PureFileSpec: &api.PureFileSpec{
+						ExportRules: "*(ro)",
+					},
+				},
+			},
+		},
+		{
+			name: "Pure volume RWX, no change in spec",
+			req: &csi.CreateVolumeRequest{
+				VolumeCapabilities: []*csi.VolumeCapability{
+					{
+						AccessMode: &csi.VolumeCapability_AccessMode{
+							Mode: csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER,
+						},
+					},
+				},
+			},
+			existingSpec: &api.VolumeSpec{
+				ProxySpec: &api.ProxySpec{
+					ProxyProtocol: api.ProxyProtocol_PROXY_PROTOCOL_PURE_FILE,
+				},
+			},
+
+			expectedSpec: &api.VolumeSpec{
+				Shared: false,
+				ProxySpec: &api.ProxySpec{
+					ProxyProtocol: api.ProxyProtocol_PROXY_PROTOCOL_PURE_FILE,
+				},
+			},
+		},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:  
For Pure File volumes, if an export rule is not set, set it to *(ro) if the pvc mode is ReadOnlyMany. This way customers can choose not to specify an export rule in storage class. Since *(rw) is the default case, we are not setting that explicitly and assume that the NFS server will set the right default.

**Which issue(s) this PR fixes** (optional)  
Closes #
or
PWX-37757

**Testing Notes**  
Add testing output or passing unit test output here.

**Special notes for your reviewer**:  
Add any notes for the reviewer here.
