### PR TITLE
PWX-40172 (master): makes chattr ignore 'inappropriate ioctl' errors

### DIFF
--- a/pkg/chattr/chattr_test.go
+++ b/pkg/chattr/chattr_test.go
@@ -1,7 +1,9 @@
 package chattr
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -48,5 +50,56 @@ func TestImmutable(t *testing.T) {
 	_, err = os.Stat(testFile)
 	require.Error(t, err, "Expected the file to be removed")
 	require.True(t, os.IsNotExist(err), "Unexpected error on remove")
+}
 
+func TestImmutable_UnsupportedFilesystem(t *testing.T) {
+
+	const (
+		imgFile   = "/tmp/chattr-test.img"
+		ntfsMount = "/tmp/chattr-test-mount"
+		fsType    = "ntfs"
+	)
+	mkfsCommand := "mkfs." + fsType
+	if which(mkfsCommand) == mkfsCommand {
+		t.Skip("Skipping test: " + mkfsCommand + " not found")
+	}
+
+	// Create a file to serve as a disk image
+	err := exec.Command("dd", "if=/dev/zero", "of="+imgFile, "bs=1M", "count=100").Run()
+	require.NoError(t, err, "Failed to create NTFS image file")
+
+	defer func() {
+		err = os.Remove(imgFile)
+		require.NoError(t, err, "Failed to remove NTFS image file")
+	}()
+
+	// Format the file
+	err = exec.Command(mkfsCommand, "-F", imgFile).Run()
+	require.NoError(t, err, fmt.Sprintf("Failed to format %s image", fsType))
+
+	// Create mount point
+	err = os.MkdirAll(ntfsMount, 0755)
+	require.NoError(t, err, "Failed to create mount point")
+
+	defer func() {
+		err = os.RemoveAll(ntfsMount)
+		require.NoError(t, err, "Failed to remove mount point")
+	}()
+
+	// Mount the image
+	err = exec.Command("mount", "-o", "loop", "-t", fsType, imgFile, ntfsMount).Run()
+	require.NoError(t, err, "Failed to mount image")
+
+	defer func() {
+		err = exec.Command("umount", ntfsMount).Run()
+		require.NoError(t, err, "Failed to unmount image")
+	}()
+
+	// Attempt to add immutable attribute to the mount point: should not error even though filesystem does not support it
+	err = AddImmutable(ntfsMount)
+	require.NoError(t, err, "Unexpected error on AddImmutable")
+
+	// Check if the mount point is immutable
+	isImmutable := IsImmutable(ntfsMount)
+	require.False(t, isImmutable, "Mount point should not be immutable")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:  
In some OSes like SLE Micro, the `/var` directory is mounted using an overlay filesystem. Something in this setup does not support `chattr`. In this case, we should just ignore `inappropriate ioctl for device` errors as there is nothing we can do.

**Which issue(s) this PR fixes** (optional)  
PWX-40172

**Testing Notes**
* Confirmed PX installs on a Harvester system
* Added UTs that make an NTFS loopback device (as NTFS does not support chattr either), mounts it, and confirms our chattr code still succeeds.

