### PR TITLE
PWX-39688 Wai till local snapshot is taken to send create snapshot response in case of cloud snap

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -618,6 +618,8 @@ type CloudBackupStatus struct {
 	// GroupCloudBackupID is valid for backups that were started as part of group
 	// cloudbackup request
 	GroupCloudBackupID string
+	// LocalSnapshotTime indicates when the local snapshot was taken
+	LocalSnapshotTime time.Time
 }
 
 type CloudBackupStatusResponse struct {
@@ -1244,6 +1246,7 @@ func (s CloudBackupStatus) ToSdkCloudBackupStatus() *SdkCloudBackupStatus {
 
 	status.StartTime, _ = ptypes.TimestampProto(s.StartTime)
 	status.CompletedTime, _ = ptypes.TimestampProto(s.CompletedTime)
+	status.LocalSnapshotTime, _ = ptypes.TimestampProto(s.LocalSnapshotTime)
 
 	return status
 }
@@ -1508,3 +1511,11 @@ const (
 	// SharedVolExportPrefix is the export path where shared volumes are mounted
 	SharedVolExportPrefix = "/var/lib/osd/pxns"
 )
+
+func (s *SdkCloudBackupStatus) IsLocalSnapshotTaken() bool {
+	localSnapTime := s.LocalSnapshotTime
+	if localSnapTime != nil && (localSnapTime.Seconds != 0 && localSnapTime.Nanos != 0) {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:  
This PR will set the creation time of the snapshot in CSI response object as the local snapshot time. As per CSI spec, the creation time of the snapshot is the time when storage system took the point in time snapshot.

**Which issue(s) this PR fixes** (optional)  
Closes #
or
PWX-39688

**Testing Notes**  
Tested creating a snapshot and made sure that the creation time is coming up in the kubectl get volumesnapshot <name> -o yaml output

**Special notes for your reviewer**:  
Add any notes for the reviewer here.
